### PR TITLE
feat: add `mdo!` do-notation via the monadify-macros proc-macro crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,6 +47,8 @@ jobs:
             flags: ""
           - name: legacy
             flags: "--features legacy"
+          - name: do-notation
+            flags: "--features do-notation"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -56,6 +58,21 @@ jobs:
       # `cargo test` runs unit, integration, and doc-tests.
       - name: Test
         run: cargo test --verbose ${{ matrix.flags }}
+
+  zero-dep:
+    name: zero-dependency guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Assert the DEFAULT-feature dependency graph pulls in no proc-macro deps
+      # (syn/quote/proc-macro2). The do-notation proc-macro must stay opt-in.
+      - name: Assert default features are dependency-free
+        run: |
+          cargo tree -e normal --prefix none | grep -Eq '^(syn|quote|proc-macro2) ' \
+            && { echo 'LEAK: proc-macro dep in default features'; exit 1; } \
+            || echo 'default features dependency-free'
 
   msrv:
     name: msrv (1.66)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = [".", "monadify-macros"]
+resolver = "2"
+
 [package]
 name = "monadify"
 description = "A library for functional programming abstractions in Rust, focusing on Monads, Functors, Applicatives, and related concepts."
@@ -14,6 +18,9 @@ keywords = ["functional", "fp", "monad"]
 categories = ["rust-patterns"] # Removed "no-std" as std is currently used
 
 [dependencies]
+# Default graph stays EMPTY. The macro crate is an OPTIONAL dependency, pulled in
+# only by the `do-notation` feature via `dep:` syntax (see [features]).
+monadify-macros = { path = "monadify-macros", version = "0.1.1", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }
@@ -26,3 +33,18 @@ harness = false
 [features]
 default = [] # HKT is now the default, no feature needed to enable it.
 legacy = []  # Optional feature to include legacy implementations.
+# NON-default. Enables the procedural `mdo!` do-notation macro. `dep:` suppresses
+# the implicit same-named feature so this is the single switch for the macro crate.
+do-notation = ["dep:monadify-macros"]
+
+[[example]]
+name = "validation"
+required-features = ["do-notation"]
+
+[[example]]
+name = "reader_config"
+required-features = ["do-notation"]
+
+[[example]]
+name = "list_comprehension"
+required-features = ["do-notation"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["rust-patterns"] # Removed "no-std" as std is currently used
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }
+proptest = "=1.4.0" # MSRV-1.66 verified; requires Cargo.lock pins (ppv-lite86 0.2.17, tempfile 3.8.1)
 
 [[bench]]
 name = "compare"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,46 @@ let opt_str: Option<String> = Some("5".to_string());
 
 For more detailed examples, please refer to the documentation comments within the source code and the test files in the `tests/` directory.
 
+## Do Notation
+
+The library includes an optional **`do-notation`** feature that provides the `mdo!` macro, inspired by Haskell's `do` expressions. It lets you write monadic computations in a flat, imperative style instead of nested closures.
+
+**Enable with**: `--features do-notation` (optional feature; zero-dependency by default)
+
+**Syntax**: `mdo! { Marker; pat <- expr; ...; final_expr }`
+- Marker must be explicit (e.g., `OptionKind`, `ResultKind::<E>`) — type inference is impossible
+- Each `pat <- expr` is a monadic bind; `expr` is cloned once per bind step
+- `guard(cond)` filters elements (Option/Vec only; short-circuits on failure)
+- `let binding = expr;` introduces pure local bindings
+- Final expression is returned raw (not auto-wrapped with `pure`)
+
+**Quick example**:
+```rust,ignore
+use monadify::{mdo, OptionKind, Applicative};
+
+let result: Option<i32> = mdo! {
+    OptionKind;
+    x <- Some(2);
+    y <- Some(3);
+    guard(x + y > 0);      // filters; short-circuits if false
+    OptionKind::pure(x + y)  // == Some(5)
+};
+assert_eq!(result, Some(5));
+```
+
+**Real-world examples**: See `examples/` directory:
+- `validation.rs` — Validation pipelines with short-circuit on first error (Option/Result)
+- `reader_config.rs` — Environment threading (ReaderT + Config); "real power" demo
+- `list_comprehension.rs` — List comprehensions with `guard` filtering (Vec)
+
+Run with: `cargo run --example validation --features do-notation`
+
+**Limitations**:
+- `CFn` / `CFnOnce` unsupported (they are not `Clone`)
+- At most one non-`Copy` external value per `mdo!` nesting level (closure capture constraint)
+
+See [`monadify::mdo`](https://docs.rs/monadify) documentation for full details.
+
 ## Building the Project
 
 To build the library:

--- a/examples/list_comprehension.rs
+++ b/examples/list_comprehension.rs
@@ -1,0 +1,220 @@
+//! Do-notation as list comprehension: Vec example.
+//!
+//! Demonstrates the use of `mdo!` with `VecKind` to express list comprehensions,
+//! including Cartesian products and filtering with `guard`.
+//!
+//! Run with: `cargo run --example list_comprehension --features do-notation`
+
+use monadify::{mdo, Applicative, VecKind};
+
+/// ─────────────────────────────────────────────────────────────────────────────
+/// BEFORE: Nested flat_map and filter chains (imperative-looking but cluttered)
+/// ─────────────────────────────────────────────────────────────────────────────
+#[allow(dead_code)]
+fn pythagorean_triples_before(limit: i32) -> Vec<(i32, i32, i32)> {
+    (1..=limit)
+        .flat_map(move |a| {
+            (1..=limit).flat_map(move |b| {
+                (1..=limit)
+                    .filter_map(move |c| {
+                        if a * a + b * b == c * c && c <= limit {
+                            Some((a, b, c))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+        })
+        .collect()
+}
+
+/// ─────────────────────────────────────────────────────────────────────────────
+/// AFTER: Using `mdo!` do-notation (clean list-comprehension style)
+/// ─────────────────────────────────────────────────────────────────────────────
+fn pythagorean_triples_after(limit: i32) -> Vec<(i32, i32, i32)> {
+    mdo! {
+        VecKind;
+        a <- (1..=limit).collect::<Vec<_>>();
+        b <- (1..=limit).collect::<Vec<_>>();
+        c <- (1..=limit).collect::<Vec<_>>();
+        guard(a * a + b * b == c * c);
+        VecKind::pure((a, b, c))
+    }
+}
+
+/// List comprehension: all even numbers from 1 to n.
+fn even_numbers(n: i32) -> Vec<i32> {
+    mdo! {
+        VecKind;
+        x <- (1..=n).collect::<Vec<_>>();
+        guard(x % 2 == 0);
+        VecKind::pure(x)
+    }
+}
+
+/// List comprehension: Cartesian product of two ranges, filtered.
+/// Result: pairs (x, y) where x + y <= 10.
+fn sum_pairs_under_10(max_x: i32, max_y: i32) -> Vec<(i32, i32)> {
+    mdo! {
+        VecKind;
+        x <- (1..=max_x).collect::<Vec<_>>();
+        y <- (1..=max_y).collect::<Vec<_>>();
+        guard(x + y <= 10);
+        VecKind::pure((x, y))
+    }
+}
+
+/// List comprehension: all two-digit numbers with repeated digits (11, 22, 33, ..., 99).
+fn repeated_digit_numbers() -> Vec<i32> {
+    mdo! {
+        VecKind;
+        digit <- (1..=9).collect::<Vec<_>>();
+        VecKind::pure(digit * 10 + digit)
+    }
+}
+
+/// List comprehension: points on a grid within a certain distance from origin.
+fn points_near_origin(max_x: i32, max_y: i32, max_distance_sq: i32) -> Vec<(i32, i32)> {
+    mdo! {
+        VecKind;
+        x <- (-max_x..=max_x).collect::<Vec<_>>();
+        y <- (-max_y..=max_y).collect::<Vec<_>>();
+        guard(x * x + y * y <= max_distance_sq);
+        VecKind::pure((x, y))
+    }
+}
+
+/// Complex comprehension: multiples of 3 and 5 (but not both).
+fn multiples_of_3_xor_5(n: i32) -> Vec<i32> {
+    mdo! {
+        VecKind;
+        x <- (1..=n).collect::<Vec<_>>();
+        guard((x % 3 == 0 && x % 5 != 0) || (x % 3 != 0 && x % 5 == 0));
+        VecKind::pure(x)
+    }
+}
+
+fn main() {
+    println!("=== Do-notation as List Comprehension: VecKind Example ===\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 1: Even numbers from 1 to 10
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 1: Even numbers from 1 to 10");
+    let evens = even_numbers(10);
+    println!("  Result: {:?}", evens);
+    assert_eq!(evens, vec![2, 4, 6, 8, 10]);
+    println!("  ✓ PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 2: Pairs (x, y) where x + y <= 10, from ranges [1,5] × [1,6]
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 2: Pairs (x, y) where x + y <= 10");
+    let pairs = sum_pairs_under_10(5, 6);
+    println!("  Result: {:?}", pairs);
+    // (1,1) through (1,6): all valid (1+6=7 ≤ 10)
+    // (2,1) through (2,6): all valid (2+6=8 ≤ 10)
+    // (3,1) through (3,6): all valid (3+6=9 ≤ 10)
+    // (4,1) through (4,6): all valid (4+6=10 ≤ 10)
+    // (5,1) through (5,5): 5+5=10 ✓, but 5+6=11 ✗
+    let expected = vec![
+        (1, 1),
+        (1, 2),
+        (1, 3),
+        (1, 4),
+        (1, 5),
+        (1, 6),
+        (2, 1),
+        (2, 2),
+        (2, 3),
+        (2, 4),
+        (2, 5),
+        (2, 6),
+        (3, 1),
+        (3, 2),
+        (3, 3),
+        (3, 4),
+        (3, 5),
+        (3, 6),
+        (4, 1),
+        (4, 2),
+        (4, 3),
+        (4, 4),
+        (4, 5),
+        (4, 6),
+        (5, 1),
+        (5, 2),
+        (5, 3),
+        (5, 4),
+        (5, 5),
+    ];
+    assert_eq!(pairs, expected);
+    println!("  ✓ PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 3: Repeated digit numbers (11, 22, 33, ..., 99)
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 3: Repeated digit numbers");
+    let repeated = repeated_digit_numbers();
+    println!("  Result: {:?}", repeated);
+    assert_eq!(repeated, vec![11, 22, 33, 44, 55, 66, 77, 88, 99]);
+    println!("  ✓ PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 4: Points near origin (within distance 5)
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 4: Points near origin (within distance² <= 25)");
+    let points = points_near_origin(5, 5, 25);
+    println!("  Count: {}", points.len());
+    println!("  Sample points: {:?}", &points[0..10.min(points.len())]);
+    // Points within distance 5: (0,0), (±1,0), (0,±1), (±2,0), etc.
+    // Should include roughly a circle of radius 5
+    assert!(points.len() > 20); // Rough check
+    assert!(points.contains(&(0, 0)));
+    assert!(points.contains(&(5, 0)));
+    assert!(points.contains(&(3, 4))); // 3² + 4² = 25
+    println!("  ✓ PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 5: Multiples of 3 XOR 5 from 1 to 30
+    // (multiples of 3 but not 5, OR multiples of 5 but not 3)
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 5: Multiples of 3 XOR 5 (1 to 30)");
+    let xor_multiples = multiples_of_3_xor_5(30);
+    println!("  Result: {:?}", xor_multiples);
+    // Multiples of 3: 3, 6, 9, 12, 15, 18, 21, 24, 27, 30
+    // Multiples of 5: 5, 10, 15, 20, 25, 30
+    // XOR: 3, 5, 6, 9, 10, 12, 18, 20, 21, 24, 25, 27 (excluding 15, 30 which are both)
+    let expected_xor = vec![3, 5, 6, 9, 10, 12, 18, 20, 21, 24, 25, 27];
+    assert_eq!(xor_multiples, expected_xor);
+    println!("  ✓ PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 6: Pythagorean triples with low limit (3, 4, 5)
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 6: Pythagorean triples (limit=5)");
+    let triples = pythagorean_triples_after(5);
+    println!("  Result: {:?}", triples);
+    // a² + b² = c² with a,b,c ∈ [1,5]
+    // Only (3,4,5) and (4,3,5) in this range
+    assert!(triples.contains(&(3, 4, 5)) || triples.contains(&(4, 3, 5)));
+    println!("  ✓ PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 7: Pythagorean triples with larger limit
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 7: Pythagorean triples (limit=13)");
+    let triples_large = pythagorean_triples_after(13);
+    println!("  Result: {:?}", triples_large);
+    // Should find (3,4,5), (4,3,5), (5,12,13), (6,8,10), (8,6,10), (12,5,13) etc.
+    assert!(!triples_large.is_empty());
+    println!("  Count: {}", triples_large.len());
+    println!("  ✓ PASSED\n");
+
+    println!("=== All tests passed! ===");
+    println!("\nKey insight: `mdo!` with `VecKind` expresses list comprehensions");
+    println!("as readable, imperative sequences instead of nested flat_map/filter chains.");
+    println!("The `guard` statement filters elements just like list comprehension guards");
+    println!("in languages like Python, Haskell, or Scala.");
+}

--- a/examples/reader_config.rs
+++ b/examples/reader_config.rs
@@ -1,0 +1,192 @@
+//! Do-notation with ReaderT: environment threading example.
+//!
+//! Demonstrates the "real power" of Reader monad: threading a read-only configuration
+//! through a multi-step computation without passing it explicitly at each step.
+//!
+//! Run with: `cargo run --example reader_config --features do-notation`
+
+use monadify::identity::{Identity, IdentityKind};
+use monadify::transformers::reader::{MonadReader, Reader, ReaderT, ReaderTKind};
+use monadify::{mdo, Applicative};
+
+/// Application configuration: base rate and scaling factor.
+#[derive(Clone, Debug, PartialEq)]
+struct AppConfig {
+    base_rate: f64,
+    scaling_factor: f64,
+}
+
+/// Type alias: a computation that reads `AppConfig` and returns an `Identity<A>`.
+/// `Reader<E, A> = ReaderT<E, IdentityKind, A>`.
+type ConfigReader<A> = Reader<AppConfig, A>;
+
+/// Kind marker alias for the `mdo!` macro: `ReaderTKind<AppConfig, IdentityKind>`.
+type ReaderKind = ReaderTKind<AppConfig, IdentityKind>;
+
+/// Helper: unwrap the `Identity` from the `ReaderT` result.
+fn run_reader<A>(comp: &ConfigReader<A>, cfg: AppConfig) -> A {
+    let Identity(value) = (comp.run_reader_t)(cfg);
+    value
+}
+
+/// Step 1: Fetch the base rate from config.
+fn get_base_rate() -> ConfigReader<f64> {
+    ReaderT::new(|cfg: AppConfig| Identity(cfg.base_rate))
+}
+
+/// Step 2: Fetch the scaling factor from config.
+fn get_scaling_factor() -> ConfigReader<f64> {
+    ReaderT::new(|cfg: AppConfig| Identity(cfg.scaling_factor))
+}
+
+/// Step 3: Compute a derived value (e.g., adjusted rate) based on the config.
+fn compute_adjusted_rate(base: f64, factor: f64) -> ConfigReader<f64> {
+    ReaderT::new(move |_cfg: AppConfig| {
+        // The environment is available but we use the computed values instead.
+        // In practice, you might read additional fields from _cfg here.
+        Identity(base * factor)
+    })
+}
+
+/// Helper: access the entire config with `ask()`.
+fn ask_config() -> ConfigReader<AppConfig> {
+    <ReaderKind as MonadReader<AppConfig, AppConfig, IdentityKind>>::ask()
+}
+
+/// ─────────────────────────────────────────────────────────────────────────────
+/// NOTE: The "BEFORE" pattern (manually threading environment through nested
+/// closures) is less readable and error-prone. The `mdo!` version (see AFTER) is
+/// much clearer and automatically threads the environment through all steps.
+/// ─────────────────────────────────────────────────────────────────────────────
+///
+/// ─────────────────────────────────────────────────────────────────────────────
+/// AFTER: Using `mdo!` do-notation (flat, readable, environment threaded implicitly)
+/// ─────────────────────────────────────────────────────────────────────────────
+fn compute_pricing() -> ConfigReader<String> {
+    mdo! {
+        ReaderKind;
+        base <- get_base_rate();
+        factor <- get_scaling_factor();
+        adjusted <- compute_adjusted_rate(base, factor);
+        let label = format!("Base: {:.2}, Factor: {:.2}, Adjusted: {:.2}", base, factor, adjusted);
+        ReaderKind::pure(label)
+    }
+}
+
+/// An alternative version that uses `ask` to access the config directly.
+fn compute_pricing_with_ask() -> ConfigReader<String> {
+    mdo! {
+        ReaderKind;
+        cfg <- ask_config();
+        let adjusted = cfg.base_rate * cfg.scaling_factor;
+        let label = format!(
+            "Config-based: Base={:.2}, Factor={:.2}, Adjusted={:.2}",
+            cfg.base_rate, cfg.scaling_factor, adjusted
+        );
+        ReaderKind::pure(label)
+    }
+}
+
+/// A more complex multi-step calculation showing environment threading across many steps.
+fn multi_step_pricing() -> ConfigReader<(f64, f64, f64)> {
+    mdo! {
+        ReaderKind;
+        base <- get_base_rate();
+        factor <- get_scaling_factor();
+        adjusted <- compute_adjusted_rate(base, factor);
+        ReaderKind::pure((base, factor, adjusted))
+    }
+}
+
+fn main() {
+    println!("=== Do-notation with ReaderT: Environment Threading Example ===\n");
+
+    // Create two different configurations to demonstrate environment threading.
+    let config1 = AppConfig {
+        base_rate: 10.0,
+        scaling_factor: 1.5,
+    };
+
+    let config2 = AppConfig {
+        base_rate: 20.0,
+        scaling_factor: 2.0,
+    };
+
+    let config3 = AppConfig {
+        base_rate: 5.5,
+        scaling_factor: 3.2,
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 1: Basic computation against config1
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 1: Basic do-notation computation");
+    let computation = compute_pricing();
+    let result1 = run_reader(&computation, config1.clone());
+    println!("  Config: {:?}", config1);
+    println!("  Result: {}", result1);
+    assert_eq!(result1, "Base: 10.00, Factor: 1.50, Adjusted: 15.00");
+    println!("  ✓ PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 2: Same computation against different config
+    // Shows that the environment threading is correct — different inputs produce different results
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 2: Same computation against different config");
+    let result2 = run_reader(&computation, config2.clone());
+    println!("  Config: {:?}", config2);
+    println!("  Result: {}", result2);
+    assert_eq!(result2, "Base: 20.00, Factor: 2.00, Adjusted: 40.00");
+    println!("  ✓ PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 3: Another config
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 3: Third configuration");
+    let result3 = run_reader(&computation, config3.clone());
+    println!("  Config: {:?}", config3);
+    println!("  Result: {}", result3);
+    assert_eq!(result3, "Base: 5.50, Factor: 3.20, Adjusted: 17.60");
+    println!("  ✓ PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 4: Using `ask()` to access the full config
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 4: Using `ask()` to access the full environment");
+    let computation_with_ask = compute_pricing_with_ask();
+    let result4 = run_reader(&computation_with_ask, config1.clone());
+    println!("  Config: {:?}", config1);
+    println!("  Result: {}", result4);
+    assert_eq!(
+        result4,
+        "Config-based: Base=10.00, Factor=1.50, Adjusted=15.00"
+    );
+    println!("  ✓ PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 5: Multi-step computation showing deep environment threading
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 5: Multi-step computation (3 bindings)");
+    let multi_comp = multi_step_pricing();
+    let (base, factor, adjusted) = run_reader(&multi_comp, config2.clone());
+    println!("  Config: {:?}", config2);
+    println!("  Base: {:.2}", base);
+    println!("  Factor: {:.2}", factor);
+    println!("  Adjusted (base * factor): {:.2}", adjusted);
+    assert_eq!(base, 20.0);
+    assert_eq!(factor, 2.0);
+    assert_eq!(adjusted, 40.0);
+    println!("  ✓ PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Summary: Show how environment threading works without explicit parameter passing
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("=== All tests passed! ===");
+    println!("\nKey insight: `mdo!` with `ReaderT` demonstrates the power of monadic threading:");
+    println!("  • Each step (get_base_rate, get_scaling_factor, etc.) silently receives");
+    println!("    the same AppConfig from the environment.");
+    println!("  • No explicit parameter passing required — the do-notation macro desugars");
+    println!("    to nested `bind` calls that thread the environment automatically.");
+    println!("  • This is especially powerful for dependency injection, configuration");
+    println!("    management, and multi-step computations in complex applications.");
+}

--- a/examples/validation.rs
+++ b/examples/validation.rs
@@ -1,0 +1,195 @@
+//! Do-notation validation pipeline example.
+//!
+//! Demonstrates the power of `mdo!` for short-circuit validation:
+//! a sequence of fallible operations using Option/Result.
+//!
+//! Run with: `cargo run --example validation --features do-notation`
+
+use monadify::{mdo, Applicative, OptionKind, ResultKind};
+
+/// Check if a number is in a valid range.
+fn validate_range(n: i32, min: i32, max: i32) -> Option<i32> {
+    if n >= min && n <= max {
+        Some(n)
+    } else {
+        None
+    }
+}
+
+/// Check if a number is positive.
+fn is_positive(n: i32) -> Option<i32> {
+    if n > 0 {
+        Some(n)
+    } else {
+        None
+    }
+}
+
+/// Represents validation output.
+#[derive(Debug, Clone, PartialEq)]
+struct ValidationResult {
+    original: i32,
+    squared: i32,
+    sum: i32,
+}
+
+/// ─────────────────────────────────────────────────────────────────────────────
+/// BEFORE: Nested and_then / manual bind chains (hard to read)
+/// ─────────────────────────────────────────────────────────────────────────────
+#[allow(dead_code)]
+fn process_numbers_before(a: i32, b: i32) -> Option<ValidationResult> {
+    is_positive(a).and_then(|a_val| {
+        is_positive(b).and_then(|b_val| {
+            validate_range(a_val, 1, 100).and_then(|a_checked| {
+                validate_range(b_val, 1, 100).map(|b_checked| ValidationResult {
+                    original: a_checked + b_checked,
+                    squared: a_checked * a_checked + b_checked * b_checked,
+                    sum: a_checked + b_checked,
+                })
+            })
+        })
+    })
+}
+
+/// ─────────────────────────────────────────────────────────────────────────────
+/// AFTER: Using `mdo!` do-notation (flat, imperative style, easy to read)
+/// ─────────────────────────────────────────────────────────────────────────────
+fn process_numbers_after(a: i32, b: i32) -> Option<ValidationResult> {
+    mdo! {
+        OptionKind;
+        a_val <- is_positive(a);
+        b_val <- is_positive(b);
+        a_checked <- validate_range(a_val, 1, 100);
+        b_checked <- validate_range(b_val, 1, 100);
+        OptionKind::pure(ValidationResult {
+            original: a_checked + b_checked,
+            squared: a_checked * a_checked + b_checked * b_checked,
+            sum: a_checked + b_checked,
+        })
+    }
+}
+
+/// Result-based version with error messages.
+fn process_numbers_with_errors(a: i32, b: i32) -> Result<ValidationResult, String> {
+    mdo! {
+        ResultKind::<String>;
+        a_val <- if a > 0 {
+            Ok(a)
+        } else {
+            Err("First number must be positive".to_string())
+        };
+        b_val <- if b > 0 {
+            Ok(b)
+        } else {
+            Err("Second number must be positive".to_string())
+        };
+        a_checked <- if a_val <= 100 {
+            Ok(a_val)
+        } else {
+            Err(format!("First number {} exceeds max 100", a_val))
+        };
+        b_checked <- if b_val <= 100 {
+            Ok(b_val)
+        } else {
+            Err(format!("Second number {} exceeds max 100", b_val))
+        };
+        ResultKind::<String>::pure(ValidationResult {
+            original: a_checked + b_checked,
+            squared: a_checked * a_checked + b_checked * b_checked,
+            sum: a_checked + b_checked,
+        })
+    }
+}
+
+fn main() {
+    println!("=== Do-notation Validation Pipeline Example ===\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // SUCCESS CASE: All validations pass
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 1: Valid numbers (both positive and in range)");
+    let result1 = process_numbers_after(5, 7);
+    println!("  process_numbers_after(5, 7): {:?}", result1);
+    assert_eq!(
+        result1,
+        Some(ValidationResult {
+            original: 12,
+            squared: 74, // 5² + 7² = 25 + 49 = 74
+            sum: 12,
+        })
+    );
+    println!("  ✓ SUCCESS\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // FAILURE CASE 1: First number negative (short-circuits immediately)
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 2: First number negative (short-circuit at first step)");
+    let result2 = process_numbers_after(-5, 7);
+    println!("  process_numbers_after(-5, 7): {:?}", result2);
+    assert_eq!(result2, None);
+    println!("  ✓ SHORT-CIRCUIT: First validation failed, remaining steps skipped\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // FAILURE CASE 2: Second number negative (short-circuits at second step)
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 3: Second number negative (short-circuit at second step)");
+    let result3 = process_numbers_after(5, -3);
+    println!("  process_numbers_after(5, -3): {:?}", result3);
+    assert_eq!(result3, None);
+    println!("  ✓ SHORT-CIRCUIT: Second validation failed after first succeeded\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // FAILURE CASE 3: First number out of range (short-circuits at third step)
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 4: First number exceeds range (short-circuit at third step)");
+    let result4 = process_numbers_after(150, 7);
+    println!("  process_numbers_after(150, 7): {:?}", result4);
+    assert_eq!(result4, None);
+    println!("  ✓ SHORT-CIRCUIT: Range check failed after positivity checks passed\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // FAILURE CASE 4: Second number out of range (short-circuits at fourth step)
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 5: Second number exceeds range (short-circuit at fourth step)");
+    let result5 = process_numbers_after(5, 200);
+    println!("  process_numbers_after(5, 200): {:?}", result5);
+    assert_eq!(result5, None);
+    println!("  ✓ SHORT-CIRCUIT: Second range check failed\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // RESULT-BASED: With detailed error messages
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 6: Result-based version with error messages");
+    let result6a = process_numbers_with_errors(10, 20);
+    println!("  Success case (10, 20): {:?}", result6a);
+    assert!(result6a.is_ok());
+
+    let result6b = process_numbers_with_errors(-5, 20);
+    println!("  First number negative: {:?}", result6b);
+    assert_eq!(result6b, Err("First number must be positive".to_string()));
+
+    let result6c = process_numbers_with_errors(10, -3);
+    println!("  Second number negative: {:?}", result6c);
+    assert_eq!(result6c, Err("Second number must be positive".to_string()));
+
+    let result6d = process_numbers_with_errors(150, 20);
+    println!("  First number out of range: {:?}", result6d);
+    assert_eq!(
+        result6d,
+        Err("First number 150 exceeds max 100".to_string())
+    );
+
+    let result6e = process_numbers_with_errors(10, 101);
+    println!("  Second number out of range: {:?}", result6e);
+    assert_eq!(
+        result6e,
+        Err("Second number 101 exceeds max 100".to_string())
+    );
+    println!("  ✓ ALL ERROR CASES PASSED\n");
+
+    println!("=== All tests passed! ===");
+    println!("\nKey insight: `mdo!` makes validation pipelines readable and maintainable");
+    println!("by eliminating deeply nested closures and using imperative sequencing.");
+    println!("When one step fails, the entire computation short-circuits to None/Err");
+    println!("without executing the remaining steps.");
+}

--- a/monadify-macros/Cargo.toml
+++ b/monadify-macros/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "monadify-macros"
+version = "0.1.1"
+edition = "2021"
+rust-version = "1.66" # match the parent monadify MSRV
+license = "MIT"
+description = "Procedural `mdo!` do-notation macro for the monadify crate."
+repository = "https://github.com/jarnura/monadify"
+
+[lib]
+proc-macro = true # MANDATORY: makes this a proc-macro crate
+
+[dependencies]
+# Upper bounds preserve MSRV 1.66 even on a fresh dependency resolution
+# (Cargo.lock is not committed for this library). The caps sit at the highest
+# versions verified to build on rustc 1.66:
+#   syn 2.0.87, quote 1.0.41, proc-macro2 1.0.86.
+# Beyond these the proc-macro toolchain raises its own MSRV — e.g. syn 2.0.88+
+# and quote 1.0.42+ require rustc >= 1.68/1.71. unicode-ident is transitive and
+# keeps an MSRV <= 1.66. Relax these caps only together with the crate MSRV.
+syn = { version = ">=2.0, <2.0.88", features = ["full"] }
+quote = ">=1.0, <1.0.42"
+proc-macro2 = ">=1.0, <1.0.87"
+# Transitive (via syn/proc-macro2); declared directly only to cap its MSRV.
+# unicode-ident 1.0.13+ raises its MSRV past 1.66; 1.0.12 is the safe ceiling.
+unicode-ident = ">=1.0, <1.0.13"

--- a/monadify-macros/src/lib.rs
+++ b/monadify-macros/src/lib.rs
@@ -1,0 +1,312 @@
+//! Procedural macro backing `monadify`'s `do`-notation.
+//!
+//! This crate exports a single procedural macro, [`mdo`], which is re-exported
+//! by `monadify` under the non-default `do-notation` feature as `monadify::mdo`.
+//!
+//! # What it does
+//!
+//! `mdo!` desugars an imperative monadic block — a sequence of `let`,
+//! `pat <- expr;`, `guard(expr);`, and bare `expr;` statements followed by a
+//! trailing *final expression* — into nested `Marker::bind(..)` calls over
+//! `monadify`'s [`Bind`](../monadify/trait.Bind.html) /
+//! [`Applicative`](../monadify/trait.Applicative.html) trait hierarchy.
+//!
+//! The block names its Kind marker explicitly (marker inference is impossible
+//! because the GAT `Of<Arg>` is not injective):
+//!
+//! ```text
+//! use monadify::{mdo, OptionKind, Applicative};
+//!
+//! let r: Option<i32> = mdo! { OptionKind;
+//!     x <- Some(2);
+//!     y <- Some(3);
+//!     guard(x + y > 0);
+//!     OptionKind::pure(x + y)      // raw monadic value, == Some(5)
+//! };
+//! ```
+//!
+//! A runnable version of this example lives on `monadify::mdo` (the gated
+//! re-export), where it can depend on `monadify` without a build cycle.
+
+use proc_macro::TokenStream;
+use proc_macro2::{Delimiter, Spacing, Span, TokenStream as TokenStream2, TokenTree};
+use quote::{quote, ToTokens};
+use syn::parse::{Parse, ParseStream, Parser};
+use syn::{Error, Expr, Pat, Result as SynResult, Token, Type};
+
+/// A single desugarable statement inside an `mdo!` block.
+enum Stmt {
+    /// `pat <- expr` — monadic bind.
+    Bind(Pat, Expr),
+    /// `let …` — a plain Rust `let`, kept verbatim (tokens exclude the `;`).
+    Let(TokenStream2),
+    /// `guard(cond)` — filter via the `MdoGuard` helper trait.
+    Guard(TokenStream2),
+    /// bare `expr` — sequencing (`_ <- expr`).
+    Bare(Expr),
+}
+
+/// Parsed `mdo!` block: explicit marker, statement list, and the raw final expr.
+struct MdoInput {
+    marker: Type,
+    stmts: Vec<Stmt>,
+    final_expr: Expr,
+}
+
+/// Returns the index of a top-level `<-` (a `<` joined to a following `-`).
+fn find_left_arrow(tokens: &[TokenTree]) -> Option<usize> {
+    for i in 0..tokens.len().saturating_sub(1) {
+        if let (TokenTree::Punct(a), TokenTree::Punct(b)) = (&tokens[i], &tokens[i + 1]) {
+            if a.as_char() == '<' && a.spacing() == Spacing::Joint && b.as_char() == '-' {
+                return Some(i);
+            }
+        }
+    }
+    None
+}
+
+/// Classify one statement segment (tokens between top-level `;`) into a [`Stmt`].
+fn classify(tokens: Vec<TokenTree>) -> SynResult<Stmt> {
+    if tokens.is_empty() {
+        return Err(Error::new(
+            Span::call_site(),
+            "empty statement in mdo! block (stray `;`?)",
+        ));
+    }
+
+    // 1. `pat <- expr` — highest priority (the `<-` is unambiguous).
+    if let Some(idx) = find_left_arrow(&tokens) {
+        let pat_ts: TokenStream2 = tokens[..idx].iter().cloned().collect();
+        let expr_ts: TokenStream2 = tokens[idx + 2..].iter().cloned().collect();
+        if pat_ts.is_empty() {
+            return Err(Error::new(
+                tokens[idx].span(),
+                "mdo! bind requires a pattern before `<-`",
+            ));
+        }
+        if expr_ts.is_empty() {
+            return Err(Error::new(
+                tokens[idx].span(),
+                "mdo! bind requires a monadic expression after `<-`",
+            ));
+        }
+        let pat = Pat::parse_single.parse2(pat_ts)?;
+        let expr: Expr = syn::parse2(expr_ts)?;
+        return Ok(Stmt::Bind(pat, expr));
+    }
+
+    // 2. `let …` — keep verbatim.
+    if let TokenTree::Ident(id) = &tokens[0] {
+        if id == "let" {
+            return Ok(Stmt::Let(tokens.into_iter().collect()));
+        }
+        // 3. `guard ( … )` recognised only as a whole statement.
+        if id == "guard" && tokens.len() == 2 {
+            if let TokenTree::Group(g) = &tokens[1] {
+                if g.delimiter() == Delimiter::Parenthesis {
+                    return Ok(Stmt::Guard(g.stream()));
+                }
+            }
+        }
+    }
+
+    // 4. bare expression (sequencing).
+    let expr: Expr = syn::parse2(tokens.into_iter().collect())?;
+    Ok(Stmt::Bare(expr))
+}
+
+impl Parse for MdoInput {
+    fn parse(input: ParseStream) -> SynResult<Self> {
+        if input.is_empty() {
+            return Err(Error::new(
+                Span::call_site(),
+                "mdo! requires a block marker followed by at least a final expression, \
+                 e.g. `mdo! { OptionKind; OptionKind::pure(1) }`",
+            ));
+        }
+
+        let marker: Type = input.parse().map_err(|_| {
+            Error::new(
+                Span::call_site(),
+                "mdo! must start with a block marker type, e.g. `mdo! { OptionKind; … }`",
+            )
+        })?;
+        if !matches!(marker, Type::Path(_)) {
+            return Err(Error::new_spanned(
+                &marker,
+                "mdo! block marker must be a type path, e.g. `OptionKind` or `ResultKind::<String>`",
+            ));
+        }
+        input.parse::<Token![;]>().map_err(|_| {
+            Error::new(
+                Span::call_site(),
+                "mdo! marker must be followed by `;`, e.g. `mdo! { OptionKind; … }`",
+            )
+        })?;
+
+        // Grab the remaining tokens and split on top-level `;` (semicolons inside
+        // groups like `{ … }` or `( … )` are nested and never seen here).
+        let rest: TokenStream2 = input.parse()?;
+        let mut segments: Vec<(Vec<TokenTree>, bool)> = Vec::new();
+        let mut cur: Vec<TokenTree> = Vec::new();
+        for tt in rest {
+            if let TokenTree::Punct(p) = &tt {
+                if p.as_char() == ';' {
+                    segments.push((std::mem::take(&mut cur), true));
+                    continue;
+                }
+            }
+            cur.push(tt);
+        }
+        if !cur.is_empty() {
+            segments.push((cur, false));
+        }
+
+        if segments.is_empty() {
+            return Err(Error::new(
+                Span::call_site(),
+                "mdo! requires at least a final expression after the marker",
+            ));
+        }
+        // The last segment must be the trailing final expression (no `;`).
+        if segments.last().map(|(_, semi)| *semi).unwrap_or(true) {
+            return Err(Error::new(
+                Span::call_site(),
+                "mdo! block must end with a final monadic expression and no trailing `;`",
+            ));
+        }
+
+        let (final_tokens, _) = segments.pop().expect("checked non-empty above");
+        if let Some(idx) = find_left_arrow(&final_tokens) {
+            return Err(Error::new(
+                final_tokens[idx].span(),
+                "the final line of an mdo! block must be a raw monadic value, not a `<-` bind",
+            ));
+        }
+        let final_expr: Expr = syn::parse2(final_tokens.into_iter().collect())?;
+
+        let mut stmts = Vec::with_capacity(segments.len());
+        for (tokens, _) in segments {
+            stmts.push(classify(tokens)?);
+        }
+
+        Ok(MdoInput {
+            marker,
+            stmts,
+            final_expr,
+        })
+    }
+}
+
+/// Procedural `do`-notation macro.
+///
+/// `mdo!` desugars an imperative monadic block into nested `Marker::bind(..)`
+/// calls over `monadify`'s `Bind`/`Applicative` traits. The block's Kind marker
+/// is named explicitly as the first token group, terminated by `;`:
+///
+/// ```text
+/// mdo! { Marker;
+///     pat <- expr;        // monadic bind
+///     let pat = expr;     // plain let
+///     guard(cond);        // filter (Option/Vec only)
+///     expr;               // sequencing (== `_ <- expr`)
+///     final_expr          // raw monadic result (NOT auto-pure-wrapped)
+/// }
+/// ```
+///
+/// Each non-final monadic right-hand side is cloned (`(expr).clone()`) because
+/// `bind`'s closure is `FnMut + Clone + 'static` and `VecKind::bind` re-invokes
+/// it per element. The final expression is returned raw as `Marker::Of<B>`.
+///
+/// # Limitations
+///
+/// **`CFnKind` / `CFnOnceKind` are not supported.** `CFn` and `CFnOnce` wrap
+/// `Box<dyn Fn(…)>` / `Box<dyn FnOnce(…)>`, which are not `Clone`. The
+/// desugaring always emits `(expr).clone()` for each monadic right-hand side
+/// (required because `bind`'s continuation is `FnMut + Clone + 'static`), so any
+/// `mdo!` block over `CFnKind`/`CFnOnceKind` — even at depth 1 — fails to
+/// compile with `E0599` (*the trait bound `CFn<…>: Clone` is not satisfied*).
+/// This exclusion is by design. A future `Rc`-backed clonable function wrapper
+/// (analogous to `ReaderT`'s `Rc<dyn Fn(R) -> M::Of<A>>`) could lift the
+/// restriction; until then, use `ReaderTKind<R, IdentityKind>` as an alternative
+/// when a function monad in a do-block is needed.
+///
+/// **At most one non-`Copy` external value may be captured per `mdo!` nesting
+/// level.** The desugaring emits nested `move` closures bound by
+/// `FnMut + Clone + 'static`, so a non-`Copy` value captured by an outer `move`
+/// closure cannot also be referenced from an inner (deeper) closure — doing so
+/// moves it out of the outer `FnMut`, which triggers `E0507`
+/// (*cannot move out of a captured variable in an `FnMut` closure*).
+///
+/// In practice this bites when a do-block reads the same non-`Copy` external
+/// (e.g. a `ReaderT`, `String`, or other non-`Copy` binding) at two different
+/// bind depths. The bound results of monadic steps are usually `Copy` (`i32`,
+/// `bool`, …) and cross nesting levels freely; the constraint applies to
+/// *external* non-`Copy` values referenced inside the block.
+///
+/// **Workaround:** combine the multiple reads into a single step that returns a
+/// tuple, so only the resulting `Copy` components cross into deeper nesting
+/// levels. For example, instead of binding two separate `ReaderT`s that each
+/// read a field, read both fields in one `ReaderT` returning `(a, b)`:
+///
+/// ```text
+/// // Instead of two non-Copy reader steps at different depths, do:
+/// (a, b) <- ReaderT::new(|cfg: Config| Identity((cfg.base, cfg.factor)));
+/// other  <- some_other_reader;   // `a`/`b` are Copy and cross freely
+/// Marker::pure(a + b + other)
+/// ```
+///
+/// # Example
+///
+/// ```text
+/// use monadify::{mdo, OptionKind, Applicative};
+///
+/// let r: Option<i32> = mdo! { OptionKind;
+///     x <- Some(2);
+///     y <- Some(3);
+///     OptionKind::pure(x + y)
+/// };
+/// assert_eq!(r, Some(5));
+/// ```
+///
+/// A compiling, runnable version of this example is documented on the
+/// `monadify::mdo` re-export (see the `monadify` crate), where it can depend on
+/// `monadify` itself without introducing a build cycle.
+#[proc_macro]
+pub fn mdo(input: TokenStream) -> TokenStream {
+    let parsed = match syn::parse::<MdoInput>(input) {
+        Ok(p) => p,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    let marker = &parsed.marker;
+    // Right-fold the statements into nested binds, starting from the raw final.
+    let mut acc: TokenStream2 = parsed.final_expr.to_token_stream();
+    for stmt in parsed.stmts.iter().rev() {
+        acc = match stmt {
+            Stmt::Bind(pat, expr) => quote! {
+                <#marker as ::monadify::Bind<_, _>>::bind(
+                    (#expr).clone(),
+                    move |#pat| { #acc }
+                )
+            },
+            Stmt::Bare(expr) => quote! {
+                <#marker as ::monadify::Bind<_, _>>::bind(
+                    (#expr).clone(),
+                    move |_| { #acc }
+                )
+            },
+            Stmt::Guard(cond) => quote! {
+                <#marker as ::monadify::Bind<_, _>>::bind(
+                    (<#marker as ::monadify::MdoGuard>::guard(#cond)).clone(),
+                    move |_| { #acc }
+                )
+            },
+            Stmt::Let(raw) => quote! {
+                { #raw ; #acc }
+            },
+        };
+    }
+
+    acc.into()
+}

--- a/src/applicative.rs
+++ b/src/applicative.rs
@@ -101,7 +101,7 @@ pub mod kind {
 
     impl<T: 'static> Applicative<T> for OptionKind {
         // Changed OptionHKTMarker to OptionKind
-        /// Lifts a value `T` into [`Some(T)`].
+        /// Lifts a value `T` into `Some(T)`.
         fn pure(value: T) -> Self::Of<T> {
             // Self::Of<T> is Option<T>
             Some(value)
@@ -110,7 +110,7 @@ pub mod kind {
 
     impl<T: 'static, E: 'static + Clone> Applicative<T> for ResultKind<E> {
         // Changed ResultHKTMarker to ResultKind
-        /// Lifts a value `T` into [`Ok(T)`].
+        /// Lifts a value `T` into `Ok(T)`.
         fn pure(value: T) -> Self::Of<T> {
             // Self::Of<T> is Result<T, E>
             Ok(value)

--- a/src/do_notation.rs
+++ b/src/do_notation.rs
@@ -1,0 +1,64 @@
+//! Support items for the `do-notation` feature's [`mdo!`](crate::mdo) macro.
+//!
+//! This module is compiled only when the non-default `do-notation` feature is
+//! enabled. It currently provides [`MdoGuard`], the minimal "monadic zero"
+//! helper that backs `guard(..)` statements inside `mdo!` blocks. It is
+//! intentionally implemented **only** for instances with a lawful empty element
+//! ([`OptionKind`] and [`VecKind`]); using `guard` under any other marker is a
+//! deliberate compile error.
+
+use crate::kind_based::kind::{Kind1, OptionKind, VecKind};
+
+/// Private module implementing the sealed-trait pattern for [`MdoGuard`].
+///
+/// The `Sealed` trait is intentionally **not** re-exported, so downstream
+/// crates cannot name it and therefore cannot satisfy the `MdoGuard: Sealed`
+/// supertrait bound. This restricts `MdoGuard` implementations to the markers
+/// sealed here ([`OptionKind`] and [`VecKind`]).
+mod sealed {
+    use crate::kind_based::kind::{OptionKind, VecKind};
+
+    /// Sealing marker trait. Not re-exported, so foreign impls are impossible.
+    pub trait Sealed {}
+
+    impl Sealed for OptionKind {}
+    impl Sealed for VecKind {}
+}
+
+/// Monadic zero used by `guard(..)` inside [`mdo!`](crate::mdo).
+///
+/// `guard(cond)` desugars to a `bind` over `Self::guard(cond)`: it yields
+/// `pure(())` when `cond` is `true` and the instance's lawful zero when `false`,
+/// short-circuiting the rest of the block.
+///
+/// Implemented only for [`OptionKind`] (`None` on `false`) and [`VecKind`]
+/// (`vec![]` on `false`) — the two instances with a genuine empty element.
+///
+/// This trait is **sealed**: it has a private `Sealed` supertrait that only
+/// `monadify` can implement, so downstream crates cannot add their own
+/// `MdoGuard` instances.
+pub trait MdoGuard: Kind1 + sealed::Sealed {
+    /// Returns `pure(())` when `cond` is `true`, or this instance's zero when
+    /// `cond` is `false`.
+    fn guard(cond: bool) -> Self::Of<()>;
+}
+
+impl MdoGuard for OptionKind {
+    fn guard(cond: bool) -> Option<()> {
+        if cond {
+            Some(())
+        } else {
+            None
+        }
+    }
+}
+
+impl MdoGuard for VecKind {
+    fn guard(cond: bool) -> Vec<()> {
+        if cond {
+            vec![()]
+        } else {
+            Vec::new()
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,66 @@ pub use kind_based::kind::{
 }; // Changed from ReaderTHKTMarker
    // Reader alias is re-exported above.
 
+/// Support items for the `do-notation` feature's `mdo!` macro (e.g. the
+/// `MdoGuard` helper trait backing `guard(..)`). Compiled only under the
+/// non-default `do-notation` feature.
+#[cfg(feature = "do-notation")]
+pub mod do_notation;
+
+/// Procedural `do`-notation macro. Available only under the non-default
+/// `do-notation` feature; desugars an imperative monadic block over the
+/// `Bind`/`Applicative` hierarchy. Usable as `monadify::mdo!`.
+///
+/// The block names its Kind marker explicitly (marker inference is impossible
+/// because the GAT `Of<Arg>` is not injective), terminated by `;`. Each
+/// statement is one of `let …`, `pat <- expr` (bind), `guard(expr)` (filter,
+/// for [`OptionKind`]/[`VecKind`] only), or a bare `expr` (sequencing),
+/// followed by a trailing raw final expression.
+///
+/// # Example
+///
+/// ```rust
+/// use monadify::{mdo, Applicative, OptionKind};
+///
+/// let r: Option<i32> = mdo! { OptionKind;
+///     x <- Some(2);
+///     y <- Some(3);
+///     guard(x + y > 0);
+///     OptionKind::pure(x + y)      // raw monadic value, == Some(5)
+/// };
+/// assert_eq!(r, Some(5));
+/// ```
+///
+/// # Limitations
+///
+/// **`CFnKind` / `CFnOnceKind` are not supported.** `CFn` and `CFnOnce` are
+/// not `Clone` (they wrap `Box<dyn Fn(…)>`). Because the desugaring emits
+/// `(expr).clone()` on every monadic right-hand side, any `mdo!` block over
+/// these markers fails with `E0599` at depth ≥ 1. See
+/// `tests/kind/do_notation/cfn_unsupported.rs` and the `monadify-macros`
+/// documentation for the full explanation and the future `Rc`-backed lift.
+///
+/// At most **one non-`Copy` external value may be captured per `mdo!` nesting
+/// level**. Because the desugaring emits nested `move` closures bound by
+/// `FnMut + Clone + 'static`, referencing the same non-`Copy` captured value
+/// (e.g. a [`ReaderT`], `String`, or other
+/// non-`Copy` binding) at two different bind depths moves it out of the outer
+/// `FnMut` and triggers `E0507`.
+///
+/// The bound results of monadic steps are usually `Copy` (`i32`, `bool`, …) and
+/// cross nesting levels freely; the constraint applies to *external* non-`Copy`
+/// values referenced inside the block. The workaround is to combine multiple
+/// reads into a single tuple-returning step so only `Copy` values cross deeper
+/// nesting levels. See the [`mdo`](macro@crate::mdo) macro's own documentation
+/// (re-exported from `monadify-macros`) for a worked example.
+#[cfg(feature = "do-notation")]
+pub use monadify_macros::mdo;
+
+/// Helper trait backing `guard(..)` inside `mdo!`. Available only under the
+/// non-default `do-notation` feature.
+#[cfg(feature = "do-notation")]
+pub use do_notation::MdoGuard;
+
 // Note on macros:
 // Macros defined with `#[macro_export]` in submodules (like `utils.rs`) are
 // automatically available at the crate root.

--- a/tests/kind/applicative.rs
+++ b/tests/kind/applicative.rs
@@ -22,14 +22,8 @@ fn option_kind_applicative_law_identity() {
     let id_cfn_creator = || CFn::new(identity::<i32>);
     let pure_id_cfn_creator = || OptionKind::pure(id_cfn_creator()); // Renamed Marker
 
-    assert_eq!(
-        OptionKind::apply(v_some.clone(), pure_id_cfn_creator()),
-        v_some
-    ); // Renamed Marker
-    assert_eq!(
-        OptionKind::apply(v_none.clone(), pure_id_cfn_creator()),
-        v_none
-    ); // Renamed Marker
+    assert_eq!(OptionKind::apply(v_some, pure_id_cfn_creator()), v_some); // Renamed Marker
+    assert_eq!(OptionKind::apply(v_none, pure_id_cfn_creator()), v_none); // Renamed Marker
 }
 
 #[test]
@@ -65,12 +59,12 @@ fn option_kind_applicative_law_interchange() {
     let pure_y: Option<A> = OptionKind::pure(y_val); // Renamed Marker
 
     // LHS: apply(pure(y), u)
-    let lhs_some = OptionKind::apply(pure_y.clone(), u_some_creator()); // Renamed Marker
-    let lhs_none = OptionKind::apply(pure_y.clone(), u_none_creator()); // Renamed Marker
+    let lhs_some = OptionKind::apply(pure_y, u_some_creator()); // Renamed Marker
+    let lhs_none = OptionKind::apply(pure_y, u_none_creator()); // Renamed Marker
 
-    let y_val_clone_for_rhs = y_val.clone();
+    let y_val_clone_for_rhs = y_val;
     let interchange_fn_creator =
-        || CFn::new(move |f_map_fn: CFn<A, B>| f_map_fn.call(y_val_clone_for_rhs.clone()));
+        || CFn::new(move |f_map_fn: CFn<A, B>| f_map_fn.call(y_val_clone_for_rhs));
     let pure_interchange_fn_wrapper_creator = || OptionKind::pure(interchange_fn_creator()); // Renamed Marker
 
     let rhs_some = OptionKind::apply(u_some_creator(), pure_interchange_fn_wrapper_creator()); // Renamed Marker
@@ -90,11 +84,11 @@ fn option_kind_lift_a1_functor_identity() {
     let id_fn_static = identity::<i32>;
 
     assert_eq!(
-        lift_a1::<OptionKind, _, _, _>(id_fn_static, fa_some.clone()),
+        lift_a1::<OptionKind, _, _, _>(id_fn_static, fa_some),
         fa_some
     ); // Renamed Marker
     assert_eq!(
-        lift_a1::<OptionKind, _, _, _>(id_fn_static, fa_none.clone()),
+        lift_a1::<OptionKind, _, _, _>(id_fn_static, fa_none),
         fa_none
     ); // Renamed Marker
 }
@@ -109,13 +103,13 @@ fn option_kind_lift_a1_functor_composition() {
     let g = |y: i32| y.to_string();
     let g_compose_f = move |x: i32| g(f(x));
 
-    let lhs_some = lift_a1::<OptionKind, _, _, _>(g_compose_f, fa_some.clone()); // Renamed Marker
-    let lhs_none = lift_a1::<OptionKind, _, _, _>(g_compose_f, fa_none.clone()); // Renamed Marker
+    let lhs_some = lift_a1::<OptionKind, _, _, _>(g_compose_f, fa_some); // Renamed Marker
+    let lhs_none = lift_a1::<OptionKind, _, _, _>(g_compose_f, fa_none); // Renamed Marker
 
-    let map_f_fa_some = lift_a1::<OptionKind, _, _, _>(f, fa_some.clone()); // Renamed Marker
+    let map_f_fa_some = lift_a1::<OptionKind, _, _, _>(f, fa_some); // Renamed Marker
     let rhs_some = lift_a1::<OptionKind, _, _, _>(g, map_f_fa_some); // Renamed Marker
 
-    let map_f_fa_none = lift_a1::<OptionKind, _, _, _>(f, fa_none.clone()); // Renamed Marker
+    let map_f_fa_none = lift_a1::<OptionKind, _, _, _>(f, fa_none); // Renamed Marker
     let rhs_none = lift_a1::<OptionKind, _, _, _>(g, map_f_fa_none); // Renamed Marker
 
     assert_eq!(lhs_some, rhs_some);
@@ -178,9 +172,9 @@ fn result_kind_applicative_law_interchange() {
     let lhs_ok = ResultKind::<TestError>::apply(pure_y.clone(), u_ok_creator()); // Renamed Marker
     let lhs_err = ResultKind::<TestError>::apply(pure_y.clone(), u_err_creator()); // Renamed Marker
 
-    let y_val_clone_for_rhs = y_val.clone();
+    let y_val_clone_for_rhs = y_val;
     let interchange_fn_creator =
-        || CFn::new(move |f_map_fn: CFn<A, B>| f_map_fn.call(y_val_clone_for_rhs.clone()));
+        || CFn::new(move |f_map_fn: CFn<A, B>| f_map_fn.call(y_val_clone_for_rhs));
     let pure_interchange_fn_wrapper_creator =
         || ResultKind::<TestError>::pure(interchange_fn_creator()); // Renamed Marker
 
@@ -345,9 +339,9 @@ fn identity_kind_applicative_law_interchange() {
 
     let lhs = IdentityKind::apply(pure_y.clone(), u_identity_creator()); // Renamed Marker
 
-    let y_val_clone_for_rhs = y_val.clone();
+    let y_val_clone_for_rhs = y_val;
     let interchange_fn_creator =
-        || CFn::new(move |f_map_fn: CFn<A, B>| f_map_fn.call(y_val_clone_for_rhs.clone()));
+        || CFn::new(move |f_map_fn: CFn<A, B>| f_map_fn.call(y_val_clone_for_rhs));
     let pure_interchange_fn_wrapper_creator = || IdentityKind::pure(interchange_fn_creator()); // Renamed Marker
 
     let rhs = IdentityKind::apply(u_identity_creator(), pure_interchange_fn_wrapper_creator()); // Renamed Marker
@@ -524,7 +518,7 @@ fn reader_t_kind_functor_identity_via_map() {
 
     let env_val = 100;
     assert_eq!(
-        (mapped.run_reader_t)(env_val.clone()),
+        (mapped.run_reader_t)(env_val),
         (fa_creator().run_reader_t)(env_val)
     );
 }
@@ -549,9 +543,6 @@ fn reader_t_kind_functor_composition_via_map() {
     let rhs = ReaderTKind::<ReaderEnv, IdentityKind>::map(map_f_fa, g); // Renamed Marker
 
     let env_val = 100;
-    assert_eq!(
-        (lhs.run_reader_t)(env_val.clone()),
-        (rhs.run_reader_t)(env_val.clone())
-    );
+    assert_eq!((lhs.run_reader_t)(env_val), (rhs.run_reader_t)(env_val));
     assert_eq!((lhs.run_reader_t)(env_val), IdType("20".to_string()));
 }

--- a/tests/kind/apply.rs
+++ b/tests/kind/apply.rs
@@ -1,0 +1,189 @@
+use monadify::apply::kind::{apply_first, apply_second, lift2, lift3};
+use monadify::fn2;
+use monadify::fn3;
+use monadify::function::CFn;
+use monadify::kind_based::kind::{OptionKind, ResultKind, VecKind};
+
+type TestError = String;
+
+// ── lift2 ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn lift2_option_some() {
+    let add = fn2!(|x: i32| move |y: i32| x + y);
+    let result = lift2::<OptionKind, _, _, _, _>(add, Some(3), Some(7));
+    assert_eq!(result, Some(10));
+}
+
+#[test]
+fn lift2_option_first_none() {
+    let add = fn2!(|x: i32| move |y: i32| x + y);
+    let result = lift2::<OptionKind, _, _, _, _>(add, None, Some(7));
+    assert_eq!(result, None);
+}
+
+#[test]
+fn lift2_option_second_none() {
+    let add = fn2!(|x: i32| move |y: i32| x + y);
+    let result = lift2::<OptionKind, _, _, _, _>(add, Some(3), None);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn lift2_result_ok() {
+    let concat = fn2!(|x: i32| move |y: i32| format!("{x}+{y}"));
+    let result = lift2::<ResultKind<TestError>, _, _, _, _>(concat, Ok(1), Ok(2));
+    assert_eq!(result, Ok("1+2".to_string()));
+}
+
+#[test]
+fn lift2_result_err_first() {
+    let concat = fn2!(|x: i32| move |y: i32| format!("{x}+{y}"));
+    let result = lift2::<ResultKind<TestError>, _, _, _, _>(concat, Err("bad".to_string()), Ok(2));
+    assert!(result.is_err());
+}
+
+#[test]
+fn lift2_vec_cartesian() {
+    // Vec Apply is a cartesian product: [1,2] + [10,20] → [11,21,12,22]
+    let add = fn2!(|x: i32| move |y: i32| x + y);
+    let mut result = lift2::<VecKind, _, _, _, _>(add, vec![1, 2], vec![10, 20]);
+    result.sort_unstable();
+    assert_eq!(result, vec![11, 12, 21, 22]);
+}
+
+// ── lift3 ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn lift3_option_all_some() {
+    let add3 = fn3!(|x: i32| move |y: i32| move |z: i32| x + y + z);
+    let result = lift3::<OptionKind, _, _, _, _, _>(add3, Some(1), Some(2), Some(3));
+    assert_eq!(result, Some(6));
+}
+
+#[test]
+fn lift3_option_middle_none() {
+    let add3 = fn3!(|x: i32| move |y: i32| move |z: i32| x + y + z);
+    let result = lift3::<OptionKind, _, _, _, _, _>(add3, Some(1), None, Some(3));
+    assert_eq!(result, None);
+}
+
+#[test]
+fn lift3_option_last_none() {
+    let add3 = fn3!(|x: i32| move |y: i32| move |z: i32| x + y + z);
+    let result = lift3::<OptionKind, _, _, _, _, _>(add3, Some(1), Some(2), None);
+    assert_eq!(result, None);
+}
+
+// ── apply_first ────────────────────────────────────────────────────────────
+
+#[test]
+fn apply_first_option_both_some() {
+    let result = apply_first::<OptionKind, i32, &str>(Some(42), Some("ignored"));
+    assert_eq!(result, Some(42));
+}
+
+#[test]
+fn apply_first_option_first_none() {
+    let result = apply_first::<OptionKind, i32, &str>(None, Some("ignored"));
+    assert_eq!(result, None);
+}
+
+#[test]
+fn apply_first_option_second_none() {
+    // If the second container is None the result is None (sequencing is strict)
+    let result = apply_first::<OptionKind, i32, &str>(Some(42), None);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn apply_first_result_both_ok() {
+    let result = apply_first::<ResultKind<TestError>, i32, &str>(Ok(7), Ok("right"));
+    assert_eq!(result, Ok(7));
+}
+
+#[test]
+fn apply_first_result_err() {
+    let result =
+        apply_first::<ResultKind<TestError>, i32, &str>(Err("oops".to_string()), Ok("right"));
+    assert!(result.is_err());
+}
+
+// ── apply_second ───────────────────────────────────────────────────────────
+
+#[test]
+fn apply_second_option_both_some() {
+    let result = apply_second::<OptionKind, &str, i32>(Some("ignored"), Some(99));
+    assert_eq!(result, Some(99));
+}
+
+#[test]
+fn apply_second_option_first_none() {
+    let result = apply_second::<OptionKind, &str, i32>(None, Some(99));
+    assert_eq!(result, None);
+}
+
+#[test]
+fn apply_second_option_second_none() {
+    let result = apply_second::<OptionKind, &str, i32>(Some("ignored"), None);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn apply_second_result_both_ok() {
+    let result = apply_second::<ResultKind<TestError>, &str, i32>(Ok("left"), Ok(55));
+    assert_eq!(result, Ok(55));
+}
+
+// ── CFn composition operators (>> and <<) ─────────────────────────────────
+
+#[test]
+fn cfn_forward_compose_shr() {
+    // f: i32 -> String, g: String -> usize
+    // f >> g  should be  i32 -> usize
+    let f = CFn::new(|x: i32| x.to_string());
+    let g = CFn::new(|s: String| s.len());
+    let fg = f >> g;
+    assert_eq!(fg.call(42), 2); // "42".len() == 2
+    assert_eq!(fg.call(100), 3); // "100".len() == 3
+}
+
+#[test]
+fn cfn_backward_compose_shl() {
+    // g: String -> usize, f: i32 -> String
+    // g << f  should be  i32 -> usize
+    let f = CFn::new(|x: i32| x.to_string());
+    let g = CFn::new(|s: String| s.len());
+    let fg = g << f;
+    assert_eq!(fg.call(42), 2);
+    assert_eq!(fg.call(1000), 4); // "1000".len() == 4
+}
+
+#[test]
+fn cfn_compose_identity_left() {
+    // id >> f == f
+    let f = CFn::new(|x: i32| x * 2);
+    let id = CFn::new(|x: i32| x);
+    let composed = id >> f;
+    assert_eq!(composed.call(5), 10);
+}
+
+#[test]
+fn cfn_compose_identity_right() {
+    // f >> id == f
+    let f = CFn::new(|x: i32| x * 2);
+    let id = CFn::new(|x: i32| x);
+    let composed = f >> id;
+    assert_eq!(composed.call(5), 10);
+}
+
+#[test]
+fn cfn_compose_three_functions() {
+    let f = CFn::new(|x: i32| x + 1);
+    let g = CFn::new(|x: i32| x * 2);
+    let h = CFn::new(|x: i32| x.to_string());
+    // (f >> g) >> h
+    let fgh = (f >> g) >> h;
+    // (3 + 1) * 2 = 8 → "8"
+    assert_eq!(fgh.call(3), "8");
+}

--- a/tests/kind/do_notation/cfn_unsupported.rs
+++ b/tests/kind/do_notation/cfn_unsupported.rs
@@ -1,0 +1,68 @@
+//! `CFn` / `CFnOnce` are intentionally unsupported by `mdo!`.
+//!
+//! # Why `mdo!` cannot work with `CFnKind` / `CFnOnceKind`
+//!
+//! The `mdo!` desugaring emits **`(expr).clone()`** for every monadic right-hand
+//! side before passing it to `Bind::bind`. This clone is required because
+//! `Bind::bind`'s continuation parameter is:
+//!
+//! ```text
+//! func: impl FnMut(A) -> Self::Of<B> + Clone + 'static
+//! ```
+//!
+//! The `FnMut + Clone` bound exists because instances such as `VecKind` invoke
+//! the continuation *once per element* (via `flat_map`); the macro must therefore
+//! clone the captured RHS before each invocation.
+//!
+//! `CFn<A, B>` wraps `Box<dyn Fn(A) -> B + 'static>`. `Box<dyn Fn(…)>` is
+//! **not `Clone`** (trait objects cannot be cloned generically), so `CFn` itself
+//! is not `Clone` either. Calling `.clone()` on any `CFn` value — which the
+//! desugaring always does — fails to compile:
+//!
+//! ```text
+//! error[E0599]: the method `clone` exists for struct `CFn<i32, i32>`,
+//!               but its trait bounds were not satisfied
+//!   = note: the following trait bounds were not satisfied:
+//!           `dyn Fn(i32) -> i32: Sized`  →  `Box<dyn Fn(i32) -> i32>: Clone`
+//!           `dyn Fn(i32) -> i32: Clone`  →  `Box<dyn Fn(i32) -> i32>: Clone`
+//! ```
+//!
+//! This error appears at **depth ≥ 1** — even a single `<-` bind block fails —
+//! because the very first emitted `(cfn_expr).clone()` requires `Clone`.
+//! The situation is identical for `CFnOnce<A, B>` / `CFnOnceKind<R>`.
+//!
+//! The error was empirically confirmed during the Phase 0 spike (scratchpad
+//! `cfn_probe`) and re-confirmed during Phase 3 using a disposable probe crate
+//! that path-depends on the real `monadify` library with `--features do-notation`.
+//!
+//! # Future lift
+//!
+//! Lifting this restriction requires an `Rc`-backed, clone-able function wrapper,
+//! e.g.:
+//!
+//! ```text
+//! pub struct RcFn<A, B>(pub Rc<dyn Fn(A) -> B + 'static>);
+//! ```
+//!
+//! Cloning an `RcFn` bumps the reference count (cheap), exactly as `ReaderT`
+//! does today (`ReaderT` wraps `Rc<dyn Fn(R) -> M::Of<A>>` and is `#[derive(Clone)]`).
+//! Adding an `RcFnKind` marker that implements the full `Functor → Bind` hierarchy
+//! would allow `mdo!` do-blocks of arbitrary depth for that wrapper type. That is
+//! a separate, additive design decision with no impact on the current trait surface.
+//!
+//! Until that wrapper exists, `mdo!` blocks over `CFnKind`/`CFnOnceKind` are
+//! **out of scope** by design. Users needing a function monad in a do-block
+//! should use `ReaderTKind<R, IdentityKind>` (already `Clone`) as an alternative.
+
+/// Anchors the module documentation above. No runtime assertions are made here
+/// because no `CFn`/`CFnOnce` `mdo!` block can compile; the exclusion is verified
+/// at the compile-error level and described in this module's doc.
+#[test]
+fn cfn_cfnonce_mdo_is_documented_unsupported() {
+    // CFn and CFnOnce are intentionally excluded from mdo! do-blocks.
+    // See module documentation for the full explanation and the empirically
+    // confirmed error (E0599 / Clone bound not satisfied at depth >= 1).
+    //
+    // This placeholder test exists so the module appears in `cargo test --features
+    // do-notation` output, anchoring the documentation.
+}

--- a/tests/kind/do_notation/identity.rs
+++ b/tests/kind/do_notation/identity.rs
@@ -1,0 +1,241 @@
+//! `mdo!` do-block tests for `IdentityKind`.
+//!
+//! Tests in this file are gated by the parent `do_notation` module's
+//! `#![cfg(feature = "do-notation")]` attribute, so they are invisible to the
+//! default build.
+//!
+//! Covered scenarios
+//! -----------------
+//! 1. Basic threading: two bindings over `Identity` values produce the expected result.
+//! 2. `let` binding + bare-expr sequencing inside the block.
+//! 3. Equivalence (key law test): `mdo!` output equals hand-written nested
+//!    `IdentityKind::bind(…)` calls for concrete inputs; property-based leg
+//!    uses `arb_identity_i32()` (256 generated cases).
+//! 4. A 3+ binding chain (three and four bindings) to verify threading depth.
+//!
+//! **Note on `guard`:** `guard` is NOT supported for `IdentityKind` — there is no
+//! lawful zero for `Identity` (no short-circuit semantics). No guard tests appear
+//! here; attempting one would be a deliberate compile error.
+//!
+//! **Ownership note:** `Identity<i32>` derives `Clone` but not `Copy`. The macro
+//! emits `(expr).clone()` for each monadic RHS. Variables that appear inside an
+//! outer `move` closure are still moved into that closure, so where the same
+//! `ma`/`mb` value is needed both for `mdo!` (lhs) and a subsequent hand-written
+//! `rhs` expression, we pre-clone into separate `_lhs` bindings — mirroring the
+//! pattern established in `result.rs`.
+
+use monadify::applicative::kind::Applicative;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::monad::kind::Bind;
+use proptest::prelude::*;
+
+// Reuse the existing `arb_identity_i32` proptest strategy (already `pub`).
+use super::super::proptest_laws::arb_identity_i32;
+
+// ── 1. Basic threading ───────────────────────────────────────────────────────
+
+/// Two bindings should thread values through and produce `Identity(2 + 3) == Identity(5)`.
+#[test]
+fn identity_mdo_two_bindings() {
+    let result: Identity<i32> = mdo! {
+        IdentityKind;
+        x <- Identity(2);
+        y <- Identity(3);
+        IdentityKind::pure(x + y)
+    };
+    assert_eq!(result, Identity(5));
+}
+
+// ── 2. `let` binding + bare-expr sequencing ──────────────────────────────────
+
+/// A `let` binding inside an `mdo!` block introduces a pure local name that
+/// can be used in subsequent steps.
+#[test]
+fn identity_mdo_let_binding_inside_block() {
+    let result: Identity<i32> = mdo! {
+        IdentityKind;
+        x <- Identity(10);
+        let doubled = x * 2;
+        IdentityKind::pure(doubled)
+    };
+    assert_eq!(result, Identity(20));
+}
+
+/// A `let` binding can reference multiple previously bound names from distinct
+/// monadic steps.
+#[test]
+fn identity_mdo_let_binding_combines_two_values() {
+    let result: Identity<i32> = mdo! {
+        IdentityKind;
+        x <- Identity(4);
+        y <- Identity(6);
+        let sum = x + y;
+        IdentityKind::pure(sum * 2)
+    };
+    assert_eq!(result, Identity(20));
+}
+
+/// A bare-expr sequencing line (no `<-`) runs the monadic action for its effect
+/// and discards the wrapped value; subsequent bindings still see earlier names.
+#[test]
+fn identity_mdo_bare_expr_sequencing() {
+    let result: Identity<i32> = mdo! {
+        IdentityKind;
+        x <- Identity(5);
+        Identity(());
+        IdentityKind::pure(x * 3)
+    };
+    assert_eq!(result, Identity(15));
+}
+
+/// `let` and bare-expr forms can appear together in the same block.
+#[test]
+fn identity_mdo_let_and_bare_expr_combined() {
+    let result: Identity<String> = mdo! {
+        IdentityKind;
+        x <- Identity(7i32);
+        let label = "value";
+        Identity(());
+        IdentityKind::pure(format!("{}: {}", label, x))
+    };
+    assert_eq!(result, Identity("value: 7".to_string()));
+}
+
+// ── 3. Equivalence (example-based) ───────────────────────────────────────────
+//
+// Key law: `mdo! { M; x <- ma; y <- mb; M::pure(f(x, y)) }`
+//          == `M::bind(ma.clone(), move |x| M::bind(mb.clone(), move |y| M::pure(f(x, y))))`
+//
+// `Identity<i32>` is not `Copy`. The outer `move |x|` closure captures `mb_lhs`
+// by move (to call `mb_lhs.clone()` inside it). We pre-clone into `_lhs` variants
+// so the originals remain accessible for the hand-written rhs below.
+
+/// Two concrete `Identity` values: `mdo!` and hand-written bind should agree on
+/// `Identity(2 + 3) == Identity(5)`.
+#[test]
+fn identity_mdo_equivalence_concrete() {
+    let ma: Identity<i32> = Identity(2);
+    let mb: Identity<i32> = Identity(3);
+
+    let ma_lhs = ma.clone();
+    let mb_lhs = mb.clone();
+    let lhs: Identity<i32> = mdo! {
+        IdentityKind;
+        x <- ma_lhs;
+        y <- mb_lhs;
+        IdentityKind::pure(x + y)
+    };
+
+    let rhs: Identity<i32> = IdentityKind::bind(ma.clone(), move |x| {
+        IdentityKind::bind(mb.clone(), move |y| IdentityKind::pure(x + y))
+    });
+
+    assert_eq!(lhs, rhs);
+    assert_eq!(lhs, Identity(5));
+}
+
+/// Negative values should thread identically through both `mdo!` and the
+/// hand-written nested bind.
+#[test]
+fn identity_mdo_equivalence_negative_values() {
+    let ma: Identity<i32> = Identity(-10);
+    let mb: Identity<i32> = Identity(4);
+
+    let ma_lhs = ma.clone();
+    let mb_lhs = mb.clone();
+    let lhs: Identity<i32> = mdo! {
+        IdentityKind;
+        x <- ma_lhs;
+        y <- mb_lhs;
+        IdentityKind::pure(x + y)
+    };
+
+    let rhs: Identity<i32> = IdentityKind::bind(ma.clone(), move |x| {
+        IdentityKind::bind(mb.clone(), move |y| IdentityKind::pure(x + y))
+    });
+
+    assert_eq!(lhs, rhs);
+    assert_eq!(lhs, Identity(-6));
+}
+
+// ── 3b. Property-based equivalence ───────────────────────────────────────────
+//
+// Asserts the desugaring identity holds for 256 generated `(ma, mb)` pairs
+// drawn from `arb_identity_i32()`. Uses `wrapping_add` to avoid overflow panics
+// on arbitrary `i32` inputs.
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    /// `mdo! { IdentityKind; x <- ma; y <- mb; IdentityKind::pure(x.wrapping_add(y)) }`
+    /// must equal the hand-written nested bind for every generated `(ma, mb)`.
+    #[test]
+    fn identity_mdo_equivalence_prop(
+        ma in arb_identity_i32(),
+        mb in arb_identity_i32(),
+    ) {
+        // Pre-clone so both lhs (mdo!) and rhs (hand-written) each own their copy.
+        let ma_lhs = ma.clone();
+        let mb_lhs = mb.clone();
+
+        let lhs: Identity<i32> = mdo! {
+            IdentityKind;
+            x <- ma_lhs;
+            y <- mb_lhs;
+            IdentityKind::pure(x.wrapping_add(y))
+        };
+
+        let rhs: Identity<i32> = IdentityKind::bind(ma.clone(), move |x| {
+            IdentityKind::bind(mb.clone(), move |y| IdentityKind::pure(x.wrapping_add(y)))
+        });
+
+        prop_assert_eq!(lhs, rhs);
+    }
+}
+
+// ── 4. 3+ binding chain ──────────────────────────────────────────────────────
+
+/// Three bindings should thread all three values and produce `Identity(1 + 2 + 3) == Identity(6)`.
+#[test]
+fn identity_mdo_three_bindings_chain() {
+    let result: Identity<i32> = mdo! {
+        IdentityKind;
+        x <- Identity(1);
+        y <- Identity(2);
+        z <- Identity(3);
+        IdentityKind::pure(x + y + z)
+    };
+    assert_eq!(result, Identity(6));
+}
+
+/// Four bindings demonstrate that pure value threading is correct at depth — no
+/// value is accidentally dropped or duplicated.
+#[test]
+fn identity_mdo_four_bindings_chain() {
+    let result: Identity<i32> = mdo! {
+        IdentityKind;
+        a <- Identity(10);
+        b <- Identity(20);
+        c <- Identity(30);
+        d <- Identity(40);
+        IdentityKind::pure(a + b + c + d)
+    };
+    assert_eq!(result, Identity(100));
+}
+
+/// Three bindings where the computation depends on a `let` derived from earlier
+/// bindings, demonstrating that `let` can appear mid-chain without disrupting
+/// threading.
+#[test]
+fn identity_mdo_three_bindings_with_let_mid_chain() {
+    let result: Identity<i32> = mdo! {
+        IdentityKind;
+        x <- Identity(3);
+        y <- Identity(4);
+        let product = x * y;
+        z <- Identity(product + 1);
+        IdentityKind::pure(z)
+    };
+    assert_eq!(result, Identity(13)); // product = 12, z = 13
+}

--- a/tests/kind/do_notation/laws.rs
+++ b/tests/kind/do_notation/laws.rs
@@ -1,0 +1,650 @@
+//! Phase 4 law-preservation tests: monad laws expressed through `mdo!`.
+//!
+//! Compiled only under `--features do-notation` (gate inherited from the parent
+//! `do_notation` module's `#![cfg(feature = "do-notation")]`).
+//!
+//! ## Property tests (proptest, 256 cases each)
+//!
+//! For each proptest-able instance — `Option<i32>`, `Result<i32, String>`,
+//! `Vec<i32>`, `Identity<i32>` — three monad laws are stated with `mdo!` on at
+//! least one side:
+//!
+//! 1. **Left identity**: `mdo!{M; x <- M::pure(a); k(x)}` == `k(a)`
+//! 2. **Right identity**: `mdo!{M; x <- m; M::pure(x)}` == `m`
+//! 3. **Associativity**:
+//!    `mdo!{M; x <- m; y <- k(x); h(y)}`
+//!    == `mdo!{M; y <- mdo!{M; x <- m; k(x)}; h(y)}` (nested do-block on RHS)
+//!    Both sides are also compared with the hand-written nested bind.
+//!
+//! The per-instance `*_mdo_equivalence_prop` tests (which assert `mdo!` ==
+//! hand-written bind) live in the sibling source files and are **not** duplicated
+//! here.
+//!
+//! ### Kleisli-arrow design notes
+//!
+//! `VecKind::bind` is `flat_map` — it calls its continuation once **per element**.
+//! That continuation is `FnMut + Clone`, so any value the outer `move |x|` closure
+//! captures and the inner `move |y|` also needs would be "moved out of a FnMut",
+//! triggering E0507.  To avoid this, the Kleisli arrows `k` and `h` used in
+//! associativity tests capture **only Copy types** (`i32`, `bool`), making the
+//! closures Copy and eliminating the issue on all four instances.
+//!
+//! ## Macro-hygiene edge-case tests (concrete)
+//!
+//! - Variable shadowing: monadic rebind and `let`-shadowing of the same ident.
+//! - Nested do-blocks: explicit named tests beyond the associativity RHS.
+//! - Guard on empty: `guard(false)` for `OptionKind` → `None`;
+//!   for `VecKind` → `vec![]`.
+//! - Evaluation order: dependent bindings prove top-to-bottom sequencing; a
+//!   `Rc<Cell<i32>>` counter proves a `let`-statement body runs exactly once.
+//! - Bare-expr sequencing: a mid-block `Some(())` that must pass through before
+//!   the next bind is evaluated.
+//! - Macro discard pattern: user code with `let _ = …` next to bare-expr
+//!   sequencing (macro emits `move |_| {…}`) confirms no identifier collision.
+//! - Tuple-pattern bind: destructuring in the `<-` position.
+
+use super::super::proptest_laws::{
+    arb_identity_i32, arb_linear_closure_params, arb_option_i32, arb_result_i32_string,
+    arb_vec_i32, linear_fn,
+};
+use monadify::applicative::kind::Applicative;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::kind_based::kind::{OptionKind, ResultKind, VecKind};
+use monadify::mdo;
+use monadify::monad::kind::Bind;
+use proptest::prelude::*;
+
+// ── Option ───────────────────────────────────────────────────────────────────
+//
+// `Option<i32>` is Copy.  Kleisli arrows capturing only `i32`/`bool` are also
+// Copy, so no pre-cloning is needed for `m` or the arrows.
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    /// Left identity for Option via `mdo!`:
+    /// `mdo!{OptionKind; x <- OptionKind::pure(a); k(x)}` == `k(a)`.
+    #[test]
+    fn option_mdo_law_left_identity(
+        a in any::<i32>(),
+        (ka, kb) in arb_linear_closure_params(),
+        k_present in any::<bool>(),
+    ) {
+        let k = move |x: i32| -> Option<i32> {
+            if k_present {
+                let mut lf = linear_fn(ka, kb);
+                Some(lf(x))
+            } else {
+                None
+            }
+        };
+        // k is Copy (captures i32 and bool only).
+        let lhs: Option<i32> = mdo! {
+            OptionKind;
+            x <- OptionKind::pure(a);
+            k(x)
+        };
+        let rhs: Option<i32> = k(a);
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Right identity for Option via `mdo!`:
+    /// `mdo!{OptionKind; x <- m; OptionKind::pure(x)}` == `m`.
+    #[test]
+    fn option_mdo_law_right_identity(m in arb_option_i32()) {
+        // Option<i32> is Copy; m is usable both inside mdo! and in the assertion.
+        let lhs: Option<i32> = mdo! {
+            OptionKind;
+            x <- m;
+            OptionKind::pure(x)
+        };
+        prop_assert_eq!(lhs, m);
+    }
+
+    /// Associativity for Option via `mdo!` with a nested do-block on the RHS.
+    ///
+    /// Proves:
+    ///   `mdo!{M; x <- m; y <- k(x); h(y)}`
+    ///   == `mdo!{M; y <- mdo!{M; x <- m; k(x)}; h(y)}`
+    ///   == `OptionKind::bind(OptionKind::bind(m, k), h)`  (hand-written)
+    #[test]
+    fn option_mdo_law_associativity(
+        m in arb_option_i32(),
+        (ka, kb) in arb_linear_closure_params(),
+        (ha, hb) in arb_linear_closure_params(),
+        k_present in any::<bool>(),
+        h_present in any::<bool>(),
+    ) {
+        let k = move |x: i32| -> Option<i32> {
+            if k_present {
+                let mut lf = linear_fn(ka, kb);
+                Some(lf(x))
+            } else {
+                None
+            }
+        };
+        let h = move |y: i32| -> Option<i32> {
+            if h_present {
+                let mut lf = linear_fn(ha, hb);
+                Some(lf(y))
+            } else {
+                None
+            }
+        };
+        // k, h, and m are all Copy.
+
+        // LHS: flat do-block   bind(m, |x| bind(k(x), h))
+        let lhs: Option<i32> = mdo! {
+            OptionKind;
+            x <- m;
+            y <- k(x);
+            h(y)
+        };
+
+        // RHS: nested do-block   bind(bind(m, k), h)
+        let rhs_nested: Option<i32> = mdo! {
+            OptionKind;
+            y <- mdo! {
+                OptionKind;
+                x <- m;
+                k(x)
+            };
+            h(y)
+        };
+
+        // Hand-written for cross-check.
+        let rhs_hand: Option<i32> = OptionKind::bind(OptionKind::bind(m, k), h);
+
+        prop_assert_eq!(lhs, rhs_nested, "flat mdo! vs nested mdo!");
+        prop_assert_eq!(lhs, rhs_hand,   "flat mdo! vs hand-written bind");
+    }
+}
+
+// ── Result<i32, String> ──────────────────────────────────────────────────────
+//
+// `Result<i32, String>` is Clone but not Copy; pre-clone `m` before each use.
+// Kleisli arrows capture only `i32`/`bool` → they are Copy, avoiding E0507 in
+// the two-level associativity mdo!.
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    /// Left identity for Result via `mdo!`:
+    /// `mdo!{ResultKind::<String>; x <- ResultKind::<String>::pure(a); k(x)}` == `k(a)`.
+    #[test]
+    fn result_mdo_law_left_identity(
+        a in any::<i32>(),
+        (ka, kb) in arb_linear_closure_params(),
+        k_ok in any::<bool>(),
+    ) {
+        let k = move |x: i32| -> Result<i32, String> {
+            if k_ok {
+                Ok(x.wrapping_mul(ka).wrapping_add(kb))
+            } else {
+                Err(String::from("k-err"))
+            }
+        };
+        // k is Copy (captures i32 and bool only).
+        let lhs: Result<i32, String> = mdo! {
+            ResultKind::<String>;
+            x <- ResultKind::<String>::pure(a);
+            k(x)
+        };
+        let rhs: Result<i32, String> = k(a);
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Right identity for Result via `mdo!`:
+    /// `mdo!{ResultKind::<String>; x <- m; ResultKind::<String>::pure(x)}` == `m`.
+    #[test]
+    fn result_mdo_law_right_identity(m in arb_result_i32_string()) {
+        let m_for_lhs = m.clone();
+        let lhs: Result<i32, String> = mdo! {
+            ResultKind::<String>;
+            x <- m_for_lhs;
+            ResultKind::<String>::pure(x)
+        };
+        prop_assert_eq!(lhs, m);
+    }
+
+    /// Associativity for Result via `mdo!` with a nested do-block on the RHS.
+    #[test]
+    fn result_mdo_law_associativity(
+        m in arb_result_i32_string(),
+        (ka, kb) in arb_linear_closure_params(),
+        (ha, hb) in arb_linear_closure_params(),
+        k_ok in any::<bool>(),
+        h_ok in any::<bool>(),
+    ) {
+        let k = move |x: i32| -> Result<i32, String> {
+            if k_ok {
+                Ok(x.wrapping_mul(ka).wrapping_add(kb))
+            } else {
+                Err(String::from("k-err"))
+            }
+        };
+        let h = move |y: i32| -> Result<i32, String> {
+            if h_ok {
+                Ok(y.wrapping_mul(ha).wrapping_add(hb))
+            } else {
+                Err(String::from("h-err"))
+            }
+        };
+        // k and h are Copy.
+
+        let m_lhs  = m.clone();
+        let m_rhs  = m.clone();
+        let m_hand = m;
+
+        let lhs: Result<i32, String> = mdo! {
+            ResultKind::<String>;
+            x <- m_lhs;
+            y <- k(x);
+            h(y)
+        };
+
+        let rhs_nested: Result<i32, String> = mdo! {
+            ResultKind::<String>;
+            y <- mdo! {
+                ResultKind::<String>;
+                x <- m_rhs;
+                k(x)
+            };
+            h(y)
+        };
+
+        let rhs_hand: Result<i32, String> = ResultKind::<String>::bind(
+            ResultKind::<String>::bind(m_hand, k),
+            h,
+        );
+
+        prop_assert_eq!(lhs.clone(), rhs_nested, "flat mdo! vs nested mdo!");
+        prop_assert_eq!(lhs,         rhs_hand,   "flat mdo! vs hand-written bind");
+    }
+}
+
+// ── Vec<i32> ─────────────────────────────────────────────────────────────────
+//
+// `Vec<i32>` is Clone but not Copy; pre-clone `m` before each use.
+// Kleisli arrows MUST be Copy (capture only `i32`/`bool`) to avoid E0507:
+// `VecKind::bind` is `flat_map`, which calls its `FnMut` continuation once per
+// element.  If `h` (captured by the outer `move |x|`) is not Copy, the inner
+// `move |y| { h(y) }` would move `h` out of the outer FnMut on each call.
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    /// Left identity for Vec via `mdo!`:
+    /// `mdo!{VecKind; x <- VecKind::pure(a); k(x)}` == `k(a)`.
+    #[test]
+    fn vec_mdo_law_left_identity(
+        a in any::<i32>(),
+        (ka, kb) in arb_linear_closure_params(),
+        k_empty in any::<bool>(),
+    ) {
+        let k = move |x: i32| -> Vec<i32> {
+            if k_empty {
+                Vec::new()
+            } else {
+                vec![x.wrapping_mul(ka).wrapping_add(kb)]
+            }
+        };
+        // k is Copy.
+        let lhs: Vec<i32> = mdo! {
+            VecKind;
+            x <- VecKind::pure(a);
+            k(x)
+        };
+        let rhs: Vec<i32> = k(a);
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Right identity for Vec via `mdo!`:
+    /// `mdo!{VecKind; x <- m; VecKind::pure(x)}` == `m`.
+    #[test]
+    fn vec_mdo_law_right_identity(m in arb_vec_i32()) {
+        let m_for_lhs = m.clone();
+        let lhs: Vec<i32> = mdo! {
+            VecKind;
+            x <- m_for_lhs;
+            VecKind::pure(x)
+        };
+        prop_assert_eq!(lhs, m);
+    }
+
+    /// Associativity for Vec via `mdo!` with a nested do-block on the RHS.
+    ///
+    /// Arrows `k` and `h` each produce at most one element (0 or 1) to keep
+    /// the flat_map cross-product bounded to at most `|m|` elements.
+    #[test]
+    fn vec_mdo_law_associativity(
+        m in arb_vec_i32(),
+        (ka, kb) in arb_linear_closure_params(),
+        (ha, hb) in arb_linear_closure_params(),
+        k_empty in any::<bool>(),
+        h_empty in any::<bool>(),
+    ) {
+        let k = move |x: i32| -> Vec<i32> {
+            if k_empty {
+                Vec::new()
+            } else {
+                vec![x.wrapping_mul(ka).wrapping_add(kb)]
+            }
+        };
+        let h = move |y: i32| -> Vec<i32> {
+            if h_empty {
+                Vec::new()
+            } else {
+                vec![y.wrapping_mul(ha).wrapping_add(hb)]
+            }
+        };
+        // k and h are Copy.
+
+        let m_lhs  = m.clone();
+        let m_rhs  = m.clone();
+        let m_hand = m;
+
+        let lhs: Vec<i32> = mdo! {
+            VecKind;
+            x <- m_lhs;
+            y <- k(x);
+            h(y)
+        };
+
+        let rhs_nested: Vec<i32> = mdo! {
+            VecKind;
+            y <- mdo! {
+                VecKind;
+                x <- m_rhs;
+                k(x)
+            };
+            h(y)
+        };
+
+        let rhs_hand: Vec<i32> = VecKind::bind(VecKind::bind(m_hand, k), h);
+
+        prop_assert_eq!(lhs.clone(), rhs_nested, "flat mdo! vs nested mdo!");
+        prop_assert_eq!(lhs,         rhs_hand,   "flat mdo! vs hand-written bind");
+    }
+}
+
+// ── Identity<i32> ────────────────────────────────────────────────────────────
+//
+// `Identity<i32>` is Clone but not Copy (derives Clone only).
+// Kleisli arrows capturing only `i32` are Copy.
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    /// Left identity for Identity via `mdo!`:
+    /// `mdo!{IdentityKind; x <- IdentityKind::pure(a); k(x)}` == `k(a)`.
+    #[test]
+    fn identity_mdo_law_left_identity(
+        a in any::<i32>(),
+        (ka, kb) in arb_linear_closure_params(),
+    ) {
+        let k = move |x: i32| -> Identity<i32> {
+            let mut lf = linear_fn(ka, kb);
+            Identity(lf(x))
+        };
+        // k is Copy (captures i32 only).
+        let lhs: Identity<i32> = mdo! {
+            IdentityKind;
+            x <- IdentityKind::pure(a);
+            k(x)
+        };
+        let rhs: Identity<i32> = k(a);
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Right identity for Identity via `mdo!`:
+    /// `mdo!{IdentityKind; x <- m; IdentityKind::pure(x)}` == `m`.
+    #[test]
+    fn identity_mdo_law_right_identity(m in arb_identity_i32()) {
+        let m_for_lhs = m.clone();
+        let lhs: Identity<i32> = mdo! {
+            IdentityKind;
+            x <- m_for_lhs;
+            IdentityKind::pure(x)
+        };
+        prop_assert_eq!(lhs, m);
+    }
+
+    /// Associativity for Identity via `mdo!` with a nested do-block on the RHS.
+    #[test]
+    fn identity_mdo_law_associativity(
+        m in arb_identity_i32(),
+        (ka, kb) in arb_linear_closure_params(),
+        (ha, hb) in arb_linear_closure_params(),
+    ) {
+        let k = move |x: i32| -> Identity<i32> {
+            let mut lf = linear_fn(ka, kb);
+            Identity(lf(x))
+        };
+        let h = move |y: i32| -> Identity<i32> {
+            let mut lf = linear_fn(ha, hb);
+            Identity(lf(y))
+        };
+        // k and h are Copy.
+
+        let m_lhs  = m.clone();
+        let m_rhs  = m.clone();
+        let m_hand = m;
+
+        let lhs: Identity<i32> = mdo! {
+            IdentityKind;
+            x <- m_lhs;
+            y <- k(x);
+            h(y)
+        };
+
+        let rhs_nested: Identity<i32> = mdo! {
+            IdentityKind;
+            y <- mdo! {
+                IdentityKind;
+                x <- m_rhs;
+                k(x)
+            };
+            h(y)
+        };
+
+        let rhs_hand: Identity<i32> = IdentityKind::bind(IdentityKind::bind(m_hand, k), h);
+
+        prop_assert_eq!(lhs.clone(), rhs_nested, "flat mdo! vs nested mdo!");
+        prop_assert_eq!(lhs,         rhs_hand,   "flat mdo! vs hand-written bind");
+    }
+}
+
+// ── Macro-hygiene edge-case tests ────────────────────────────────────────────
+
+/// Rebinding the same identifier in successive `<-` lines: the second binding
+/// shadows the first.  The outer `x = 5` is visible in `Some(x * 2)` (the RHS
+/// of the second bind), and the inner `x = 10` is what the final expression sees.
+#[test]
+fn hygiene_variable_shadowing_monadic_rebind() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(5i32);
+        x <- Some(x * 2i32);    // outer x = 5 used here; inner x = 10
+        OptionKind::pure(x)      // x is the inner binding = 10
+    };
+    assert_eq!(result, Some(10));
+}
+
+/// A `let` binding inside `mdo!` shadows a previously monadic-bound name.
+/// The let desugars to `{ let x = x + 3; rest }` inside the outer closure;
+/// the new `x = 10` shadows without corrupting the earlier `x = 7`.
+#[test]
+fn hygiene_variable_shadowing_let_binding() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(7i32);
+        let x = x + 3i32;      // pure-let shadows the monadic x; x = 10
+        OptionKind::pure(x)     // x is the let binding = 10
+    };
+    assert_eq!(result, Some(10));
+}
+
+/// Explicit nested `mdo!` (Option inside Option), distinct from the
+/// associativity law test.  The inner block produces `Some(12)` which the
+/// outer bind unwraps into `inner`, then returns `Some(13)`.
+#[test]
+fn hygiene_nested_do_block_option_in_option() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        inner <- mdo! {
+            OptionKind;
+            a <- Some(3i32);
+            b <- Some(4i32);
+            OptionKind::pure(a * b)      // = Some(12)
+        };
+        OptionKind::pure(inner + 1i32)   // = Some(13)
+    };
+    assert_eq!(result, Some(13));
+}
+
+/// When the inner do-block short-circuits to `None`, the outer bind propagates
+/// `None` without executing the outer continuation.
+#[test]
+fn hygiene_nested_do_block_inner_short_circuits() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        inner <- mdo! {
+            OptionKind;
+            a <- Some(3i32);
+            b <- None::<i32>;
+            OptionKind::pure(a + b)        // unreachable; inner = None
+        };
+        OptionKind::pure(inner + 100i32)   // unreachable
+    };
+    assert_eq!(result, None);
+}
+
+/// Nested do-blocks using `VecKind` (Vec in Vec).  The inner block produces a
+/// four-element Vec; the outer block doubles each element.
+#[test]
+fn hygiene_nested_do_block_vec_in_vec() {
+    let result: Vec<i32> = mdo! {
+        VecKind;
+        s <- mdo! {
+            VecKind;
+            a <- vec![1i32, 2];
+            b <- vec![10i32, 20];
+            VecKind::pure(a + b)      // [11, 21, 12, 22]
+        };
+        VecKind::pure(s * 2i32)       // [22, 42, 24, 44]
+    };
+    assert_eq!(result, vec![22, 42, 24, 44]);
+}
+
+/// `guard(false)` inside an Option do-block yields `None` regardless of the
+/// surrounding binds, demonstrating the guard/bind interplay.
+#[test]
+fn hygiene_guard_false_option_yields_none() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(42i32);
+        guard(false);
+        OptionKind::pure(x)
+    };
+    assert_eq!(result, None);
+}
+
+/// `guard(false)` inside a Vec do-block yields `vec![]` regardless of the
+/// surrounding binds.
+#[test]
+fn hygiene_guard_false_vec_yields_empty() {
+    let result: Vec<i32> = mdo! {
+        VecKind;
+        x <- vec![1i32, 2, 3];
+        guard(false);
+        VecKind::pure(x)
+    };
+    assert_eq!(result, Vec::<i32>::new());
+}
+
+/// Evaluation order via dependent bindings: each step uses the value produced
+/// by the PREVIOUS step, so the result of `x + y + z = 1 + 2 + 3 = 6` proves
+/// steps executed in source order.
+#[test]
+fn hygiene_evaluation_order_dependent_bindings() {
+    let result: Identity<i32> = mdo! {
+        IdentityKind;
+        x <- Identity(1i32);
+        y <- Identity(x + 1i32);    // y = 2, uses x = 1
+        z <- Identity(y + 1i32);    // z = 3, uses y = 2
+        IdentityKind::pure(x + y + z)
+    };
+    assert_eq!(result, Identity(6)); // 1 + 2 + 3
+}
+
+/// A bare `Some(())` expression in the middle of an Option do-block runs
+/// top-to-bottom: subsequent binds still see names from earlier steps.
+#[test]
+fn hygiene_bare_expr_sequencing_runs_in_order() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(10i32);
+        Some(());              // bare expr; must not short-circuit
+        y <- Some(x + 5i32);  // x = 10 is still in scope
+        OptionKind::pure(y)
+    };
+    assert_eq!(result, Some(15));
+}
+
+/// A `let` statement body runs exactly once and its side effect is observable
+/// via an `Rc<Cell<i32>>` counter retained in the outer scope.
+///
+/// Only a single closure depth is used here (no second bind that would
+/// require capturing the counter at two different nesting levels), which avoids
+/// the E0507 "move-out-of-FnMut" constraint on the mdo! desugaring.
+#[test]
+fn hygiene_let_stmt_runs_exactly_once_cell_counter() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let counter = Rc::new(Cell::new(0i32));
+    let handle = Rc::clone(&counter); // kept in outer scope for assertion
+
+    // `counter` is captured by `move |x|` (the outer bind's closure) and used
+    // only in the `let` statement — no deeper closure references it.
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(10i32);
+        let n = { counter.set(counter.get() + 1); counter.get() };
+        OptionKind::pure(x + n)
+    };
+
+    // n = 1 (incremented once), so result = Some(10 + 1) = Some(11).
+    assert_eq!(result, Some(11));
+    // `handle` still points to the shared Cell; proves the let ran exactly once.
+    assert_eq!(handle.get(), 1);
+}
+
+/// The macro emits `move |_| { … }` for bare-expr sequencing.  A user-written
+/// `let _ = …` inside the same block takes the `Stmt::Let` desugaring path and
+/// becomes `{ let _ = …; rest }` — it does NOT clash with the closure's `_`
+/// parameter, which lives in a separate scope.
+#[test]
+fn hygiene_user_let_underscore_no_clash_with_macro_discard_pattern() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(5i32);
+        Some(());          // bare expr — macro emits: move |_| { … }
+        let _ = x * 100;  // user let _ — Stmt::Let path: { let _ = x*100; rest }
+        OptionKind::pure(x * 2i32)
+    };
+    assert_eq!(result, Some(10));
+}
+
+/// A tuple-pattern in the `<-` position destructures the monadic value
+/// correctly, binding both components to fresh names.
+#[test]
+fn hygiene_tuple_pattern_bind_destructures_correctly() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        (a, b) <- Some((3i32, 4i32));
+        OptionKind::pure(a + b)
+    };
+    assert_eq!(result, Some(7));
+}

--- a/tests/kind/do_notation/mod.rs
+++ b/tests/kind/do_notation/mod.rs
@@ -1,0 +1,24 @@
+//! Do-notation integration tests for the kind-based monad instances.
+//!
+//! This module is compiled **only** when the `do-notation` feature is enabled.
+//! Every submodule inherits that gate.
+//!
+//! Run with:
+//! ```text
+//! cargo test --features do-notation
+//! ```
+
+#![cfg(feature = "do-notation")]
+// The equivalence tests call `.clone()` on `Option<i32>` to mirror the macro's
+// own `(expr).clone()` desugaring, ensuring structural parity with non-Copy
+// instances (Result, Vec, Identity, ReaderT).  The redundant-clone lint is
+// intentional here for cross-instance test symmetry.
+#![allow(clippy::clone_on_copy)]
+
+pub mod cfn_unsupported;
+pub mod identity;
+pub mod laws;
+pub mod option;
+pub mod reader;
+pub mod result;
+pub mod vec;

--- a/tests/kind/do_notation/option.rs
+++ b/tests/kind/do_notation/option.rs
@@ -1,0 +1,266 @@
+//! `mdo!` do-block tests for `OptionKind`.
+//!
+//! Tests in this file are gated by the parent `do_notation` module's
+//! `#![cfg(feature = "do-notation")]` attribute, so they are invisible to the
+//! default build.
+//!
+//! Covered scenarios
+//! -----------------
+//! 1. Worked do-block: 2–3 bindings that all succeed → asserts the computed `Some(_)`.
+//! 2. Short-circuit: a `None` binding anywhere in the chain → whole block is `None`.
+//! 3. Equivalence (key law test): `mdo!` output equals hand-written nested
+//!    `OptionKind::bind(…)` calls for several concrete inputs, including `None` cases.
+//! 4. Guard: `guard(cond)` passes through when `cond` is `true` and short-circuits
+//!    to `None` when `cond` is `false`.
+//! 5. Property-based equivalence: asserts the desugaring identity holds for many
+//!    generated `(ma, mb)` pairs (256 cases, reusing the existing proptest harness).
+//!
+//! **RED phase**: the `mdo!` stub in `monadify-macros/src/lib.rs` emits `()` for
+//! every invocation regardless of input. Every test below will therefore fail to
+//! compile (type mismatch: `()` vs `Option<i32>`) or fail at runtime if the
+//! compiler somehow accepts the body.  That is the intentional failing state.
+
+use monadify::applicative::kind::Applicative;
+use monadify::kind_based::kind::OptionKind;
+use monadify::mdo;
+use monadify::monad::kind::Bind;
+use proptest::prelude::*;
+
+// Reuse the existing proptest strategy helpers (already `pub` in the harness).
+use super::super::proptest_laws::arb_option_i32;
+
+// ── 1. Worked do-block ────────────────────────────────────────────────────────
+
+/// Two bindings that both succeed should propagate `Some(2 + 3) == Some(5)`.
+#[test]
+fn option_mdo_two_bindings_both_some() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(2);
+        y <- Some(3);
+        OptionKind::pure(x + y)
+    };
+    assert_eq!(result, Some(5));
+}
+
+/// Three bindings that all succeed should produce `Some(1 + 2 + 3) == Some(6)`.
+#[test]
+fn option_mdo_three_bindings_all_some() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(1);
+        y <- Some(2);
+        z <- Some(3);
+        OptionKind::pure(x + y + z)
+    };
+    assert_eq!(result, Some(6));
+}
+
+// ── 2. Short-circuit ─────────────────────────────────────────────────────────
+
+/// A `None` on the *first* binding short-circuits the entire block.
+#[test]
+fn option_mdo_short_circuit_first_binding_none() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- None::<i32>;
+        y <- Some(3);
+        OptionKind::pure(x + y)
+    };
+    assert_eq!(result, None);
+}
+
+/// A `None` on the *second* binding short-circuits even after a successful first.
+#[test]
+fn option_mdo_short_circuit_second_binding_none() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(2);
+        y <- None::<i32>;
+        OptionKind::pure(x + y)
+    };
+    assert_eq!(result, None);
+}
+
+/// A `None` in the *middle* of three bindings short-circuits the rest.
+#[test]
+fn option_mdo_short_circuit_middle_of_three() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(1);
+        y <- None::<i32>;
+        z <- Some(3);
+        OptionKind::pure(x + y + z)
+    };
+    assert_eq!(result, None);
+}
+
+// ── 3. Equivalence (example-based) ───────────────────────────────────────────
+//
+// The key law: `mdo! { M; x <- ma; y <- mb; M::pure(f(x, y)) }`
+//              == `M::bind(ma.clone(), move |x| M::bind(mb.clone(), move |y| M::pure(f(x, y))))`
+
+/// Both `ma` and `mb` are `Some`: result should be `Some(2 + 3) == Some(5)`.
+#[test]
+fn option_mdo_equivalence_both_some() {
+    let ma: Option<i32> = Some(2);
+    let mb: Option<i32> = Some(3);
+
+    let lhs: Option<i32> = mdo! {
+        OptionKind;
+        x <- ma;
+        y <- mb;
+        OptionKind::pure(x + y)
+    };
+
+    let rhs: Option<i32> = OptionKind::bind(ma.clone(), move |x| {
+        OptionKind::bind(mb.clone(), move |y| OptionKind::pure(x + y))
+    });
+
+    assert_eq!(lhs, rhs);
+    assert_eq!(lhs, Some(5));
+}
+
+/// `ma` is `None`: both `mdo!` and the hand-written bind should return `None`.
+#[test]
+fn option_mdo_equivalence_first_none() {
+    let ma: Option<i32> = None;
+    let mb: Option<i32> = Some(3);
+
+    let lhs: Option<i32> = mdo! {
+        OptionKind;
+        x <- ma;
+        y <- mb;
+        OptionKind::pure(x + y)
+    };
+
+    let rhs: Option<i32> = OptionKind::bind(ma.clone(), move |x| {
+        OptionKind::bind(mb.clone(), move |y| OptionKind::pure(x + y))
+    });
+
+    assert_eq!(lhs, rhs);
+    assert_eq!(lhs, None);
+}
+
+/// `mb` is `None`: both `mdo!` and the hand-written bind should return `None`.
+#[test]
+fn option_mdo_equivalence_second_none() {
+    let ma: Option<i32> = Some(7);
+    let mb: Option<i32> = None;
+
+    let lhs: Option<i32> = mdo! {
+        OptionKind;
+        x <- ma;
+        y <- mb;
+        OptionKind::pure(x + y)
+    };
+
+    let rhs: Option<i32> = OptionKind::bind(ma.clone(), move |x| {
+        OptionKind::bind(mb.clone(), move |y| OptionKind::pure(x + y))
+    });
+
+    assert_eq!(lhs, rhs);
+    assert_eq!(lhs, None);
+}
+
+/// Both `ma` and `mb` are `None`: result is `None` on both sides.
+#[test]
+fn option_mdo_equivalence_both_none() {
+    let ma: Option<i32> = None;
+    let mb: Option<i32> = None;
+
+    let lhs: Option<i32> = mdo! {
+        OptionKind;
+        x <- ma;
+        y <- mb;
+        OptionKind::pure(x + y)
+    };
+
+    let rhs: Option<i32> = OptionKind::bind(ma.clone(), move |x| {
+        OptionKind::bind(mb.clone(), move |y| OptionKind::pure(x + y))
+    });
+
+    assert_eq!(lhs, rhs);
+    assert_eq!(lhs, None);
+}
+
+// ── 4. Guard ─────────────────────────────────────────────────────────────────
+
+/// `guard(x > 0)` with a positive `x` should pass through (`Some(x)`).
+#[test]
+fn option_mdo_guard_condition_true_passes_through() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(4);
+        guard(x > 0);
+        OptionKind::pure(x)
+    };
+    assert_eq!(result, Some(4));
+}
+
+/// `guard(x < 0)` with a positive `x` makes the condition `false` → `None`.
+#[test]
+fn option_mdo_guard_condition_false_short_circuits() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(4);
+        guard(x < 0);
+        OptionKind::pure(x)
+    };
+    assert_eq!(result, None);
+}
+
+/// Guard with a literal `false` always short-circuits regardless of earlier bindings.
+#[test]
+fn option_mdo_guard_literal_false() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(99);
+        guard(false);
+        OptionKind::pure(x)
+    };
+    assert_eq!(result, None);
+}
+
+/// Guard with a literal `true` always passes through.
+#[test]
+fn option_mdo_guard_literal_true() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(42);
+        guard(true);
+        OptionKind::pure(x)
+    };
+    assert_eq!(result, Some(42));
+}
+
+// ── 5. Property-based equivalence ────────────────────────────────────────────
+//
+// Asserts that the desugaring identity holds for 256 generated `(ma, mb)` pairs
+// drawn from `arb_option_i32()`.  Reuses the existing proptest harness without
+// introducing new dependencies.
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    /// `mdo! { OptionKind; x <- ma; y <- mb; OptionKind::pure(x.wrapping_add(y)) }`
+    /// must equal the hand-written nested bind for every `(ma, mb)`.
+    #[test]
+    fn option_mdo_equivalence_prop(
+        ma in arb_option_i32(),
+        mb in arb_option_i32(),
+    ) {
+        let lhs: Option<i32> = mdo! {
+            OptionKind;
+            x <- ma;
+            y <- mb;
+            OptionKind::pure(x.wrapping_add(y))
+        };
+
+        let rhs: Option<i32> = OptionKind::bind(ma.clone(), move |x| {
+            OptionKind::bind(mb.clone(), move |y| OptionKind::pure(x.wrapping_add(y)))
+        });
+
+        prop_assert_eq!(lhs, rhs);
+    }
+}

--- a/tests/kind/do_notation/reader.rs
+++ b/tests/kind/do_notation/reader.rs
@@ -1,0 +1,514 @@
+//! `mdo!` do-block tests for `ReaderTKind` (Reader monad: threading a read-only environment).
+//!
+//! Tests in this file are gated by the parent `do_notation` module's
+//! `#![cfg(feature = "do-notation")]` attribute, so they are invisible to the
+//! default build.
+//!
+//! ## What we test
+//!
+//! The "real power" of Reader is that a single environment value is silently
+//! threaded through every step without being passed explicitly.  These tests
+//! use `Config` (a two-field struct) as the environment and
+//! `ReaderT<Config, IdentityKind, A>` (alias: `Reader<Config, A>`) as the monad.
+//!
+//! Using the `IdentityKind` inner monad keeps each `ReaderT` run value as
+//! `Identity<A>` — no optionality or error context — so the tests focus
+//! purely on environment threading rather than short-circuiting.
+//!
+//! ## Covered scenarios
+//!
+//! 1. **Env threading** — multiple `ReaderT::new(...)` computations in a do-block
+//!    each receive the SAME `Config` from the environment.
+//! 2. **`ask`** — `MonadReader::ask()` lifts the entire environment into the block;
+//!    a `let` binding can derive values from it without creating another `ReaderT`.
+//! 3. **`ask` + field-reading combined** — mixes `ask` with explicit `ReaderT::new`
+//!    steps in the same do-block.
+//! 4. **Equivalence** — the `mdo!` version, when run against several concrete `Config`
+//!    values, produces identical results to the hand-written nested `bind` chain.
+//!    (Closures cannot be compared directly; we compare by *running* both against
+//!    the same environments — per the spike's note on arbitrary-closure equality.)
+//! 5. **Three-binding chain** — depth > 2, confirming the desugaring is correct
+//!    at greater nesting levels.
+//! 6. **`local`** — a sub-computation wrapped in `local(f, comp)` sees a modified
+//!    environment; earlier steps in the same do-block see the original environment.
+//!
+//! ## Notes
+//!
+//! - `guard` is intentionally absent: ReaderT has no lawful zero, so using
+//!   `guard` inside a ReaderT do-block is a deliberate compile error.
+//! - `ReaderT` is `Rc<dyn Fn> + #[derive(Clone)]`; every `.clone()` the macro
+//!   emits is a cheap reference-count bump, not a deep copy.
+//! - `type ReaderKind` is a type alias for the verbose
+//!   `ReaderTKind<Config, IdentityKind>`.  A type alias is a valid `Type::Path`
+//!   in the macro grammar; the compiler substitutes the underlying type when
+//!   resolving the `Bind` impl.
+
+use monadify::applicative::kind::Applicative;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::monad::kind::Bind;
+use monadify::transformers::reader::{MonadReader, Reader, ReaderT, ReaderTKind};
+use proptest::prelude::*;
+
+/// A minimal read-only configuration environment used throughout these tests.
+#[derive(Clone, Debug, PartialEq)]
+struct Config {
+    base: i32,
+    factor: i32,
+}
+
+/// Kind marker alias so `mdo! { ReaderKind; … }` is readable without turbofish.
+/// Expands to `ReaderTKind<Config, IdentityKind>` at compile time.
+type ReaderKind = ReaderTKind<Config, IdentityKind>;
+
+/// Concrete `Reader<Config, A>` — a computation `Config -> Identity<A>`.
+type ConfigReader<A> = Reader<Config, A>;
+
+/// Helper: call `ask()` pinned to `Config` / `IdentityKind` so tests are less verbose.
+fn ask_env() -> ConfigReader<Config> {
+    <ReaderKind as MonadReader<Config, Config, IdentityKind>>::ask()
+}
+
+/// Helper: run a `ConfigReader<i32>` against a `Config` and unwrap the `Identity`.
+fn run_i32(computation: &ConfigReader<i32>, cfg: Config) -> i32 {
+    let Identity(value) = (computation.run_reader_t)(cfg);
+    value
+}
+
+// ── 1. Env threading ──────────────────────────────────────────────────────────
+
+/// Two reader computations bound in sequence receive the SAME environment.
+/// `base` and `factor` both come from the *same* `Config` passed at run time.
+#[test]
+fn reader_mdo_same_env_threaded_to_every_bind() {
+    let computation: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        base   <- ReaderT::new(|cfg: Config| Identity(cfg.base));
+        factor <- ReaderT::new(|cfg: Config| Identity(cfg.factor));
+        ReaderKind::pure(base * factor)
+    };
+
+    assert_eq!(run_i32(&computation, Config { base: 3, factor: 7 }), 21);
+    assert_eq!(
+        run_i32(
+            &computation,
+            Config {
+                base: 0,
+                factor: 99
+            }
+        ),
+        0
+    );
+    assert_eq!(
+        run_i32(
+            &computation,
+            Config {
+                base: -2,
+                factor: 5
+            }
+        ),
+        -10
+    );
+    assert_eq!(run_i32(&computation, Config { base: 1, factor: 1 }), 1);
+}
+
+/// Different `Config` values produce different results — the environment is not baked in.
+#[test]
+fn reader_mdo_different_envs_produce_different_results() {
+    let computation: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        base   <- ReaderT::new(|cfg: Config| Identity(cfg.base));
+        factor <- ReaderT::new(|cfg: Config| Identity(cfg.factor));
+        ReaderKind::pure(base + factor)
+    };
+
+    let r1 = run_i32(
+        &computation,
+        Config {
+            base: 10,
+            factor: 20,
+        },
+    );
+    let r2 = run_i32(&computation, Config { base: 1, factor: 2 });
+    assert_eq!(r1, 30);
+    assert_eq!(r2, 3);
+    assert_ne!(r1, r2);
+}
+
+// ── 2. `ask` reads the full environment ────────────────────────────────────────
+
+/// `ask_env()` (i.e. `MonadReader::ask()`) binds the entire `Config` in the do-block.
+/// A `let` binding derives a value from it inline — no second `ReaderT` needed.
+#[test]
+fn reader_mdo_ask_exposes_full_environment() {
+    let computation: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        cfg <- ask_env();
+        let derived = cfg.base + cfg.factor;
+        ReaderKind::pure(derived)
+    };
+
+    assert_eq!(run_i32(&computation, Config { base: 4, factor: 6 }), 10);
+    assert_eq!(run_i32(&computation, Config { base: 0, factor: 0 }), 0);
+    assert_eq!(
+        run_i32(
+            &computation,
+            Config {
+                base: -1,
+                factor: 1
+            }
+        ),
+        0
+    );
+    assert_eq!(
+        run_i32(
+            &computation,
+            Config {
+                base: 100,
+                factor: -3
+            }
+        ),
+        97
+    );
+}
+
+/// `ask` followed by a `let` that computes a string — shows non-`i32` result types work.
+#[test]
+fn reader_mdo_ask_derives_string_label() {
+    let computation: ConfigReader<String> = mdo! {
+        ReaderKind;
+        cfg <- ask_env();
+        let label = format!("base={} factor={}", cfg.base, cfg.factor);
+        ReaderKind::pure(label)
+    };
+
+    let Identity(result) = (computation.run_reader_t)(Config { base: 7, factor: 3 });
+    assert_eq!(result, "base=7 factor=3");
+}
+
+// ── 3. `ask` combined with explicit field readers ─────────────────────────────
+
+/// Mixing `ask` with a `ReaderT::new(...)` in the same block — both see the same env.
+#[test]
+fn reader_mdo_ask_combined_with_field_reader() {
+    let computation: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        cfg   <- ask_env();
+        extra <- ReaderT::new(|cfg: Config| Identity(cfg.factor * 10));
+        ReaderKind::pure(cfg.base + extra)
+    };
+
+    // cfg.base = 3, extra = factor * 10 = 5 * 10 = 50, result = 53
+    assert_eq!(run_i32(&computation, Config { base: 3, factor: 5 }), 53);
+    // cfg.base = 0, extra = 0 * 10 = 0, result = 0
+    assert_eq!(run_i32(&computation, Config { base: 0, factor: 0 }), 0);
+}
+
+// ── 4. Equivalence: mdo! == hand-written nested bind ─────────────────────────
+
+/// The `mdo!` desugaring and an equivalent hand-written nested `Bind::bind` chain
+/// must produce identical results when run against the same environments.
+///
+/// Closures/functions cannot be compared for structural equality; we compare by
+/// *running* both sides against a set of concrete `Config` values.
+#[test]
+fn reader_mdo_equivalence_matches_hand_written_bind() {
+    // lhs: built by the macro (desugared automatically).
+    let lhs: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        base   <- ReaderT::new(|cfg: Config| Identity(cfg.base));
+        factor <- ReaderT::new(|cfg: Config| Identity(cfg.factor));
+        ReaderKind::pure(base.wrapping_add(factor))
+    };
+
+    // rhs: hand-written equivalent — the exact desugared form `mdo!` would emit.
+    let rhs: ConfigReader<i32> = ReaderKind::bind(
+        ReaderT::new(|cfg: Config| Identity(cfg.base)),
+        move |base| {
+            ReaderKind::bind(
+                ReaderT::new(|cfg: Config| Identity(cfg.factor)),
+                move |factor| ReaderKind::pure(base.wrapping_add(factor)),
+            )
+        },
+    );
+
+    let envs = [
+        Config { base: 0, factor: 0 },
+        Config { base: 1, factor: 2 },
+        Config {
+            base: -5,
+            factor: 10,
+        },
+        Config {
+            base: 42,
+            factor: -7,
+        },
+        Config {
+            base: i32::MAX,
+            factor: i32::MIN,
+        },
+    ];
+
+    for env in &envs {
+        let lhs_result = run_i32(&lhs, env.clone());
+        let rhs_result = run_i32(&rhs, env.clone());
+        assert_eq!(
+            lhs_result, rhs_result,
+            "mdo! and hand-written bind disagree for env {:?}",
+            env
+        );
+    }
+}
+
+/// Same equivalence check but for a three-step chain (depth 3).
+#[test]
+fn reader_mdo_equivalence_three_step_chain() {
+    let lhs: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        b1 <- ReaderT::new(|cfg: Config| Identity(cfg.base));
+        b2 <- ReaderT::new(|cfg: Config| Identity(cfg.base));
+        f  <- ReaderT::new(|cfg: Config| Identity(cfg.factor));
+        ReaderKind::pure(b1.wrapping_add(b2).wrapping_add(f))
+    };
+
+    let rhs: ConfigReader<i32> =
+        ReaderKind::bind(ReaderT::new(|cfg: Config| Identity(cfg.base)), move |b1| {
+            ReaderKind::bind(ReaderT::new(|cfg: Config| Identity(cfg.base)), move |b2| {
+                ReaderKind::bind(ReaderT::new(|cfg: Config| Identity(cfg.factor)), move |f| {
+                    ReaderKind::pure(b1.wrapping_add(b2).wrapping_add(f))
+                })
+            })
+        });
+
+    let envs = [
+        Config { base: 0, factor: 0 },
+        Config {
+            base: 10,
+            factor: 3,
+        },
+        Config {
+            base: -4,
+            factor: 8,
+        },
+    ];
+
+    for env in &envs {
+        let lhs_result = run_i32(&lhs, env.clone());
+        let rhs_result = run_i32(&rhs, env.clone());
+        assert_eq!(
+            lhs_result, rhs_result,
+            "three-step mdo! and hand-written bind disagree for env {:?}",
+            env
+        );
+    }
+}
+
+// ── 4b. Property-based equivalence ───────────────────────────────────────────
+//
+// Reader results are functions (`Config -> Identity<A>`), so they cannot be
+// compared structurally. Instead we generate a random environment, build BOTH
+// the `mdo!` block and the hand-written `Marker::bind` chain, RUN each against
+// the same generated `Config`, and compare the produced values. The desugaring
+// identity must hold for every generated environment.
+//
+// `base`/`factor` are drawn from `any::<i32>()`; arithmetic uses `wrapping_*`
+// so no overflow panic can occur for extreme generated inputs.
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    /// For every generated `Config`, running the `mdo!` desugaring and the
+    /// hand-written nested `bind` chain against that same environment must yield
+    /// identical results.
+    #[test]
+    fn reader_mdo_equivalence_prop(base in any::<i32>(), factor in any::<i32>()) {
+        let env = Config { base, factor };
+
+        // lhs: built by the macro (desugared automatically).
+        let lhs: ConfigReader<i32> = mdo! {
+            ReaderKind;
+            b <- ReaderT::new(|cfg: Config| Identity(cfg.base));
+            f <- ReaderT::new(|cfg: Config| Identity(cfg.factor));
+            ReaderKind::pure(b.wrapping_mul(f).wrapping_add(b).wrapping_add(f))
+        };
+
+        // rhs: hand-written equivalent — the exact desugared form `mdo!` emits.
+        let rhs: ConfigReader<i32> = ReaderKind::bind(
+            ReaderT::new(|cfg: Config| Identity(cfg.base)),
+            move |b| {
+                ReaderKind::bind(
+                    ReaderT::new(|cfg: Config| Identity(cfg.factor)),
+                    move |f| ReaderKind::pure(b.wrapping_mul(f).wrapping_add(b).wrapping_add(f)),
+                )
+            },
+        );
+
+        let lhs_result = run_i32(&lhs, env.clone());
+        let rhs_result = run_i32(&rhs, env.clone());
+        prop_assert_eq!(lhs_result, rhs_result);
+    }
+}
+
+// ── 5. Three-binding chain ────────────────────────────────────────────────────
+
+/// Three bindings with all three reading from the environment demonstrate depth-3
+/// desugaring is correct.
+#[test]
+fn reader_mdo_three_bindings_all_see_same_env() {
+    let computation: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        b1 <- ReaderT::new(|cfg: Config| Identity(cfg.base));
+        b2 <- ReaderT::new(|cfg: Config| Identity(cfg.base));
+        f  <- ReaderT::new(|cfg: Config| Identity(cfg.factor));
+        ReaderKind::pure(b1 + b2 + f)
+    };
+
+    // b1 = 10, b2 = 10, f = 3 → 23
+    assert_eq!(
+        run_i32(
+            &computation,
+            Config {
+                base: 10,
+                factor: 3
+            }
+        ),
+        23
+    );
+    // b1 = 0, b2 = 0, f = 0 → 0
+    assert_eq!(run_i32(&computation, Config { base: 0, factor: 0 }), 0);
+    // b1 = -1, b2 = -1, f = 5 → 3
+    assert_eq!(
+        run_i32(
+            &computation,
+            Config {
+                base: -1,
+                factor: 5
+            }
+        ),
+        3
+    );
+}
+
+/// Four bindings — the deepest nesting level in these tests.
+#[test]
+fn reader_mdo_four_bindings_correct_at_depth() {
+    let computation: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        a <- ReaderT::new(|cfg: Config| Identity(cfg.base));
+        b <- ReaderT::new(|cfg: Config| Identity(cfg.factor));
+        c <- ReaderT::new(|cfg: Config| Identity(cfg.base * 2));
+        d <- ReaderT::new(|cfg: Config| Identity(cfg.factor * 2));
+        ReaderKind::pure(a + b + c + d)
+    };
+
+    // a=5, b=3, c=10, d=6 → 24
+    let cfg = Config { base: 5, factor: 3 };
+    assert_eq!(run_i32(&computation, cfg), 24);
+}
+
+// ── 6. `local` modifies the env for a sub-computation ─────────────────────────
+
+/// `local(f, comp)` makes `comp` see a transformed environment.
+/// Earlier bindings in the same do-block see the ORIGINAL environment.
+#[test]
+fn reader_mdo_local_doubles_factor_for_inner_computation() {
+    // Sub-computation that reads `factor`.
+    let read_factor: ConfigReader<i32> = ReaderT::new(|cfg: Config| Identity(cfg.factor));
+
+    // Wrap it so its env has `factor` doubled.
+    let doubled_factor: ConfigReader<i32> =
+        <ReaderKind as MonadReader<Config, i32, IdentityKind>>::local(
+            |mut cfg: Config| {
+                cfg.factor *= 2;
+                cfg
+            },
+            read_factor,
+        );
+
+    // In the do-block:
+    //   `original` reads from the REAL env (factor = 5)
+    //   `modified` runs `doubled_factor` which pre-transforms env → factor = 10
+    let computation: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        original <- ReaderT::new(|cfg: Config| Identity(cfg.factor));
+        modified  <- doubled_factor;
+        ReaderKind::pure(original + modified)
+    };
+
+    let cfg = Config { base: 0, factor: 5 };
+    // original = 5, modified = 10, sum = 15
+    assert_eq!(run_i32(&computation, cfg), 15);
+}
+
+/// `local` that inflates only `base` does not affect bindings that read `factor`.
+///
+/// **Macro depth note:** the `mdo!` macro emits `move` closures; a non-Copy
+/// captured value at depth N can only be *borrowed* (via `.clone()`) at depth N,
+/// not moved into depth N+1 (that would be a move-out-of-FnMut).  To keep
+/// `inflated_base` at depth 1, we read `base` and `factor` in a single step using
+/// a tuple reader instead of two separate bind steps.
+#[test]
+fn reader_mdo_local_only_affects_its_inner_computation() {
+    // local inflates `base` × 100 for its wrapped computation
+    let inflated_base: ConfigReader<i32> =
+        <ReaderKind as MonadReader<Config, i32, IdentityKind>>::local(
+            |mut cfg: Config| {
+                cfg.base *= 100;
+                cfg
+            },
+            ReaderT::new(|cfg: Config| Identity(cfg.base)),
+        );
+
+    // Read `base` and `factor` together in one step so `inflated_base` (non-Copy)
+    // is only referenced at depth 1 in the mdo expansion.  The bound tuple
+    // components `original_base: i32` and `factor: i32` are `Copy`, so the
+    // innermost `move |inflated|` captures them without triggering E0507.
+    let computation: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        (original_base, factor) <- ReaderT::new(|cfg: Config| Identity((cfg.base, cfg.factor)));
+        inflated                <- inflated_base;
+        ReaderKind::pure(original_base + factor + inflated)
+    };
+
+    let cfg = Config { base: 2, factor: 3 };
+    // original_base = 2, factor = 3, inflated = 2 * 100 = 200, total = 205
+    let Identity(result) = (computation.run_reader_t)(cfg);
+    assert_eq!(result, 205);
+}
+
+/// `local` that negates `base` then combines with original `base` — verifies the
+/// two environments are kept distinct.
+#[test]
+fn reader_mdo_local_negated_base_combined_with_original() {
+    let negated_base: ConfigReader<i32> =
+        <ReaderKind as MonadReader<Config, i32, IdentityKind>>::local(
+            |mut cfg: Config| {
+                cfg.base = -cfg.base;
+                cfg
+            },
+            ReaderT::new(|cfg: Config| Identity(cfg.base)),
+        );
+
+    let computation: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        pos_base <- ReaderT::new(|cfg: Config| Identity(cfg.base));
+        neg_base <- negated_base;
+        ReaderKind::pure(pos_base + neg_base)
+    };
+
+    // pos_base = 7, neg_base = -7 → sum = 0
+    assert_eq!(run_i32(&computation, Config { base: 7, factor: 0 }), 0);
+    // pos_base = 0 → 0
+    assert_eq!(run_i32(&computation, Config { base: 0, factor: 0 }), 0);
+    // pos_base = -3 → pos + neg = -3 + 3 = 0
+    assert_eq!(
+        run_i32(
+            &computation,
+            Config {
+                base: -3,
+                factor: 0
+            }
+        ),
+        0
+    );
+}

--- a/tests/kind/do_notation/result.rs
+++ b/tests/kind/do_notation/result.rs
@@ -1,0 +1,319 @@
+//! `mdo!` do-block tests for `ResultKind<E>`.
+//!
+//! Tests in this file are gated by the parent `do_notation` module's
+//! `#![cfg(feature = "do-notation")]` attribute, so they are invisible to the
+//! default build.
+//!
+//! Covered scenarios
+//! -----------------
+//! 1. Happy path: two/three `Ok` bindings produce the expected `Ok` result.
+//! 2. Short-circuit on `Err`: the first `Err` aborts the whole block and the
+//!    error value is preserved (verified via observable return value).
+//! 3. Equivalence (key law test): `mdo!` output equals hand-written nested
+//!    `ResultKind::<String>::bind(…)` calls across `Ok`/`Err` combinations,
+//!    including a property-based leg with 256 generated inputs.
+//! 4. `let` binding inside the block and bare-expr sequencing, to exercise
+//!    those statement forms for `ResultKind`.
+//!
+//! **Note on `guard`:** `guard` is intentionally NOT supported for `ResultKind`
+//! (it is a deliberate compile error). No guard tests appear here.
+//!
+//! **`E: Clone`:** `ResultKind<E>` requires `E: Clone`; `String` satisfies this.
+//! All tests use `ResultKind::<String>` as the explicit block marker.
+//!
+//! **Variable ownership note:** `Result<i32, String>` is not `Copy`. The macro
+//! emits `(expr).clone()` for each monadic RHS, which moves the variable. Where
+//! a variable is needed both for `mdo!` and for a subsequent `rhs` expression,
+//! we pre-clone into separate bindings.
+
+use monadify::applicative::kind::Applicative;
+use monadify::kind_based::kind::ResultKind;
+use monadify::mdo;
+use monadify::monad::kind::Bind;
+use proptest::prelude::*;
+
+// Reuse the existing proptest strategy helpers (already `pub` in the harness).
+use super::super::proptest_laws::arb_result_i32_string;
+
+// ── 1. Happy path ────────────────────────────────────────────────────────────
+
+/// Two `Ok` bindings should propagate `Ok(2 + 3) == Ok(5)`.
+#[test]
+fn result_mdo_two_bindings_both_ok() {
+    let result: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- Ok(2);
+        y <- Ok(3);
+        ResultKind::<String>::pure(x + y)
+    };
+    assert_eq!(result, Ok(5));
+}
+
+/// Three `Ok` bindings should produce `Ok(1 + 2 + 3) == Ok(6)`.
+#[test]
+fn result_mdo_three_bindings_all_ok() {
+    let result: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- Ok(1);
+        y <- Ok(2);
+        z <- Ok(3);
+        ResultKind::<String>::pure(x + y + z)
+    };
+    assert_eq!(result, Ok(6));
+}
+
+// ── 2. Short-circuit on Err ───────────────────────────────────────────────────
+//
+// Short-circuit semantics are verified through the observable return value:
+// the block returns exactly the first `Err` and nothing else.
+
+/// An `Err` on the *first* binding short-circuits the entire block.
+#[test]
+fn result_mdo_short_circuit_first_binding_err() {
+    let result: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- Err::<i32, String>("first-err".to_string());
+        y <- Ok::<i32, String>(3);
+        ResultKind::<String>::pure(x + y)
+    };
+    assert_eq!(result, Err("first-err".to_string()));
+}
+
+/// An `Err` on the *second* binding short-circuits even after a successful first.
+#[test]
+fn result_mdo_short_circuit_second_binding_err() {
+    let result: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- Ok(2);
+        y <- Err::<i32, String>("second-err".to_string());
+        ResultKind::<String>::pure(x + y)
+    };
+    assert_eq!(result, Err("second-err".to_string()));
+}
+
+/// An `Err` in the *middle* of three bindings short-circuits the rest.
+#[test]
+fn result_mdo_short_circuit_middle_of_three() {
+    let result: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- Ok(1);
+        y <- Err::<i32, String>("mid-err".to_string());
+        z <- Ok(3);
+        ResultKind::<String>::pure(x + y + z)
+    };
+    assert_eq!(result, Err("mid-err".to_string()));
+}
+
+/// The error value propagated is the *first* `Err` encountered, not any later one.
+#[test]
+fn result_mdo_first_err_wins() {
+    let result: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- Err::<i32, String>("first".to_string());
+        y <- Err::<i32, String>("second".to_string());
+        ResultKind::<String>::pure(x + y)
+    };
+    assert_eq!(result, Err("first".to_string()));
+}
+
+// ── 3. Equivalence (example-based) ───────────────────────────────────────────
+//
+// The key law: `mdo! { M; x <- ma; y <- mb; M::pure(f(x, y)) }`
+//              == `M::bind(ma.clone(), move |x| M::bind(mb.clone(), move |y| M::pure(f(x, y))))`
+//
+// Because `Result<i32, String>` is not `Copy`, the macro's emitted `(ma).clone()`
+// moves `ma` into the outer closure. We pre-clone `ma`/`mb` into separate bindings
+// so both `lhs` (mdo!) and `rhs` (hand-written bind) each receive their own copy.
+
+/// Both `ma` and `mb` are `Ok`: result should be `Ok(2 + 3) == Ok(5)`.
+#[test]
+fn result_mdo_equivalence_both_ok() {
+    let ma: Result<i32, String> = Ok(2);
+    let mb: Result<i32, String> = Ok(3);
+
+    let ma_lhs = ma.clone();
+    let mb_lhs = mb.clone();
+    let lhs: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- ma_lhs;
+        y <- mb_lhs;
+        ResultKind::<String>::pure(x + y)
+    };
+
+    let rhs: Result<i32, String> = ResultKind::<String>::bind(ma, move |x| {
+        ResultKind::<String>::bind(mb.clone(), move |y| ResultKind::<String>::pure(x + y))
+    });
+
+    assert_eq!(lhs, rhs);
+    assert_eq!(lhs, Ok(5));
+}
+
+/// `ma` is `Err`: both `mdo!` and the hand-written bind should return `Err("e")`.
+#[test]
+fn result_mdo_equivalence_first_err() {
+    let ma: Result<i32, String> = Err("e".to_string());
+    let mb: Result<i32, String> = Ok(3);
+
+    let ma_lhs = ma.clone();
+    let mb_lhs = mb.clone();
+    let lhs: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- ma_lhs;
+        y <- mb_lhs;
+        ResultKind::<String>::pure(x + y)
+    };
+
+    let rhs: Result<i32, String> = ResultKind::<String>::bind(ma, move |x| {
+        ResultKind::<String>::bind(mb.clone(), move |y| ResultKind::<String>::pure(x + y))
+    });
+
+    assert_eq!(lhs, rhs);
+    assert_eq!(lhs, Err("e".to_string()));
+}
+
+/// `mb` is `Err`: both `mdo!` and the hand-written bind should return `Err("e")`.
+#[test]
+fn result_mdo_equivalence_second_err() {
+    let ma: Result<i32, String> = Ok(7);
+    let mb: Result<i32, String> = Err("e".to_string());
+
+    let ma_lhs = ma.clone();
+    let mb_lhs = mb.clone();
+    let lhs: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- ma_lhs;
+        y <- mb_lhs;
+        ResultKind::<String>::pure(x + y)
+    };
+
+    let rhs: Result<i32, String> = ResultKind::<String>::bind(ma, move |x| {
+        ResultKind::<String>::bind(mb.clone(), move |y| ResultKind::<String>::pure(x + y))
+    });
+
+    assert_eq!(lhs, rhs);
+    assert_eq!(lhs, Err("e".to_string()));
+}
+
+/// Both `ma` and `mb` are `Err`: first `Err` wins on both sides.
+#[test]
+fn result_mdo_equivalence_both_err() {
+    let ma: Result<i32, String> = Err("first".to_string());
+    let mb: Result<i32, String> = Err("second".to_string());
+
+    let ma_lhs = ma.clone();
+    let mb_lhs = mb.clone();
+    let lhs: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- ma_lhs;
+        y <- mb_lhs;
+        ResultKind::<String>::pure(x + y)
+    };
+
+    let rhs: Result<i32, String> = ResultKind::<String>::bind(ma, move |x| {
+        ResultKind::<String>::bind(mb.clone(), move |y| ResultKind::<String>::pure(x + y))
+    });
+
+    assert_eq!(lhs, rhs);
+    assert_eq!(lhs, Err("first".to_string()));
+}
+
+// ── 3b. Property-based equivalence ───────────────────────────────────────────
+//
+// Asserts the desugaring identity holds for 256 generated `(ma, mb)` pairs
+// drawn from `arb_result_i32_string()`. Reuses the existing proptest harness.
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    /// `mdo! { ResultKind::<String>; x <- ma; y <- mb; ResultKind::<String>::pure(x.wrapping_add(y)) }`
+    /// must equal the hand-written nested bind for every `(ma, mb)`.
+    #[test]
+    fn result_mdo_equivalence_prop(
+        ma in arb_result_i32_string(),
+        mb in arb_result_i32_string(),
+    ) {
+        // Pre-clone for mdo! (which moves its inputs into closures) and rhs.
+        let ma_lhs = ma.clone();
+        let mb_lhs = mb.clone();
+
+        let lhs: Result<i32, String> = mdo! {
+            ResultKind::<String>;
+            x <- ma_lhs;
+            y <- mb_lhs;
+            ResultKind::<String>::pure(x.wrapping_add(y))
+        };
+
+        let rhs: Result<i32, String> = ResultKind::<String>::bind(ma, move |x| {
+            ResultKind::<String>::bind(mb.clone(), move |y| {
+                ResultKind::<String>::pure(x.wrapping_add(y))
+            })
+        });
+
+        prop_assert_eq!(lhs, rhs);
+    }
+}
+
+// ── 4. `let` binding and bare-expr sequencing ─────────────────────────────────
+
+/// A `let` binding inside an `mdo!` block introduces a pure local name.
+#[test]
+fn result_mdo_let_binding_inside_block() {
+    let result: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- Ok(10);
+        let doubled = x * 2;
+        ResultKind::<String>::pure(doubled)
+    };
+    assert_eq!(result, Ok(20));
+}
+
+/// A `let` binding can reference multiple previously bound names.
+#[test]
+fn result_mdo_let_binding_combines_two_values() {
+    let result: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- Ok(4);
+        y <- Ok(6);
+        let sum = x + y;
+        ResultKind::<String>::pure(sum * 2)
+    };
+    assert_eq!(result, Ok(20));
+}
+
+/// A bare-expr sequencing line threads the monadic effect and discards the value;
+/// subsequent bindings still see earlier bound names.
+#[test]
+fn result_mdo_bare_expr_sequencing_ok() {
+    let result: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- Ok(5);
+        Ok::<(), String>(());
+        ResultKind::<String>::pure(x * 3)
+    };
+    assert_eq!(result, Ok(15));
+}
+
+/// A bare-expr sequencing line that returns `Err` short-circuits, just like a bind.
+#[test]
+fn result_mdo_bare_expr_sequencing_err_short_circuits() {
+    let result: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- Ok(5);
+        Err::<(), String>("bare-err".to_string());
+        ResultKind::<String>::pure(x * 3)
+    };
+    assert_eq!(result, Err("bare-err".to_string()));
+}
+
+/// Combining `let` and bare-expr: both forms can appear together.
+#[test]
+fn result_mdo_let_and_bare_expr_combined() {
+    let result: Result<String, String> = mdo! {
+        ResultKind::<String>;
+        x <- Ok::<i32, String>(7);
+        let label = "value";
+        Ok::<(), String>(());
+        ResultKind::<String>::pure(format!("{}: {}", label, x))
+    };
+    assert_eq!(result, Ok("value: 7".to_string()));
+}

--- a/tests/kind/do_notation/vec.rs
+++ b/tests/kind/do_notation/vec.rs
@@ -1,0 +1,361 @@
+//! `mdo!` do-block tests for `VecKind`.
+//!
+//! Tests in this file are gated by the parent `do_notation` module's
+//! `#![cfg(feature = "do-notation")]` attribute, so they are invisible to the
+//! default build.
+//!
+//! Covered scenarios
+//! -----------------
+//! 1. Cartesian product: two `<-` bindings over non-empty vecs produce all
+//!    element combinations in flat_map order (outer-first, inner-second).
+//! 2. Empty short-circuit: a binding over `vec![]` (typed) anywhere in the chain
+//!    makes the whole block `vec![]`.
+//! 3. List-comprehension with `guard`: `guard(cond)` filters elements via the
+//!    `VecKind` zero (`vec![]` on false, `vec![()]` on true). Also verifies that
+//!    an always-false guard returns `vec![]`.
+//! 4. Pythagorean-ish nested filter: pairs `(x, y)` drawn from two ranges,
+//!    filtered by `guard(x + y == 4)`, demonstrating real comprehension power.
+//! 5. Equivalence (example-based + proptest): `mdo!` output equals hand-written
+//!    nested `VecKind::bind(…)` calls, across concrete cases and 256 generated
+//!    `(Vec<i32>, Vec<i32>)` pairs drawn from `arb_vec_i32()`.
+//!
+//! **Ownership note:** `Vec<i32>` is not `Copy`. The macro emits
+//! `(expr).clone()` for each monadic RHS, which means the RHS is cloned rather
+//! than moved, but captured variables used *inside* the outer `move` closure are
+//! still moved into that closure. Where the same `va`/`vb` is needed for both
+//! `mdo!` (lhs) and a subsequent `rhs` hand-written bind, we pre-clone into
+//! separate `_lhs` bindings so the originals remain available — mirroring the
+//! pattern in `result.rs`.
+//!
+//! **Element type must be `Clone + 'static`:** `VecKind::bind` requires `A: Clone`
+//! (it is called once per element via `flat_map`); `VecKind::pure` requires
+//! `T: Clone`. All tests use `i32` or `(i32, i32)`, both of which satisfy this.
+
+use monadify::applicative::kind::Applicative;
+use monadify::kind_based::kind::VecKind;
+use monadify::mdo;
+use monadify::monad::kind::Bind;
+use proptest::prelude::*;
+
+// Reuse the existing bounded `arb_vec_i32` strategy (size 0..=32).
+use super::super::proptest_laws::arb_vec_i32;
+
+// ── 1. Cartesian product ──────────────────────────────────────────────────────
+//
+// `VecKind::bind` is `flat_map`.  Two bindings produce all (x, y) combinations
+// in outer-first, inner-second order:
+//   x=1 → [1+10, 1+20] = [11, 21]
+//   x=2 → [2+10, 2+20] = [12, 22]
+//   overall = [11, 21, 12, 22]
+
+/// Two bindings over `[1,2]` and `[10,20]` should produce `[11,21,12,22]`
+/// in flat_map-nesting order.
+#[test]
+fn vec_mdo_cartesian_product_two_bindings() {
+    let result: Vec<i32> = mdo! {
+        VecKind;
+        x <- vec![1i32, 2];
+        y <- vec![10i32, 20];
+        VecKind::pure(x + y)
+    };
+    assert_eq!(result, vec![11, 21, 12, 22]);
+}
+
+/// Three bindings produce the 8-element cross product in flat_map order:
+/// outer-first nesting.
+#[test]
+fn vec_mdo_cartesian_product_three_bindings() {
+    let result: Vec<i32> = mdo! {
+        VecKind;
+        x <- vec![0i32, 1];
+        y <- vec![0i32, 10];
+        z <- vec![0i32, 100];
+        VecKind::pure(x + y + z)
+    };
+    // x=0 → y=0 → [0, 100]; y=10 → [10, 110]
+    // x=1 → y=0 → [1, 101]; y=10 → [11, 111]
+    assert_eq!(result, vec![0, 100, 10, 110, 1, 101, 11, 111]);
+}
+
+// ── 2. Empty short-circuit ────────────────────────────────────────────────────
+
+/// A binding over `Vec::<i32>::new()` on the *first* position short-circuits the
+/// whole block to `vec![]`.
+#[test]
+fn vec_mdo_empty_first_binding_short_circuits() {
+    let result: Vec<i32> = mdo! {
+        VecKind;
+        x <- Vec::<i32>::new();
+        y <- vec![10i32, 20];
+        VecKind::pure(x + y)
+    };
+    assert_eq!(result, vec![]);
+}
+
+/// A binding over `Vec::<i32>::new()` on the *second* position short-circuits
+/// even after a successful first binding.
+#[test]
+fn vec_mdo_empty_second_binding_short_circuits() {
+    let result: Vec<i32> = mdo! {
+        VecKind;
+        x <- vec![1i32, 2];
+        y <- Vec::<i32>::new();
+        VecKind::pure(x + y)
+    };
+    assert_eq!(result, vec![]);
+}
+
+/// A binding over `Vec::<i32>::new()` in the *middle* of three bindings
+/// short-circuits the rest.
+#[test]
+fn vec_mdo_empty_middle_of_three_short_circuits() {
+    let result: Vec<i32> = mdo! {
+        VecKind;
+        x <- vec![1i32, 2];
+        y <- Vec::<i32>::new();
+        z <- vec![100i32];
+        VecKind::pure(x + y + z)
+    };
+    assert_eq!(result, vec![]);
+}
+
+// ── 3. List-comprehension with guard ─────────────────────────────────────────
+//
+// `guard(cond)` desugars via `MdoGuard for VecKind`:
+//   cond == true  → vec![()] → bind passes `()` to next step
+//   cond == false → vec![]   → bind over empty vec → contributes nothing
+//
+// This is the canonical list-comprehension filter.
+
+/// `guard(x % 2 == 0)` keeps only even elements; odd elements contribute nothing.
+#[test]
+fn vec_mdo_guard_filters_evens() {
+    let result: Vec<i32> = mdo! {
+        VecKind;
+        x <- vec![1i32, 2, 3, 4];
+        guard(x % 2 == 0);
+        VecKind::pure(x)
+    };
+    assert_eq!(result, vec![2, 4]);
+}
+
+/// `guard(x % 2 == 0)` applied to an all-odd vec returns `vec![]`.
+#[test]
+fn vec_mdo_guard_all_filtered_out_returns_empty() {
+    let result: Vec<i32> = mdo! {
+        VecKind;
+        x <- vec![1i32, 3, 5, 7];
+        guard(x % 2 == 0);
+        VecKind::pure(x)
+    };
+    assert_eq!(result, vec![]);
+}
+
+/// A literal `guard(true)` never filters anything; all elements pass through.
+#[test]
+fn vec_mdo_guard_literal_true_passes_all() {
+    let result: Vec<i32> = mdo! {
+        VecKind;
+        x <- vec![1i32, 2, 3];
+        guard(true);
+        VecKind::pure(x)
+    };
+    assert_eq!(result, vec![1, 2, 3]);
+}
+
+/// A literal `guard(false)` eliminates every element, yielding `vec![]`.
+#[test]
+fn vec_mdo_guard_literal_false_yields_empty() {
+    let result: Vec<i32> = mdo! {
+        VecKind;
+        x <- vec![1i32, 2, 3];
+        guard(false);
+        VecKind::pure(x)
+    };
+    assert_eq!(result, vec![]);
+}
+
+// ── 4. Pythagorean-ish nested filter ─────────────────────────────────────────
+//
+// A two-variable comprehension filtered by `x + y == 4` demonstrates that guard
+// correctly spans multiple outer bindings and that the resulting order matches
+// flat_map nesting (outer-x first, inner-y second).
+//
+//   x=1: y=1 → 2≠4 skip; y=2 → 3≠4 skip; y=3 → 4==4 keep → (1,3)
+//   x=2: y=1 → 3≠4 skip; y=2 → 4==4 keep → (2,2); y=3 → 5≠4 skip
+//   x=3: y=1 → 4==4 keep → (3,1); y=2 → 5≠4 skip; y=3 → 6≠4 skip
+//
+// Expected: [(1,3), (2,2), (3,1)]
+
+/// Pairs `(x, y)` with `x + y == 4` from ranges `[1,2,3] × [1,2,3]`.
+#[test]
+fn vec_mdo_guard_nested_filter_pairs_sum_to_4() {
+    let result: Vec<(i32, i32)> = mdo! {
+        VecKind;
+        x <- vec![1i32, 2, 3];
+        y <- vec![1i32, 2, 3];
+        guard(x + y == 4);
+        VecKind::pure((x, y))
+    };
+    assert_eq!(result, vec![(1, 3), (2, 2), (3, 1)]);
+}
+
+/// Guard over both bindings: `x != y` filters the diagonal, `guard(x + y > 5)`
+/// further restricts. Shows composition of multiple sequential guards.
+#[test]
+fn vec_mdo_multiple_guards_composed() {
+    let result: Vec<(i32, i32)> = mdo! {
+        VecKind;
+        x <- vec![1i32, 2, 3, 4];
+        y <- vec![1i32, 2, 3, 4];
+        guard(x != y);
+        guard(x + y > 5);
+        VecKind::pure((x, y))
+    };
+    // Pairs where x != y AND x + y > 5:
+    // From [1..4] × [1..4]:
+    //   x=1: y=1 (skip x==y); y=2 1+2=3≤5 skip; y=3 1+3=4≤5 skip; y=4 1+4=5≤5 skip
+    //   x=2: y=1 2+1=3≤5 skip; y=2 skip; y=3 2+3=5≤5 skip; y=4 2+4=6>5 keep (2,4)
+    //   x=3: y=1 3+1=4≤5 skip; y=2 3+2=5≤5 skip; y=3 skip; y=4 3+4=7>5 keep (3,4)
+    //   x=4: y=1 4+1=5≤5 skip; y=2 4+2=6>5 keep (4,2); y=3 4+3=7>5 keep (4,3); y=4 skip
+    assert_eq!(result, vec![(2, 4), (3, 4), (4, 2), (4, 3)]);
+}
+
+// ── 5. Equivalence (example-based) ───────────────────────────────────────────
+//
+// Key law: `mdo! { VecKind; x <- va; y <- vb; VecKind::pure(f(x,y)) }`
+//          == `VecKind::bind(va.clone(), move |x| VecKind::bind(vb.clone(), move |y| VecKind::pure(f(x,y))))`
+//
+// `Vec<i32>` is not `Copy`. The macro moves `vb` into the outer `move` closure
+// (captured at the first `<-` line). We pre-clone both `va` and `vb` into `_lhs`
+// variants so the originals remain accessible for the hand-written rhs.
+
+/// Both `va` and `vb` are non-empty: `mdo!` and hand-written bind yield identical
+/// cartesian-product results.
+#[test]
+fn vec_mdo_equivalence_both_nonempty() {
+    let va: Vec<i32> = vec![1, 2];
+    let vb: Vec<i32> = vec![10, 20];
+
+    let va_lhs = va.clone();
+    let vb_lhs = vb.clone();
+    let lhs: Vec<i32> = mdo! {
+        VecKind;
+        x <- va_lhs;
+        y <- vb_lhs;
+        VecKind::pure(x + y)
+    };
+
+    let rhs: Vec<i32> = VecKind::bind(va.clone(), move |x| {
+        VecKind::bind(vb.clone(), move |y| VecKind::pure(x + y))
+    });
+
+    assert_eq!(lhs, rhs);
+    assert_eq!(lhs, vec![11, 21, 12, 22]);
+}
+
+/// `va` is empty: both sides return `vec![]`.
+#[test]
+fn vec_mdo_equivalence_first_empty() {
+    let va: Vec<i32> = vec![];
+    let vb: Vec<i32> = vec![10, 20];
+
+    let va_lhs = va.clone();
+    let vb_lhs = vb.clone();
+    let lhs: Vec<i32> = mdo! {
+        VecKind;
+        x <- va_lhs;
+        y <- vb_lhs;
+        VecKind::pure(x + y)
+    };
+
+    let rhs: Vec<i32> = VecKind::bind(va.clone(), move |x| {
+        VecKind::bind(vb.clone(), move |y| VecKind::pure(x + y))
+    });
+
+    assert_eq!(lhs, rhs);
+    assert_eq!(lhs, vec![]);
+}
+
+/// `vb` is empty: both sides return `vec![]`.
+#[test]
+fn vec_mdo_equivalence_second_empty() {
+    let va: Vec<i32> = vec![1, 2];
+    let vb: Vec<i32> = vec![];
+
+    let va_lhs = va.clone();
+    let vb_lhs = vb.clone();
+    let lhs: Vec<i32> = mdo! {
+        VecKind;
+        x <- va_lhs;
+        y <- vb_lhs;
+        VecKind::pure(x + y)
+    };
+
+    let rhs: Vec<i32> = VecKind::bind(va.clone(), move |x| {
+        VecKind::bind(vb.clone(), move |y| VecKind::pure(x + y))
+    });
+
+    assert_eq!(lhs, rhs);
+    assert_eq!(lhs, vec![]);
+}
+
+/// Both `va` and `vb` are empty: both sides return `vec![]`.
+#[test]
+fn vec_mdo_equivalence_both_empty() {
+    let va: Vec<i32> = vec![];
+    let vb: Vec<i32> = vec![];
+
+    let va_lhs = va.clone();
+    let vb_lhs = vb.clone();
+    let lhs: Vec<i32> = mdo! {
+        VecKind;
+        x <- va_lhs;
+        y <- vb_lhs;
+        VecKind::pure(x + y)
+    };
+
+    let rhs: Vec<i32> = VecKind::bind(va.clone(), move |x| {
+        VecKind::bind(vb.clone(), move |y| VecKind::pure(x + y))
+    });
+
+    assert_eq!(lhs, rhs);
+    assert_eq!(lhs, vec![]);
+}
+
+// ── 5b. Property-based equivalence ───────────────────────────────────────────
+//
+// Asserts the desugaring identity holds for 256 generated `(va, vb)` pairs
+// drawn from `arb_vec_i32()` (size 0..=32). Uses `wrapping_add` to avoid
+// overflow panics on arbitrary `i32` inputs.
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    /// `mdo! { VecKind; x <- va; y <- vb; VecKind::pure(x.wrapping_add(y)) }`
+    /// must equal the hand-written nested bind for every `(va, vb)`.
+    #[test]
+    fn vec_mdo_equivalence_prop(
+        va in arb_vec_i32(),
+        vb in arb_vec_i32(),
+    ) {
+        // Pre-clone for lhs (mdo! moves vb_lhs into the outer `move` closure).
+        let va_lhs = va.clone();
+        let vb_lhs = vb.clone();
+
+        let lhs: Vec<i32> = mdo! {
+            VecKind;
+            x <- va_lhs;
+            y <- vb_lhs;
+            VecKind::pure(x.wrapping_add(y))
+        };
+
+        // Originals va/vb are still valid: va was borrowed-to-clone by macro,
+        // vb was captured inside vb_lhs (a pre-clone) not consumed from va/vb.
+        let rhs: Vec<i32> = VecKind::bind(va.clone(), move |x| {
+            VecKind::bind(vb.clone(), move |y| VecKind::pure(x.wrapping_add(y)))
+        });
+
+        prop_assert_eq!(lhs, rhs);
+    }
+}

--- a/tests/kind/functor.rs
+++ b/tests/kind/functor.rs
@@ -31,7 +31,7 @@ pub mod option_kind_functor_laws {
         // Renamed test
         let opt = Some(10);
         let identity_fn = clone_fn_map(|x: i32| x);
-        assert_eq!(OptionKind::map(opt.clone(), identity_fn), opt); // Renamed Marker
+        assert_eq!(OptionKind::map(opt, identity_fn), opt); // Renamed Marker
     }
 
     #[test]
@@ -39,7 +39,7 @@ pub mod option_kind_functor_laws {
         // Renamed test
         let opt: Option<i32> = None;
         let identity_fn = clone_fn_map(|x: i32| x);
-        assert_eq!(OptionKind::map(opt.clone(), identity_fn), opt); // Renamed Marker
+        assert_eq!(OptionKind::map(opt, identity_fn), opt); // Renamed Marker
     }
 
     // Composition law: OptionKind::map(opt, |x| g(f(x))) == OptionKind::map(OptionKind::map(opt, f), g)
@@ -52,8 +52,7 @@ pub mod option_kind_functor_laws {
 
         let f_clone = f.clone();
         let g_clone = g.clone();
-        let composed_map =
-            OptionKind::map(opt.clone(), move |x| g_clone.clone()(f_clone.clone()(x))); // Renamed Marker
+        let composed_map = OptionKind::map(opt, move |x| g_clone.clone()(f_clone.clone()(x))); // Renamed Marker
         let sequential_map = OptionKind::map(OptionKind::map(opt, f), g); // Renamed Marker
 
         assert_eq!(composed_map, sequential_map);
@@ -69,8 +68,7 @@ pub mod option_kind_functor_laws {
 
         let f_clone = f.clone();
         let g_clone = g.clone();
-        let composed_map =
-            OptionKind::map(opt.clone(), move |x| g_clone.clone()(f_clone.clone()(x))); // Renamed Marker
+        let composed_map = OptionKind::map(opt, move |x| g_clone.clone()(f_clone.clone()(x))); // Renamed Marker
         let sequential_map = OptionKind::map(OptionKind::map(opt, f), g); // Renamed Marker
 
         assert_eq!(composed_map, sequential_map);
@@ -483,7 +481,7 @@ pub mod reader_t_kind_functor_laws {
         let env_val = "test_env".to_string();
         let reader_t_creator = || ReaderT::new(move |_env: EnvReader| Some(10));
 
-        let f = clone_fn_map(|x: i32| (x as f64 * 2.0));
+        let f = clone_fn_map(|x: i32| x as f64 * 2.0);
         let g = clone_fn_map(|y: f64| format!("Value: {:.1}", y));
 
         let f_clone_composed = f.clone();
@@ -514,7 +512,7 @@ pub mod reader_t_kind_functor_laws {
         let env_val = "test_env".to_string();
         let reader_t_creator = || ReaderT::new(move |_env: EnvReader| None::<i32>);
 
-        let f = clone_fn_map(|x: i32| (x as f64 * 2.0));
+        let f = clone_fn_map(|x: i32| x as f64 * 2.0);
         let g = clone_fn_map(|y: f64| format!("Value: {:.1}", y));
 
         let f_clone_composed = f.clone();

--- a/tests/kind/mod.rs
+++ b/tests/kind/mod.rs
@@ -1,6 +1,10 @@
 pub mod applicative;
+pub mod apply;
 pub mod functor;
 pub mod identity;
+// The `kind` submodule intentionally mirrors the crate's `kind_based::kind` path.
+#[allow(clippy::module_inception)]
 pub mod kind;
 pub mod monad;
+pub mod proptest_laws;
 pub mod transformers;

--- a/tests/kind/mod.rs
+++ b/tests/kind/mod.rs
@@ -8,3 +8,7 @@ pub mod kind;
 pub mod monad;
 pub mod proptest_laws;
 pub mod transformers;
+
+// Do-notation tests: compiled only when the `do-notation` feature is enabled.
+#[cfg(feature = "do-notation")]
+pub mod do_notation;

--- a/tests/kind/monad.rs
+++ b/tests/kind/monad.rs
@@ -548,8 +548,7 @@ mod cfn_kind_monad_laws {
         let env_val: Env = 5;
         let x: i32 = 10;
 
-        let mma: CFn<Env, CFn<Env, i32>> =
-            CFn::new(move |_env_outer: Env| CFnKind::<Env>::pure(x.clone())); // Renamed Marker
+        let mma: CFn<Env, CFn<Env, i32>> = CFn::new(move |_env_outer: Env| CFnKind::<Env>::pure(x)); // Renamed Marker
 
         let lhs_cfn: CFn<Env, i32> = CFnKind::<Env>::join(mma); // Renamed Marker
         let rhs_cfn: CFn<Env, i32> = CFnKind::<Env>::pure(x); // Renamed Marker
@@ -687,7 +686,7 @@ mod cfn_once_kind_monad_laws {
         let x: i32 = 10;
 
         let mma: CFnOnce<Env, CFnOnce<Env, i32>> =
-            CFnOnce::new(move |_env_outer: Env| CFnOnceKind::<Env>::pure(x.clone())); // Renamed Marker
+            CFnOnce::new(move |_env_outer: Env| CFnOnceKind::<Env>::pure(x)); // Renamed Marker
 
         let lhs_cfn_once: CFnOnce<Env, i32> = CFnOnceKind::<Env>::join(mma); // Renamed Marker
         let rhs_cfn_once: CFnOnce<Env, i32> = CFnOnceKind::<Env>::pure(x); // Renamed Marker

--- a/tests/kind/proptest_laws/applicative.rs
+++ b/tests/kind/proptest_laws/applicative.rs
@@ -1,0 +1,343 @@
+//! Applicative law property tests for the kind-based data instances.
+//!
+//! Covers the **identity**, **homomorphism**, **interchange** and
+//! **composition** laws over the property-testable Applicative instances per the
+//! gap matrix — thirteen cells total:
+//!
+//! - **Option / Result<i32, String> / Identity**: all four laws.
+//! - **Vec**: **interchange only**. `identity`, `homomorphism` and `composition`
+//!   are blocked because they place a function in the container via
+//!   `pure(CFn)` and `Vec`'s cartesian `apply` must *reuse* (clone) each wrapped
+//!   `CFn`, and `CFn` is **not `Clone`** (see the gap matrix and the stubbed
+//!   example tests in `tests/kind/applicative.rs`).
+//!
+//! `CFn` / `CFnOnce` / `ReaderT` are function-typed and remain example-only.
+//! Companion to the example-based tests in `tests/kind/applicative.rs`; the
+//! shared strategies live in the parent module (`super`) and are reused here,
+//! not redefined.
+//!
+//! This crate spells the apply operator `g <*> v` as `apply(v, g)` — i.e.
+//! `apply(value_container, function_container)`. The four laws therefore read:
+//!
+//! - **Identity:** `pure(id) <*> v == v`  →  `apply(v, pure(id)) == v`.
+//! - **Homomorphism:** `pure(f) <*> pure(x) == pure(f(x))`  →
+//!   `apply(pure(x), pure(f)) == pure(f(x))`.
+//! - **Interchange:** `u <*> pure(y) == pure(|f| f(y)) <*> u`  →
+//!   `apply(pure(y), u) == apply(u, pure(|f| f(y)))`.
+//! - **Composition:** `pure(compose) <*> u <*> v <*> w == u <*> (v <*> w)`.
+//!
+//! ## Composition / Vec-interchange formulation (read me)
+//!
+//! Two cells cannot assert the *literal* canonical form and instead assert the
+//! **strongest expressible equivalent** against ground-truth `g(f(x))` semantics:
+//!
+//! - **Composition** (Option / Result / Identity): the literal left-hand side
+//!   `pure(compose) <*> u <*> v <*> w` is not constructible, exactly as
+//!   documented in the sibling `apply.rs` — `pure(compose)` would need the
+//!   middle composing closure to *move* a captured `CFn` into its result
+//!   (making it `FnOnce`, but `CFn::new` requires `Fn`), and the usual clone
+//!   escape hatch is unavailable because **`CFn` is not `Clone`**. So we build
+//!   the fully-constructible right-associated side `u <*> (v <*> w)` —
+//!   `apply(apply(w, v), u)` — and assert it equals the ground truth `g(f(x))`
+//!   lifted into the container. For a lawful Applicative both the canonical
+//!   left-hand side and `u <*> (v <*> w)` reduce to exactly this, so this
+//!   verifies the law without the non-constructible `pure(compose)`.
+//! - **Vec interchange:** the canonical right-hand side `pure(|f| f(y)) <*> u`
+//!   is `apply(u, pure(|f| f(y)))`, but `Vec`'s cartesian `apply` clones each
+//!   element of its value container (here `u`'s `CFn` elements) — not possible
+//!   since `CFn` is not `Clone`. So we assert the constructible left-hand side
+//!   `apply(pure(y), u)` (each `f` applied to `y` once) against the ground truth
+//!   `[f_i(y)]`, which is exactly what the canonical right-hand side denotes.
+//!
+//! Linear closures are materialized from `arb_linear_closure_params` via
+//! `linear_fn`/`linear_cfn` (rebuilt fresh per use because `CFn` is not
+//! `Clone`), using `wrapping_*` arithmetic to avoid overflow panics on arbitrary
+//! `i32` inputs.
+
+use super::{
+    arb_identity_i32, arb_linear_closure_params, arb_option_i32, arb_result_i32_string, linear_cfn,
+    linear_fn,
+};
+use monadify::applicative::kind::Applicative;
+use monadify::apply::kind::Apply;
+use monadify::function::CFn;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::kind_based::kind::{OptionKind, ResultKind, VecKind};
+use proptest::prelude::*;
+
+type TestError = String;
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    // --- Option ---
+
+    /// Applicative identity for `Option`: `apply(v, pure(id)) == v`.
+    #[test]
+    fn option_applicative_identity(v in arb_option_i32()) {
+        let pure_id: Option<CFn<i32, i32>> = OptionKind::pure(CFn::new(|x: i32| x));
+        prop_assert_eq!(OptionKind::apply(v, pure_id), v);
+    }
+
+    /// Applicative homomorphism for `Option`:
+    /// `apply(pure(x), pure(f)) == pure(f(x))`.
+    #[test]
+    fn option_applicative_homomorphism(
+        x in any::<i32>(),
+        (a, b) in arb_linear_closure_params(),
+    ) {
+        let pure_x: Option<i32> = OptionKind::pure(x);
+        let pure_f: Option<CFn<i32, i32>> = OptionKind::pure(linear_cfn(a, b));
+        let lhs = OptionKind::apply(pure_x, pure_f);
+
+        let mut f = linear_fn(a, b);
+        let rhs: Option<i32> = OptionKind::pure(f(x));
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Applicative interchange for `Option`:
+    /// `apply(pure(y), u) == apply(u, pure(|f| f(y)))`.
+    #[test]
+    fn option_applicative_interchange(
+        y in any::<i32>(),
+        (a, b) in arb_linear_closure_params(),
+        present in any::<bool>(),
+    ) {
+        let make_u = || -> Option<CFn<i32, i32>> {
+            if present { Some(linear_cfn(a, b)) } else { None }
+        };
+
+        // LHS: u <*> pure(y) == apply(pure(y), u)
+        let lhs = OptionKind::apply(OptionKind::pure(y), make_u());
+
+        // RHS: pure(|f| f(y)) <*> u == apply(u, pure(|f| f(y)))
+        let pure_interchange: Option<CFn<CFn<i32, i32>, i32>> =
+            OptionKind::pure(CFn::new(move |f: CFn<i32, i32>| f.call(y)));
+        let rhs = OptionKind::apply(make_u(), pure_interchange);
+
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Applicative composition for `Option`: the constructible right-associated
+    /// side `u <*> (v <*> w) == apply(apply(w, v), u)` equals `g(f(x))` lifted
+    /// into `Option`, with the `None` arms short-circuiting. `v` carries `f`,
+    /// `u` carries `g`; both the presence arm and the linear function are
+    /// generated. See the module docs for why the literal `pure(compose)` chain
+    /// is not constructible.
+    #[test]
+    fn option_applicative_composition(
+        w in arb_option_i32(),
+        (fa, fb) in arb_linear_closure_params(),
+        (ga, gb) in arb_linear_closure_params(),
+        f_present in any::<bool>(),
+        g_present in any::<bool>(),
+    ) {
+        let v: Option<CFn<i32, i32>> = if f_present { Some(linear_cfn(fa, fb)) } else { None };
+        let u: Option<CFn<i32, i32>> = if g_present { Some(linear_cfn(ga, gb)) } else { None };
+
+        let lhs = OptionKind::apply(OptionKind::apply(w, v), u);
+
+        let rhs: Option<i32> = match (w, f_present, g_present) {
+            (Some(x), true, true) => {
+                let mut f = linear_fn(fa, fb);
+                let mut g = linear_fn(ga, gb);
+                Some(g(f(x)))
+            }
+            _ => None,
+        };
+
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    // --- Result<i32, String> ---
+
+    /// Applicative identity for `Result<i32, String>`: `apply(r, pure(id)) == r`.
+    #[test]
+    fn result_applicative_identity(r in arb_result_i32_string()) {
+        let pure_id: Result<CFn<i32, i32>, TestError> =
+            ResultKind::<TestError>::pure(CFn::new(|x: i32| x));
+        prop_assert_eq!(ResultKind::<TestError>::apply(r.clone(), pure_id), r);
+    }
+
+    /// Applicative homomorphism for `Result<i32, String>`:
+    /// `apply(pure(x), pure(f)) == pure(f(x))`.
+    #[test]
+    fn result_applicative_homomorphism(
+        x in any::<i32>(),
+        (a, b) in arb_linear_closure_params(),
+    ) {
+        let pure_x: Result<i32, TestError> = ResultKind::<TestError>::pure(x);
+        let pure_f: Result<CFn<i32, i32>, TestError> =
+            ResultKind::<TestError>::pure(linear_cfn(a, b));
+        let lhs = ResultKind::<TestError>::apply(pure_x, pure_f);
+
+        let mut f = linear_fn(a, b);
+        let rhs: Result<i32, TestError> = ResultKind::<TestError>::pure(f(x));
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Applicative interchange for `Result<i32, String>`:
+    /// `apply(pure(y), u) == apply(u, pure(|f| f(y)))`.
+    #[test]
+    fn result_applicative_interchange(
+        y in any::<i32>(),
+        (a, b) in arb_linear_closure_params(),
+        ok in any::<bool>(),
+        e in ".*",
+    ) {
+        let make_u = || -> Result<CFn<i32, i32>, TestError> {
+            if ok { Ok(linear_cfn(a, b)) } else { Err(e.clone()) }
+        };
+
+        // LHS: u <*> pure(y) == apply(pure(y), u)
+        let lhs = ResultKind::<TestError>::apply(ResultKind::<TestError>::pure(y), make_u());
+
+        // RHS: pure(|f| f(y)) <*> u == apply(u, pure(|f| f(y)))
+        let pure_interchange: Result<CFn<CFn<i32, i32>, i32>, TestError> =
+            ResultKind::<TestError>::pure(CFn::new(move |f: CFn<i32, i32>| f.call(y)));
+        let rhs = ResultKind::<TestError>::apply(make_u(), pure_interchange);
+
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Applicative composition for `Result<i32, String>`: the constructible
+    /// right-associated side `apply(apply(w, v), u)` equals `g(f(x))` lifted into
+    /// `Result`, with `Err` short-circuiting in `w`-then-`v`-then-`u` precedence
+    /// (matching this crate's `and_then`/`map` based `apply`). `v` carries `f`,
+    /// `u` carries `g`; presence arm, error string and linear function are
+    /// generated.
+    #[test]
+    fn result_applicative_composition(
+        w in arb_result_i32_string(),
+        (fa, fb) in arb_linear_closure_params(),
+        (ga, gb) in arb_linear_closure_params(),
+        f_ok in any::<bool>(),
+        g_ok in any::<bool>(),
+        ev in ".*",
+        eu in ".*",
+    ) {
+        let v: Result<CFn<i32, i32>, TestError> =
+            if f_ok { Ok(linear_cfn(fa, fb)) } else { Err(ev.clone()) };
+        let u: Result<CFn<i32, i32>, TestError> =
+            if g_ok { Ok(linear_cfn(ga, gb)) } else { Err(eu.clone()) };
+
+        let inner = <ResultKind<TestError> as Apply<i32, i32>>::apply(w.clone(), v);
+        let lhs = <ResultKind<TestError> as Apply<i32, i32>>::apply(inner, u);
+
+        let rhs: Result<i32, TestError> = match w {
+            Err(e) => Err(e),
+            Ok(x) => {
+                if !f_ok {
+                    Err(ev)
+                } else if !g_ok {
+                    Err(eu)
+                } else {
+                    let mut f = linear_fn(fa, fb);
+                    let mut g = linear_fn(ga, gb);
+                    Ok(g(f(x)))
+                }
+            }
+        };
+
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    // --- Identity ---
+
+    /// Applicative identity for `Identity`: `apply(i, pure(id)) == i`.
+    #[test]
+    fn identity_applicative_identity(i in arb_identity_i32()) {
+        let pure_id: Identity<CFn<i32, i32>> = IdentityKind::pure(CFn::new(|x: i32| x));
+        prop_assert_eq!(IdentityKind::apply(i.clone(), pure_id), i);
+    }
+
+    /// Applicative homomorphism for `Identity`:
+    /// `apply(pure(x), pure(f)) == pure(f(x))`.
+    #[test]
+    fn identity_applicative_homomorphism(
+        x in any::<i32>(),
+        (a, b) in arb_linear_closure_params(),
+    ) {
+        let pure_x: Identity<i32> = IdentityKind::pure(x);
+        let pure_f: Identity<CFn<i32, i32>> = IdentityKind::pure(linear_cfn(a, b));
+        let lhs = IdentityKind::apply(pure_x, pure_f);
+
+        let mut f = linear_fn(a, b);
+        let rhs: Identity<i32> = IdentityKind::pure(f(x));
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Applicative interchange for `Identity`:
+    /// `apply(pure(y), u) == apply(u, pure(|f| f(y)))`.
+    #[test]
+    fn identity_applicative_interchange(
+        y in any::<i32>(),
+        (a, b) in arb_linear_closure_params(),
+    ) {
+        let make_u = || -> Identity<CFn<i32, i32>> { Identity(linear_cfn(a, b)) };
+
+        // LHS: u <*> pure(y) == apply(pure(y), u)
+        let lhs = IdentityKind::apply(IdentityKind::pure(y), make_u());
+
+        // RHS: pure(|f| f(y)) <*> u == apply(u, pure(|f| f(y)))
+        let pure_interchange: Identity<CFn<CFn<i32, i32>, i32>> =
+            IdentityKind::pure(CFn::new(move |f: CFn<i32, i32>| f.call(y)));
+        let rhs = IdentityKind::apply(make_u(), pure_interchange);
+
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Applicative composition for `Identity` (no short-circuit arm; always
+    /// present): the right-associated side `apply(apply(Identity(x), v), u)`
+    /// equals `Identity(g(f(x)))`.
+    #[test]
+    fn identity_applicative_composition(
+        i in arb_identity_i32(),
+        (fa, fb) in arb_linear_closure_params(),
+        (ga, gb) in arb_linear_closure_params(),
+    ) {
+        let x = i.0;
+        let v = Identity(linear_cfn(fa, fb));
+        let u = Identity(linear_cfn(ga, gb));
+
+        let lhs = IdentityKind::apply(IdentityKind::apply(i, v), u);
+
+        let rhs = {
+            let mut f = linear_fn(fa, fb);
+            let mut g = linear_fn(ga, gb);
+            Identity(g(f(x)))
+        };
+
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    // --- Vec (interchange only) ---
+
+    /// Applicative interchange for `Vec`: the constructible left-hand side
+    /// `u <*> pure(y) == apply(pure(y), u)` (each `f` in `u` applied to `y`
+    /// once) equals the ground truth `[f_i(y)]` — exactly what the canonical
+    /// right-hand side `pure(|f| f(y)) <*> u` denotes. The canonical RHS itself
+    /// is not constructible here: `Vec`'s cartesian `apply` would clone `u`'s
+    /// `CFn` value-container elements, and `CFn` is not `Clone`.
+    #[test]
+    fn vec_applicative_interchange(
+        y in any::<i32>(),
+        params in prop::collection::vec(arb_linear_closure_params(), 0..=8),
+    ) {
+        let u: Vec<CFn<i32, i32>> = params.iter().map(|&(a, b)| linear_cfn(a, b)).collect();
+
+        // LHS: u <*> pure(y) == apply(pure(y), u)
+        let lhs = VecKind::apply(VecKind::pure(y), u);
+
+        // Ground truth for pure(|f| f(y)) <*> u: each function applied to y once.
+        let rhs: Vec<i32> = params
+            .iter()
+            .map(|&(a, b)| {
+                let mut f = linear_fn(a, b);
+                f(y)
+            })
+            .collect();
+
+        prop_assert_eq!(lhs, rhs);
+    }
+}

--- a/tests/kind/proptest_laws/apply.rs
+++ b/tests/kind/proptest_laws/apply.rs
@@ -1,0 +1,163 @@
+//! Apply (`<*>`) law property tests for the kind-based data instances.
+//!
+//! Covers the **composition** law over the three property-testable Apply
+//! instances (Option, Result<i32, String>, Identity) — three cells total.
+//! `Vec` is excluded: its `apply` is cartesian and must *reuse* (clone) each
+//! wrapped `CFn` across elements, and `CFn` is **not `Clone`** (see the gap
+//! matrix). `CFn`/`CFnOnce`/`ReaderT` are function-typed and remain
+//! example-only. Companion to the example-based tests in `tests/kind/apply.rs`;
+//! the shared strategies live in the parent module (`super`) and are reused
+//! here, not redefined.
+//!
+//! ## Formulation (read me)
+//!
+//! The Apply **composition** law is canonically
+//! `apply(apply(apply(pure(compose), u), v), w) == apply(u, apply(v, w))`
+//! with `compose = |f| |g| |x| f(g(x))`.
+//!
+//! The literal left-hand side **cannot be constructed** with this crate's API:
+//! `pure(compose)` would place `compose` in the container as a
+//! `CFn<CFn<B,C>, CFn<CFn<A,B>, CFn<A,C>>>`. Building it requires the middle
+//! `|g| ...` closure (which must be `Fn`, because `CFn::new` requires `Fn`) to
+//! **move** its captured `CFn` `f` into the returned closure — that consumes a
+//! capture, making the closure `FnOnce`, not `Fn`. The usual escape hatch
+//! (clone `f` inside) is unavailable because **`CFn` is not `Clone`**.
+//!
+//! So we assert the **strongest expressible equivalent**: the right-associated
+//! side `u <*> (v <*> w)` — fully constructible here as
+//! `apply(apply(w, v), u)` (recall this crate spells `g <*> x` as
+//! `apply(x, g)`) — checked against the **ground-truth semantics** `g(f(x))`.
+//! For a lawful Apply the canonical left-hand side
+//! `pure(compose) <*> u <*> v <*> w` equals the right side `u <*> (v <*> w)`
+//! by the law, and both provably reduce to exactly this ground truth, so
+//! asserting `(u <*> (v <*> w)) == ground_truth` verifies the composition law
+//! without needing the non-constructible `pure(compose)`.
+//!
+//! The function containers `u`/`v` are themselves generated (both the
+//! present/absent arm and the wrapped linear closure), so this exercises the
+//! container's short-circuit/error-precedence behaviour as well as the
+//! functional composition. Linear closures are materialized from
+//! `arb_linear_closure_params` via `linear_fn`/`linear_cfn` (rebuilt fresh per
+//! use because `CFn` is not `Clone`), using `wrapping_*` arithmetic to avoid
+//! overflow panics on arbitrary `i32` inputs.
+
+use super::{
+    arb_identity_i32, arb_linear_closure_params, arb_result_i32_string, linear_cfn, linear_fn,
+};
+use monadify::apply::kind::Apply;
+use monadify::function::CFn;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::kind_based::kind::{OptionKind, ResultKind};
+use proptest::prelude::*;
+
+type TestError = String;
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    // --- Option ---
+
+    /// Apply composition for `Option`:
+    /// `u <*> (v <*> w) == fmap (g ∘ f) w`, i.e.
+    /// `apply(apply(w, v), u)` equals `g(f(x))` lifted into `Option`, with the
+    /// `None` arms short-circuiting. `v` carries `f`, `u` carries `g`; both the
+    /// presence arm and the linear function are generated.
+    #[test]
+    fn option_apply_composition(
+        w in any::<Option<i32>>(),
+        (fa, fb) in arb_linear_closure_params(),
+        (ga, gb) in arb_linear_closure_params(),
+        f_present in any::<bool>(),
+        g_present in any::<bool>(),
+    ) {
+        let v: Option<CFn<i32, i32>> = if f_present { Some(linear_cfn(fa, fb)) } else { None };
+        let u: Option<CFn<i32, i32>> = if g_present { Some(linear_cfn(ga, gb)) } else { None };
+
+        // LHS: u <*> (v <*> w) == apply(apply(w, v), u)
+        let lhs = OptionKind::apply(OptionKind::apply(w, v), u);
+
+        // Ground truth: present only when w, v and u are all present.
+        let rhs: Option<i32> = match (w, f_present, g_present) {
+            (Some(x), true, true) => {
+                let mut f = linear_fn(fa, fb);
+                let mut g = linear_fn(ga, gb);
+                Some(g(f(x)))
+            }
+            _ => None,
+        };
+
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    // --- Result<i32, String> ---
+
+    /// Apply composition for `Result<i32, String>`:
+    /// `apply(apply(w, v), u)` equals `g(f(x))` lifted into `Result`, with the
+    /// `Err` arms short-circuiting in `w`-then-`v`-then-`u` precedence (matching
+    /// this crate's `and_then`/`map` based `apply`). `v` carries `f`, `u`
+    /// carries `g`; presence arm, error string and linear function are generated.
+    #[test]
+    fn result_apply_composition(
+        w in arb_result_i32_string(),
+        (fa, fb) in arb_linear_closure_params(),
+        (ga, gb) in arb_linear_closure_params(),
+        f_ok in any::<bool>(),
+        g_ok in any::<bool>(),
+        ev in ".*",
+        eu in ".*",
+    ) {
+        let v: Result<CFn<i32, i32>, TestError> =
+            if f_ok { Ok(linear_cfn(fa, fb)) } else { Err(ev.clone()) };
+        let u: Result<CFn<i32, i32>, TestError> =
+            if g_ok { Ok(linear_cfn(ga, gb)) } else { Err(eu.clone()) };
+
+        // LHS: u <*> (v <*> w) == apply(apply(w, v), u)
+        let inner = <ResultKind<TestError> as Apply<i32, i32>>::apply(w.clone(), v);
+        let lhs = <ResultKind<TestError> as Apply<i32, i32>>::apply(inner, u);
+
+        // Ground truth with w-then-v-then-u error precedence.
+        let rhs: Result<i32, TestError> = match w {
+            Err(e) => Err(e),
+            Ok(x) => {
+                if !f_ok {
+                    Err(ev)
+                } else if !g_ok {
+                    Err(eu)
+                } else {
+                    let mut f = linear_fn(fa, fb);
+                    let mut g = linear_fn(ga, gb);
+                    Ok(g(f(x)))
+                }
+            }
+        };
+
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    // --- Identity ---
+
+    /// Apply composition for `Identity` (no short-circuit arm; always present):
+    /// `apply(apply(Identity(x), Identity(f)), Identity(g)) == Identity(g(f(x)))`.
+    #[test]
+    fn identity_apply_composition(
+        i in arb_identity_i32(),
+        (fa, fb) in arb_linear_closure_params(),
+        (ga, gb) in arb_linear_closure_params(),
+    ) {
+        let x = i.0;
+        let v = Identity(linear_cfn(fa, fb));
+        let u = Identity(linear_cfn(ga, gb));
+
+        // LHS: u <*> (v <*> w) == apply(apply(Identity(x), v), u)
+        let lhs = IdentityKind::apply(IdentityKind::apply(i, v), u);
+
+        // Ground truth.
+        let rhs = {
+            let mut f = linear_fn(fa, fb);
+            let mut g = linear_fn(ga, gb);
+            Identity(g(f(x)))
+        };
+
+        prop_assert_eq!(lhs, rhs);
+    }
+}

--- a/tests/kind/proptest_laws/functor.rs
+++ b/tests/kind/proptest_laws/functor.rs
@@ -1,0 +1,132 @@
+//! Functor law property tests for the kind-based data instances.
+//!
+//! Covers the **identity** and **composition** laws over the four
+//! property-testable data instances (Option, Result<i32, String>, Vec,
+//! Identity) — eight cells total. Companion to the example-based tests in
+//! `tests/kind/functor.rs`; the shared strategies live in the parent module
+//! (`super`) and are reused here, not redefined.
+//!
+//! Laws:
+//! - identity: `map(x, |a| a) == x`
+//! - composition: `map(x, |a| g(f(a))) == map(map(x, f), g)`
+//!
+//! The composition closures `f`/`g` are materialized from
+//! `arb_linear_closure_params` via `linear_fn` (rebuilt fresh per use because
+//! `CFn` is not `Clone`), using `wrapping_*` arithmetic to avoid overflow
+//! panics on arbitrary `i32` inputs.
+
+use super::{
+    arb_identity_i32, arb_linear_closure_params, arb_option_i32, arb_result_i32_string,
+    arb_vec_i32, linear_fn,
+};
+use monadify::functor::kind::Functor;
+use monadify::identity::IdentityKind;
+use monadify::kind_based::kind::{OptionKind, ResultKind, VecKind};
+use proptest::prelude::*;
+
+type TestError = String;
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    // --- Option ---
+
+    /// Functor identity for `Option`: `map(v, id) == v`.
+    #[test]
+    fn option_functor_identity(v in arb_option_i32()) {
+        prop_assert_eq!(OptionKind::map(v, |x| x), v);
+    }
+
+    /// Functor composition for `Option`: `map(v, g∘f) == map(map(v, f), g)`.
+    #[test]
+    fn option_functor_composition(
+        v in arb_option_i32(),
+        (fa, fb) in arb_linear_closure_params(),
+        (ga, gb) in arb_linear_closure_params(),
+    ) {
+        let composed = {
+            let mut f = linear_fn(fa, fb);
+            let mut g = linear_fn(ga, gb);
+            OptionKind::map(v, move |x| g(f(x)))
+        };
+        let sequential = OptionKind::map(OptionKind::map(v, linear_fn(fa, fb)), linear_fn(ga, gb));
+        prop_assert_eq!(composed, sequential);
+    }
+
+    // --- Result<i32, String> ---
+
+    /// Functor identity for `Result<i32, String>`: `map(r, id) == r`.
+    #[test]
+    fn result_functor_identity(r in arb_result_i32_string()) {
+        prop_assert_eq!(ResultKind::<TestError>::map(r.clone(), |x| x), r);
+    }
+
+    /// Functor composition for `Result<i32, String>`:
+    /// `map(r, g∘f) == map(map(r, f), g)`.
+    #[test]
+    fn result_functor_composition(
+        r in arb_result_i32_string(),
+        (fa, fb) in arb_linear_closure_params(),
+        (ga, gb) in arb_linear_closure_params(),
+    ) {
+        let composed = {
+            let mut f = linear_fn(fa, fb);
+            let mut g = linear_fn(ga, gb);
+            ResultKind::<TestError>::map(r.clone(), move |x| g(f(x)))
+        };
+        let sequential = ResultKind::<TestError>::map(
+            ResultKind::<TestError>::map(r, linear_fn(fa, fb)),
+            linear_fn(ga, gb),
+        );
+        prop_assert_eq!(composed, sequential);
+    }
+
+    // --- Vec ---
+
+    /// Functor identity for `Vec`: `map(v, id) == v`.
+    #[test]
+    fn vec_functor_identity(v in arb_vec_i32()) {
+        prop_assert_eq!(VecKind::map(v.clone(), |x| x), v);
+    }
+
+    /// Functor composition for `Vec`: `map(v, g∘f) == map(map(v, f), g)`.
+    #[test]
+    fn vec_functor_composition(
+        v in arb_vec_i32(),
+        (fa, fb) in arb_linear_closure_params(),
+        (ga, gb) in arb_linear_closure_params(),
+    ) {
+        let composed = {
+            let mut f = linear_fn(fa, fb);
+            let mut g = linear_fn(ga, gb);
+            VecKind::map(v.clone(), move |x| g(f(x)))
+        };
+        let sequential = VecKind::map(VecKind::map(v, linear_fn(fa, fb)), linear_fn(ga, gb));
+        prop_assert_eq!(composed, sequential);
+    }
+
+    // --- Identity ---
+
+    /// Functor identity for `Identity`: `map(i, id) == i`.
+    #[test]
+    fn identity_functor_identity(i in arb_identity_i32()) {
+        prop_assert_eq!(IdentityKind::map(i.clone(), |x| x), i);
+    }
+
+    /// Functor composition for `Identity`: `map(i, g∘f) == map(map(i, f), g)`.
+    #[test]
+    fn identity_functor_composition(
+        i in arb_identity_i32(),
+        (fa, fb) in arb_linear_closure_params(),
+        (ga, gb) in arb_linear_closure_params(),
+    ) {
+        let composed = {
+            let mut f = linear_fn(fa, fb);
+            let mut g = linear_fn(ga, gb);
+            IdentityKind::map(i.clone(), move |x| g(f(x)))
+        };
+        let sequential =
+            IdentityKind::map(IdentityKind::map(i, linear_fn(fa, fb)), linear_fn(ga, gb));
+        prop_assert_eq!(composed, sequential);
+    }
+}

--- a/tests/kind/proptest_laws/mod.rs
+++ b/tests/kind/proptest_laws/mod.rs
@@ -1,0 +1,85 @@
+//! Property-based (`proptest`) law-test harness for the kind-based data instances.
+//!
+//! Companion to the example-based tests in the sibling modules
+//! (`functor`, `apply`, `applicative`, `monad`). This module provides the
+//! reusable `proptest` strategies and closure generators shared by the
+//! law-family modules added in the next phase, plus a single smoke test that
+//! proves the harness compiles and runs under both the default and `legacy`
+//! feature matrices.
+//!
+//! Design reference:
+//! `.a5c/runs/01KW2RTB9JS5H05EYB7Z9P1YYY/artifacts/property-testing-design.md`.
+
+use monadify::function::CFn;
+use monadify::identity::Identity;
+use proptest::prelude::*;
+
+pub mod applicative;
+pub mod apply;
+pub mod functor;
+pub mod monad;
+
+// --- Arbitrary strategies (reusable across the law-family modules) ---
+
+/// `Option<i32>` exercising both the `Some` and `None` arms.
+pub fn arb_option_i32() -> impl Strategy<Value = Option<i32>> {
+    any::<Option<i32>>()
+}
+
+/// `Result<i32, String>` exercising both the `Ok` and `Err` arms with
+/// arbitrary error strings.
+pub fn arb_result_i32_string() -> impl Strategy<Value = Result<i32, String>> {
+    prop_oneof![any::<i32>().prop_map(Ok), ".*".prop_map(Err)]
+}
+
+/// `Vec<i32>` with a **bounded** length `0..=32` to keep cartesian / `flat_map`
+/// blow-up and runtime bounded for the Apply/Monad laws.
+pub fn arb_vec_i32() -> impl Strategy<Value = Vec<i32>> {
+    prop::collection::vec(any::<i32>(), 0..=32)
+}
+
+/// `Identity<i32>` wrapping an arbitrary `i32`.
+pub fn arb_identity_i32() -> impl Strategy<Value = Identity<i32>> {
+    any::<i32>().prop_map(Identity)
+}
+
+/// Slope/intercept `(a, b)` parameters used to materialize a deterministic
+/// linear closure `move |x| x.wrapping_mul(a).wrapping_add(b)`.
+///
+/// Closures are not `Arbitrary` and `CFn` is **not `Clone`**, so we never
+/// generate a closure value directly. Instead we generate scalar parameters and
+/// rebuild a fresh closure (and a fresh `CFn`) at each use site.
+pub fn arb_linear_closure_params() -> impl Strategy<Value = (i32, i32)> {
+    (any::<i32>(), any::<i32>())
+}
+
+// --- Closure builders (rebuilt per use because `CFn` is not `Clone`) ---
+
+/// Build a plain `FnMut(i32) -> i32 + Clone + 'static` from generated params.
+///
+/// `wrapping_*` arithmetic avoids overflow panics on arbitrary `i32` inputs.
+pub fn linear_fn(a: i32, b: i32) -> impl FnMut(i32) -> i32 + Clone + 'static {
+    move |x: i32| x.wrapping_mul(a).wrapping_add(b)
+}
+
+/// Fresh `CFn<i32, i32>` for Applicative `apply` (function-in-container) laws.
+///
+/// Rebuilt per use because `CFn` is not `Clone`.
+pub fn linear_cfn(a: i32, b: i32) -> CFn<i32, i32> {
+    CFn::new(move |x: i32| x.wrapping_mul(a).wrapping_add(b))
+}
+
+// --- Smoke test: proves the harness compiles and runs ---
+
+use monadify::functor::kind::Functor;
+use monadify::kind_based::kind::OptionKind;
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    /// Functor identity law for `Option`: `map(v, id) == v`.
+    #[test]
+    fn smoke_option_functor_identity(v in arb_option_i32()) {
+        prop_assert_eq!(OptionKind::map(v, |x| x), v);
+    }
+}

--- a/tests/kind/proptest_laws/monad.rs
+++ b/tests/kind/proptest_laws/monad.rs
@@ -1,0 +1,299 @@
+//! Monad law property tests for the kind-based data instances.
+//!
+//! Covers the **left-identity**, **right-identity** and **associativity** laws
+//! over the four property-testable Monad instances per the gap matrix — twelve
+//! cells total (Option, Result<i32, String>, Vec, Identity).
+//!
+//! `Vec`'s `bind` is `flat_map`, which moves each element through the Kleisli
+//! arrow without ever cloning a `CFn`, so `Vec` is property-testable for all
+//! three laws. `CFn` / `CFnOnce` / `ReaderT` are function-typed and remain
+//! example-only.
+//!
+//! Companion to the example-based tests in `tests/kind/monad.rs`; the shared
+//! strategies live in the parent module (`super`) and are reused here, not
+//! redefined.
+//!
+//! Laws (with `bind(m, f)` spelling `m >>= f`):
+//! - **left identity:** `bind(pure(a), f) == f(a)`
+//! - **right identity:** `bind(m, pure) == m`
+//! - **associativity:** `bind(bind(m, f), g) == bind(m, |x| bind(f(x), g))`
+//!
+//! The Kleisli arrows `f`/`g` return values *in* the monad and are materialized
+//! from generated scalar parameters (a presence/Ok flag, `linear_fn`
+//! slope/intercept pairs, and — for `Vec` — a small generated-length result),
+//! rebuilt fresh per use because `CFn` is not `Clone`. `wrapping_*` arithmetic
+//! (via `linear_fn`) avoids overflow panics on arbitrary `i32` inputs. The
+//! generated arms deliberately include the short-circuiting cases (`None`,
+//! `Err`, and the empty `Vec`).
+
+use super::{
+    arb_identity_i32, arb_linear_closure_params, arb_option_i32, arb_result_i32_string,
+    arb_vec_i32, linear_fn,
+};
+use monadify::applicative::kind::Applicative;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::kind_based::kind::{OptionKind, ResultKind, VecKind};
+use monadify::monad::kind::Bind;
+use proptest::prelude::*;
+
+type TestError = String;
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    // --- Option (Kleisli arrow short-circuits via `None`) ---
+
+    /// Monad left identity for `Option`: `bind(pure(a), f) == f(a)`.
+    #[test]
+    fn option_monad_left_identity(
+        a in any::<i32>(),
+        (fa, fb) in arb_linear_closure_params(),
+        present in any::<bool>(),
+    ) {
+        let f = move |x: i32| -> Option<i32> {
+            if present {
+                let mut lf = linear_fn(fa, fb);
+                Some(lf(x))
+            } else {
+                None
+            }
+        };
+        let lhs = OptionKind::bind(OptionKind::pure(a), f);
+        let rhs = f(a);
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Monad right identity for `Option`: `bind(m, pure) == m`.
+    #[test]
+    fn option_monad_right_identity(m in arb_option_i32()) {
+        let lhs = OptionKind::bind(m, |x: i32| OptionKind::pure(x));
+        prop_assert_eq!(lhs, m);
+    }
+
+    /// Monad associativity for `Option`:
+    /// `bind(bind(m, f), g) == bind(m, |x| bind(f(x), g))`.
+    #[test]
+    fn option_monad_associativity(
+        m in arb_option_i32(),
+        (fa, fb) in arb_linear_closure_params(),
+        (ga, gb) in arb_linear_closure_params(),
+        f_present in any::<bool>(),
+        g_present in any::<bool>(),
+    ) {
+        let f = move |x: i32| -> Option<i32> {
+            if f_present {
+                let mut lf = linear_fn(fa, fb);
+                Some(lf(x))
+            } else {
+                None
+            }
+        };
+        let g = move |y: i32| -> Option<i32> {
+            if g_present {
+                let mut lg = linear_fn(ga, gb);
+                Some(lg(y))
+            } else {
+                None
+            }
+        };
+
+        let lhs = OptionKind::bind(OptionKind::bind(m, f), g);
+
+        let f2 = f;
+        let g2 = g;
+        let rhs = OptionKind::bind(m, move |x: i32| OptionKind::bind(f2(x), g2));
+
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    // --- Result<i32, String> (Kleisli arrow short-circuits via `Err`) ---
+
+    /// Monad left identity for `Result<i32, String>`: `bind(pure(a), f) == f(a)`.
+    #[test]
+    fn result_monad_left_identity(
+        a in any::<i32>(),
+        (fa, fb) in arb_linear_closure_params(),
+        f_ok in any::<bool>(),
+        e in ".*",
+    ) {
+        let f = move |x: i32| -> Result<i32, TestError> {
+            if f_ok {
+                let mut lf = linear_fn(fa, fb);
+                Ok(lf(x))
+            } else {
+                Err(e.clone())
+            }
+        };
+        let lhs = ResultKind::<TestError>::bind(ResultKind::<TestError>::pure(a), f.clone());
+        let rhs = f(a);
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Monad right identity for `Result<i32, String>`: `bind(m, pure) == m`.
+    #[test]
+    fn result_monad_right_identity(m in arb_result_i32_string()) {
+        let lhs =
+            ResultKind::<TestError>::bind(m.clone(), |x: i32| ResultKind::<TestError>::pure(x));
+        prop_assert_eq!(lhs, m);
+    }
+
+    /// Monad associativity for `Result<i32, String>`:
+    /// `bind(bind(m, f), g) == bind(m, |x| bind(f(x), g))`.
+    #[test]
+    fn result_monad_associativity(
+        m in arb_result_i32_string(),
+        (fa, fb) in arb_linear_closure_params(),
+        (ga, gb) in arb_linear_closure_params(),
+        f_ok in any::<bool>(),
+        g_ok in any::<bool>(),
+        ef in ".*",
+        eg in ".*",
+    ) {
+        let f = move |x: i32| -> Result<i32, TestError> {
+            if f_ok {
+                let mut lf = linear_fn(fa, fb);
+                Ok(lf(x))
+            } else {
+                Err(ef.clone())
+            }
+        };
+        let g = move |y: i32| -> Result<i32, TestError> {
+            if g_ok {
+                let mut lg = linear_fn(ga, gb);
+                Ok(lg(y))
+            } else {
+                Err(eg.clone())
+            }
+        };
+
+        let lhs = ResultKind::<TestError>::bind(
+            ResultKind::<TestError>::bind(m.clone(), f.clone()),
+            g.clone(),
+        );
+
+        let f2 = f.clone();
+        let g2 = g.clone();
+        let rhs = ResultKind::<TestError>::bind(m, move |x: i32| {
+            ResultKind::<TestError>::bind(f2(x), g2.clone())
+        });
+
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    // --- Vec (flat_map cross product; includes the empty-vec case) ---
+
+    /// Monad left identity for `Vec`: `bind(pure(a), f) == f(a)`. The Kleisli
+    /// arrow yields a small generated-length `Vec` (including the empty case).
+    #[test]
+    fn vec_monad_left_identity(
+        a in any::<i32>(),
+        fparams in prop::collection::vec(arb_linear_closure_params(), 0..=3),
+    ) {
+        let f = move |x: i32| -> Vec<i32> {
+            fparams
+                .iter()
+                .map(|&(p, q)| {
+                    let mut lf = linear_fn(p, q);
+                    lf(x)
+                })
+                .collect()
+        };
+        let lhs = VecKind::bind(VecKind::pure(a), f.clone());
+        let rhs = f(a);
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Monad right identity for `Vec`: `bind(m, pure) == m`.
+    #[test]
+    fn vec_monad_right_identity(m in arb_vec_i32()) {
+        let lhs = VecKind::bind(m.clone(), |x: i32| VecKind::pure(x));
+        prop_assert_eq!(lhs, m);
+    }
+
+    /// Monad associativity for `Vec`:
+    /// `bind(bind(m, f), g) == bind(m, |x| bind(f(x), g))` — exercises the
+    /// `flat_map` cross product, including empty intermediate results.
+    #[test]
+    fn vec_monad_associativity(
+        m in arb_vec_i32(),
+        fparams in prop::collection::vec(arb_linear_closure_params(), 0..=3),
+        gparams in prop::collection::vec(arb_linear_closure_params(), 0..=3),
+    ) {
+        let f = move |x: i32| -> Vec<i32> {
+            fparams
+                .iter()
+                .map(|&(p, q)| {
+                    let mut lf = linear_fn(p, q);
+                    lf(x)
+                })
+                .collect()
+        };
+        let g = move |y: i32| -> Vec<i32> {
+            gparams
+                .iter()
+                .map(|&(p, q)| {
+                    let mut lg = linear_fn(p, q);
+                    lg(y)
+                })
+                .collect()
+        };
+
+        let lhs = VecKind::bind(VecKind::bind(m.clone(), f.clone()), g.clone());
+
+        let f2 = f.clone();
+        let g2 = g.clone();
+        let rhs = VecKind::bind(m, move |x: i32| VecKind::bind(f2(x), g2.clone()));
+
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    // --- Identity (no short-circuit arm) ---
+
+    /// Monad left identity for `Identity`: `bind(pure(a), f) == f(a)`.
+    #[test]
+    fn identity_monad_left_identity(
+        a in any::<i32>(),
+        (fa, fb) in arb_linear_closure_params(),
+    ) {
+        let f = move |x: i32| -> Identity<i32> {
+            let mut lf = linear_fn(fa, fb);
+            Identity(lf(x))
+        };
+        let lhs = IdentityKind::bind(IdentityKind::pure(a), f);
+        let rhs = f(a);
+        prop_assert_eq!(lhs, rhs);
+    }
+
+    /// Monad right identity for `Identity`: `bind(m, pure) == m`.
+    #[test]
+    fn identity_monad_right_identity(i in arb_identity_i32()) {
+        let lhs = IdentityKind::bind(i.clone(), |x: i32| IdentityKind::pure(x));
+        prop_assert_eq!(lhs, i);
+    }
+
+    /// Monad associativity for `Identity`:
+    /// `bind(bind(m, f), g) == bind(m, |x| bind(f(x), g))`.
+    #[test]
+    fn identity_monad_associativity(
+        i in arb_identity_i32(),
+        (fa, fb) in arb_linear_closure_params(),
+        (ga, gb) in arb_linear_closure_params(),
+    ) {
+        let f = move |x: i32| -> Identity<i32> {
+            let mut lf = linear_fn(fa, fb);
+            Identity(lf(x))
+        };
+        let g = move |y: i32| -> Identity<i32> {
+            let mut lg = linear_fn(ga, gb);
+            Identity(lg(y))
+        };
+
+        let lhs = IdentityKind::bind(IdentityKind::bind(i.clone(), f), g);
+
+        let f2 = f;
+        let g2 = g;
+        let rhs = IdentityKind::bind(i, move |x: i32| IdentityKind::bind(f2(x), g2));
+
+        prop_assert_eq!(lhs, rhs);
+    }
+}

--- a/tests/legacy/applicative.rs
+++ b/tests/legacy/applicative.rs
@@ -66,7 +66,7 @@ mod applicative_laws {
         let v = Some(10);
         assert_eq!(
             Apply::apply(
-                v.clone(),
+                v,
                 <Option<_> as Applicative<CFn<i32, i32>>>::pure(CFn::new(identity::<i32>))
             ),
             v
@@ -78,7 +78,7 @@ mod applicative_laws {
         let v: Option<i32> = None;
         assert_eq!(
             Apply::apply(
-                v.clone(),
+                v,
                 <Option<_> as Applicative<CFn<i32, i32>>>::pure(CFn::new(identity::<i32>))
             ),
             v
@@ -93,7 +93,7 @@ mod applicative_laws {
 
         assert_eq!(
             Apply::apply(
-                pure_x.clone(),
+                pure_x,
                 <Option<_> as Applicative<CFn<i32, i32>>>::pure(CFn::new(f))
             ),
             <Option<_> as Applicative<i32>>::pure(f(x))
@@ -145,7 +145,7 @@ mod applicative_laws {
         let f = |x: i32| x.to_string();
         let pure_f = <Option<_> as Applicative<CFn<i32, String>>>::pure(CFn::new(f));
 
-        let lhs = Functor::map(v.clone(), f); // clone v for map
+        let lhs = Functor::map(v, f); // clone v for map
         let rhs = Apply::apply(v, pure_f);
 
         assert_eq!(lhs, rhs);
@@ -158,7 +158,7 @@ mod applicative_laws {
         let f = |x: i32| x.to_string();
         let pure_f = <Option<_> as Applicative<CFn<i32, String>>>::pure(CFn::new(f));
 
-        let lhs = Functor::map(v.clone(), f); // clone v for map
+        let lhs = Functor::map(v, f); // clone v for map
         let rhs = Apply::apply(v, pure_f);
 
         assert_eq!(lhs, rhs);
@@ -254,7 +254,7 @@ mod result_applicative_laws {
 
         let u_for_rhs: Result<CFn<i32, i32>, String> = Ok(CFn::new(f));
         // The closure for map needs to capture y.
-        let y_clone_for_map = y.clone();
+        let y_clone_for_map = y;
         let rhs = Functor::map(u_for_rhs, move |f_func: CFn<i32, i32>| {
             (f_func).call(y_clone_for_map)
         });
@@ -272,7 +272,7 @@ mod result_applicative_laws {
             <Result<_, String> as Applicative<i32>>::pure(y),
             Err("function error".to_string()),
         );
-        let y_clone_for_map = y.clone();
+        let y_clone_for_map = y;
         let rhs = Functor::map(u, move |f_func: CFn<i32, i32>| {
             (f_func).call(y_clone_for_map)
         });
@@ -359,11 +359,9 @@ mod vec_applicative_laws {
         let u_lhs: Vec<CFn<i32, i32>> = vec![CFn::new(add_5), CFn::new(mul_2)];
         let lhs = Apply::apply(<Vec<_> as Applicative<i32>>::pure(y), u_lhs);
 
-        let y_cloned = y.clone();
+        let y_cloned = y;
         let u_rhs: Vec<CFn<i32, i32>> = vec![CFn::new(add_5), CFn::new(mul_2)];
-        let rhs = Functor::map(u_rhs, move |f_val: CFn<i32, i32>| {
-            (f_val).call(y_cloned.clone())
-        });
+        let rhs = Functor::map(u_rhs, move |f_val: CFn<i32, i32>| (f_val).call(y_cloned));
 
         assert_eq!(lhs, rhs);
         assert_eq!(lhs, vec![15, 20]);
@@ -377,10 +375,8 @@ mod vec_applicative_laws {
 
         let lhs = Apply::apply(<Vec<_> as Applicative<i32>>::pure(y), u_lhs);
 
-        let y_cloned = y.clone();
-        let rhs = Functor::map(u_rhs, move |f_val: CFn<i32, i32>| {
-            (f_val).call(y_cloned.clone())
-        });
+        let y_cloned = y;
+        let rhs = Functor::map(u_rhs, move |f_val: CFn<i32, i32>| (f_val).call(y_cloned));
 
         assert_eq!(lhs, rhs);
         assert_eq!(lhs, Vec::<i32>::new());

--- a/tests/legacy/apply.rs
+++ b/tests/legacy/apply.rs
@@ -9,7 +9,7 @@ mod classic_apply_tests {
         let closure = monadify::fn2!(|x: i32| move |y: i8| format!("{x}{y}"));
         // Option::map uses Functor trait
         let some_closure =
-            <Option<i32> as monadify::legacy::functor::Functor<i32>>::map(Some(1), closure.clone());
+            <Option<i32> as monadify::legacy::functor::Functor<i32>>::map(Some(1), closure);
         let none_closure =
             <Option<i32> as monadify::legacy::functor::Functor<i32>>::map(None, closure);
 
@@ -25,7 +25,7 @@ mod classic_apply_tests {
 
         let closure_lift = monadify::fn2!(|x: i32| move |y: i8| format!("{x}{y}"));
         assert_eq!(
-            monadify::legacy::apply::lift2(closure_lift.clone(), Some(1), Some(2)),
+            monadify::legacy::apply::lift2(closure_lift, Some(1), Some(2)),
             Some("12".to_string())
         );
         assert_eq!(

--- a/tests/legacy/functor.rs
+++ b/tests/legacy/functor.rs
@@ -58,7 +58,7 @@ mod classic_functor_tests {
             let f = |x: i32| x * 2;
             let g = |y: i32| y + 5;
 
-            let composed_map = <Option<i32> as Functor<i32>>::map(opt.clone(), move |x| g(f(x)));
+            let composed_map = <Option<i32> as Functor<i32>>::map(opt, move |x| g(f(x)));
             let sequential_map = <Option<i32> as Functor<i32>>::map(opt.map(f), g);
 
             assert_eq!(composed_map, sequential_map);
@@ -71,7 +71,7 @@ mod classic_functor_tests {
             let f = |x: i32| x * 2;
             let g = |y: i32| y + 5;
 
-            let composed_map = <Option<i32> as Functor<i32>>::map(opt.clone(), move |x| g(f(x)));
+            let composed_map = <Option<i32> as Functor<i32>>::map(opt, move |x| g(f(x)));
             let sequential_map = <Option<i32> as Functor<i32>>::map(opt.map(f), g);
 
             assert_eq!(composed_map, sequential_map);
@@ -151,8 +151,7 @@ mod classic_functor_tests {
             let f = |x: &str| x.to_uppercase();
             let g = |y: String| y.len();
 
-            let composed_map =
-                <Result<&str, u32> as Functor<&str>>::map(res.clone(), move |x| g(f(x)));
+            let composed_map = <Result<&str, u32> as Functor<&str>>::map(res, move |x| g(f(x)));
             let sequential_map = <Result<String, u32> as Functor<String>>::map(res.map(f), g);
 
             assert_eq!(composed_map, sequential_map);
@@ -165,8 +164,7 @@ mod classic_functor_tests {
             let f = |x: &str| x.to_uppercase();
             let g = |y: String| y.len();
 
-            let composed_map =
-                <Result<&str, u32> as Functor<&str>>::map(res.clone(), move |x| g(f(x)));
+            let composed_map = <Result<&str, u32> as Functor<&str>>::map(res, move |x| g(f(x)));
             let sequential_map = <Result<String, u32> as Functor<String>>::map(res.map(f), g);
 
             assert_eq!(composed_map, sequential_map);

--- a/tests/legacy/monad.rs
+++ b/tests/legacy/monad.rs
@@ -113,8 +113,7 @@ mod monad_laws {
         let f = |x: i32| -> Option<f64> { Some((x * 2) as f64) };
         let g = |y: f64| -> Option<String> { Some(y.to_string()) };
 
-        let lhs =
-            <Option<f64> as Bind<f64>>::bind(<Option<i32> as Bind<i32>>::bind(m.clone(), f), g);
+        let lhs = <Option<f64> as Bind<f64>>::bind(<Option<i32> as Bind<i32>>::bind(m, f), g);
 
         let f_inner = |x: i32| -> Option<f64> { Some((x * 2) as f64) };
         let g_inner = |y: f64| -> Option<String> { Some(y.to_string()) };
@@ -131,8 +130,7 @@ mod monad_laws {
         let f = |x: i32| -> Option<f64> { Some((x * 2) as f64) };
         let g = |y: f64| -> Option<String> { Some(y.to_string()) };
 
-        let lhs =
-            <Option<f64> as Bind<f64>>::bind(<Option<i32> as Bind<i32>>::bind(m.clone(), f), g);
+        let lhs = <Option<f64> as Bind<f64>>::bind(<Option<i32> as Bind<i32>>::bind(m, f), g);
 
         let f_inner = |x: i32| -> Option<f64> { Some((x * 2) as f64) };
         let g_inner = |y: f64| -> Option<String> { Some(y.to_string()) };
@@ -149,8 +147,7 @@ mod monad_laws {
         let f = |_x: i32| -> Option<f64> { None };
         let g = |y: f64| -> Option<String> { Some(y.to_string()) };
 
-        let lhs =
-            <Option<f64> as Bind<f64>>::bind(<Option<i32> as Bind<i32>>::bind(m.clone(), f), g);
+        let lhs = <Option<f64> as Bind<f64>>::bind(<Option<i32> as Bind<i32>>::bind(m, f), g);
 
         let f_inner = |_x: i32| -> Option<f64> { None };
         let g_inner = |y: f64| -> Option<String> { Some(y.to_string()) };
@@ -167,8 +164,7 @@ mod monad_laws {
         let f = |x: i32| -> Option<f64> { Some((x * 2) as f64) };
         let g = |_y: f64| -> Option<String> { None };
 
-        let lhs =
-            <Option<f64> as Bind<f64>>::bind(<Option<i32> as Bind<i32>>::bind(m.clone(), f), g);
+        let lhs = <Option<f64> as Bind<f64>>::bind(<Option<i32> as Bind<i32>>::bind(m, f), g);
 
         let f_inner = |x: i32| -> Option<f64> { Some((x * 2) as f64) };
         let g_inner = |_y: f64| -> Option<String> { None };

--- a/tests/profunctor.rs
+++ b/tests/profunctor.rs
@@ -346,7 +346,7 @@ mod choice_laws {
             move |r: Result<X, u16>| map_result(f, r),    // Added move
             move |r: Result<X, String>| map_result(g, r), // Added move
         );
-        let lhs_result_err = lhs_p_err(input_err.clone());
+        let lhs_result_err = lhs_p_err(input_err);
 
         // --- RHS ---
         // Calculate RHS for Err input
@@ -366,7 +366,7 @@ mod choice_laws {
             move |r: Result<X, u16>| map_result(f, r),    // Added move
             move |r: Result<X, String>| map_result(g, r), // Added move
         );
-        let lhs_result_ok = lhs_p_ok(input_ok.clone());
+        let lhs_result_ok = lhs_p_ok(input_ok);
 
         // Calculate RHS for Ok input
         let p_rhs_ok: CFn<i32, String> = CFn::new(|x| format!("Value: {x}"));
@@ -409,7 +409,7 @@ mod choice_laws {
             move |r: Result<u16, X>| map_result_right(f, r), // Added move
             move |r: Result<String, X>| map_result_right(g, r), // Added move
         );
-        let lhs_result_ok = lhs_p_ok(input_ok.clone());
+        let lhs_result_ok = lhs_p_ok(input_ok);
 
         // --- RHS ---
         // Calculate RHS for Ok input
@@ -429,7 +429,7 @@ mod choice_laws {
             move |r: Result<u16, X>| map_result_right(f, r), // Added move
             move |r: Result<String, X>| map_result_right(g, r), // Added move
         );
-        let lhs_result_err = lhs_p_err(input_err.clone());
+        let lhs_result_err = lhs_p_err(input_err);
 
         // Calculate RHS for Err input
         let p_rhs_err: CFn<i32, String> = CFn::new(|x| format!("Value: {x}"));


### PR DESCRIPTION
## Summary

Adds Haskell-style **`do` notation** to monadify via a new `mdo!` procedural macro, so monadic code reads as flat, sequential bind-blocks instead of nested `bind`/`and_then` closures.

```rust
// before
OptionKind::bind(parse_age(s), move |age|
    OptionKind::bind(check_adult(age), move |age| OptionKind::pure(age)))

// after
mdo! { OptionKind;
    age <- parse_age(s);
    guard(age >= 18);
    OptionKind::pure(age)
}
```

### What's included
- **`monadify-macros`** — new proc-macro crate exporting `mdo!`, re-exported from `monadify` behind the **non-default `do-notation` feature**. Default features stay **zero-dependency** (enforced by a CI `cargo tree` guard job).
- **Desugaring** — `mdo! { Marker; x <- ma; let y = ..; guard(cond); Marker::pure(expr) }` right-folds into nested `Marker::bind((rhs).clone(), move |pat| ..)` over the existing `Bind`/`Applicative` hierarchy. The Kind marker is **explicit** (the GAT `Of` is non-injective, so inference is impossible).
- **Instances** — Option, Result, Vec, Identity, ReaderT. `guard` is sealed to Option/Vec (the lawful zeros). `CFn`/`CFnOnce` are documented out of scope (not `Clone`) with a future `RcFn` lift path.
- **Tests** — per-instance do-block + equivalence proptests, monad-law preservation through `mdo!` (left/right identity + associativity for Option/Result/Vec/Identity), and macro-hygiene edge cases (shadowing, nested blocks, guard-on-empty, evaluation order).
- **Showcase** — `examples/{validation,reader_config,list_comprehension}.rs`, a README "Do notation" section, and macro docs with a `# Limitations` note.
- **MSRV 1.66** — preserved via version caps in `monadify-macros/Cargo.toml` (`syn`/`quote`/`proc-macro2`/`unicode-ident`), verified against a fresh lockfile, so the guarantee holds for CI and downstream without a committed `Cargo.lock`.
- **CI** — added a `do-notation` test leg and a `zero-dep` guard job.

### Note on commits
This branch is based on `c00ad95` (proptest law tests), which is not yet on `main` — the do-notation law tests reuse its `proptest_laws` strategies. The PR therefore includes **both** commits.

## Test plan
- [x] `cargo test --workspace --all-features` (default suite green)
- [x] `cargo test --features legacy` (legacy matrix green)
- [x] `cargo test --features do-notation` (do-notation + law + hygiene tests)
- [x] `cargo fmt --all --check` + `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo +1.66.0 check --workspace --all-features` (MSRV, fresh lockfile)
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo run --all-features --example {validation,reader_config,list_comprehension}`
- [x] `cargo tree -e normal` (default features) shows no `syn`/`quote`/`proc-macro2`