### PR TITLE
feat(mdo): accept bare pure(x) resolving to the block marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ let result: Option<i32> = mdo! {
     x <- Some(2);
     y <- Some(3);
     guard(x + y > 0);      // filters; short-circuits if false
-    OptionKind::pure(x + y)  // == Some(5)
+    pure(x + y)            // bare `pure(...)` resolves to OptionKind::pure, == Some(5)
 };
 assert_eq!(result, Some(5));
 ```
@@ -110,7 +110,8 @@ assert_eq!(result, Some(5));
 
 Run with: `cargo run --example validation --features do-notation`
 
-**Limitations**:
+**Limitations and notes**:
+- `pure` is a reserved free-call head inside `mdo!` blocks (rewritten to `Marker::pure`); use `::pure`-qualified or `.pure()` method syntax to bypass
 - `CFn` / `CFnOnce` unsupported (they are not `Clone`)
 - At most one non-`Copy` external value per `mdo!` nesting level (closure capture constraint)
 

--- a/examples/list_comprehension.rs
+++ b/examples/list_comprehension.rs
@@ -5,7 +5,7 @@
 //!
 //! Run with: `cargo run --example list_comprehension --features do-notation`
 
-use monadify::{mdo, Applicative, VecKind};
+use monadify::{mdo, VecKind};
 
 /// ─────────────────────────────────────────────────────────────────────────────
 /// BEFORE: Nested flat_map and filter chains (imperative-looking but cluttered)
@@ -39,7 +39,7 @@ fn pythagorean_triples_after(limit: i32) -> Vec<(i32, i32, i32)> {
         b <- (1..=limit).collect::<Vec<_>>();
         c <- (1..=limit).collect::<Vec<_>>();
         guard(a * a + b * b == c * c);
-        VecKind::pure((a, b, c))
+        pure((a, b, c))
     }
 }
 
@@ -49,7 +49,7 @@ fn even_numbers(n: i32) -> Vec<i32> {
         VecKind;
         x <- (1..=n).collect::<Vec<_>>();
         guard(x % 2 == 0);
-        VecKind::pure(x)
+        pure(x)
     }
 }
 
@@ -61,7 +61,7 @@ fn sum_pairs_under_10(max_x: i32, max_y: i32) -> Vec<(i32, i32)> {
         x <- (1..=max_x).collect::<Vec<_>>();
         y <- (1..=max_y).collect::<Vec<_>>();
         guard(x + y <= 10);
-        VecKind::pure((x, y))
+        pure((x, y))
     }
 }
 
@@ -70,7 +70,7 @@ fn repeated_digit_numbers() -> Vec<i32> {
     mdo! {
         VecKind;
         digit <- (1..=9).collect::<Vec<_>>();
-        VecKind::pure(digit * 10 + digit)
+        pure(digit * 10 + digit)
     }
 }
 
@@ -81,7 +81,7 @@ fn points_near_origin(max_x: i32, max_y: i32, max_distance_sq: i32) -> Vec<(i32,
         x <- (-max_x..=max_x).collect::<Vec<_>>();
         y <- (-max_y..=max_y).collect::<Vec<_>>();
         guard(x * x + y * y <= max_distance_sq);
-        VecKind::pure((x, y))
+        pure((x, y))
     }
 }
 
@@ -91,7 +91,7 @@ fn multiples_of_3_xor_5(n: i32) -> Vec<i32> {
         VecKind;
         x <- (1..=n).collect::<Vec<_>>();
         guard((x % 3 == 0 && x % 5 != 0) || (x % 3 != 0 && x % 5 == 0));
-        VecKind::pure(x)
+        pure(x)
     }
 }
 

--- a/examples/reader_config.rs
+++ b/examples/reader_config.rs
@@ -6,8 +6,8 @@
 //! Run with: `cargo run --example reader_config --features do-notation`
 
 use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
 use monadify::transformers::reader::{MonadReader, Reader, ReaderT, ReaderTKind};
-use monadify::{mdo, Applicative};
 
 /// Application configuration: base rate and scaling factor.
 #[derive(Clone, Debug, PartialEq)]
@@ -69,7 +69,7 @@ fn compute_pricing() -> ConfigReader<String> {
         factor <- get_scaling_factor();
         adjusted <- compute_adjusted_rate(base, factor);
         let label = format!("Base: {:.2}, Factor: {:.2}, Adjusted: {:.2}", base, factor, adjusted);
-        ReaderKind::pure(label)
+        pure(label)
     }
 }
 
@@ -83,7 +83,7 @@ fn compute_pricing_with_ask() -> ConfigReader<String> {
             "Config-based: Base={:.2}, Factor={:.2}, Adjusted={:.2}",
             cfg.base_rate, cfg.scaling_factor, adjusted
         );
-        ReaderKind::pure(label)
+        pure(label)
     }
 }
 
@@ -94,7 +94,7 @@ fn multi_step_pricing() -> ConfigReader<(f64, f64, f64)> {
         base <- get_base_rate();
         factor <- get_scaling_factor();
         adjusted <- compute_adjusted_rate(base, factor);
-        ReaderKind::pure((base, factor, adjusted))
+        pure((base, factor, adjusted))
     }
 }
 

--- a/examples/validation.rs
+++ b/examples/validation.rs
@@ -5,7 +5,7 @@
 //!
 //! Run with: `cargo run --example validation --features do-notation`
 
-use monadify::{mdo, Applicative, OptionKind, ResultKind};
+use monadify::{mdo, OptionKind, ResultKind};
 
 /// Check if a number is in a valid range.
 fn validate_range(n: i32, min: i32, max: i32) -> Option<i32> {
@@ -61,7 +61,7 @@ fn process_numbers_after(a: i32, b: i32) -> Option<ValidationResult> {
         b_val <- is_positive(b);
         a_checked <- validate_range(a_val, 1, 100);
         b_checked <- validate_range(b_val, 1, 100);
-        OptionKind::pure(ValidationResult {
+        pure(ValidationResult {
             original: a_checked + b_checked,
             squared: a_checked * a_checked + b_checked * b_checked,
             sum: a_checked + b_checked,
@@ -93,7 +93,7 @@ fn process_numbers_with_errors(a: i32, b: i32) -> Result<ValidationResult, Strin
         } else {
             Err(format!("Second number {} exceeds max 100", b_val))
         };
-        ResultKind::<String>::pure(ValidationResult {
+        pure(ValidationResult {
             original: a_checked + b_checked,
             squared: a_checked * a_checked + b_checked * b_checked,
             sum: a_checked + b_checked,

--- a/monadify-macros/src/lib.rs
+++ b/monadify-macros/src/lib.rs
@@ -29,8 +29,8 @@
 //! re-export), where it can depend on `monadify` without a build cycle.
 
 use proc_macro::TokenStream;
-use proc_macro2::{Delimiter, Spacing, Span, TokenStream as TokenStream2, TokenTree};
-use quote::{quote, ToTokens};
+use proc_macro2::{Delimiter, Group, Spacing, Span, TokenStream as TokenStream2, TokenTree};
+use quote::{quote, quote_spanned, ToTokens};
 use syn::parse::{Parse, ParseStream, Parser};
 use syn::{Error, Expr, Pat, Result as SynResult, Token, Type};
 
@@ -53,6 +53,123 @@ struct MdoInput {
     final_expr: Expr,
 }
 
+/// Returns `true` if `tt` is a `:` punctuation token.
+fn is_colon(tt: &TokenTree) -> bool {
+    matches!(tt, TokenTree::Punct(p) if p.as_char() == ':')
+}
+
+/// Returns `true` if `tt` is a `:` punctuation token with `Spacing::Joint`
+/// (i.e., the first `:` of a `::` digraph).
+fn is_colon_joint(tt: &TokenTree) -> bool {
+    matches!(tt, TokenTree::Punct(p) if p.as_char() == ':' && p.spacing() == Spacing::Joint)
+}
+
+/// Returns `true` if `tt` is a `.` punctuation token.
+fn is_dot(tt: &TokenTree) -> bool {
+    matches!(tt, TokenTree::Punct(p) if p.as_char() == '.')
+}
+
+/// Rewrites every bare `pure(...)` call-head in `ts` to
+/// `<marker as ::monadify::Applicative<_>>::pure`, leaving qualified forms
+/// (`::pure`, `.pure`, or `pure` not followed by `(`) unchanged.
+///
+/// The walk is fully recursive: inner groups (parentheses, brackets, braces)
+/// are descended into so that nested forms like `foo(pure(3))` and
+/// `pure(pure(1))` are both handled correctly.
+///
+/// # Suppression rules (two-token look-behind)
+///
+/// The rewriter tracks the **last two emitted tokens** to distinguish the
+/// three digraph pairs that share a single-character prefix with valid
+/// separators:
+///
+/// - **`::pure` path qualifier** (suppress): the token immediately before
+///   `pure` is `:`, AND the token before that is also `:` with
+///   `Spacing::Joint`.  A lone `:` (struct-field colon) does NOT meet the
+///   second condition and must NOT suppress — `Foo { f: pure(x) }` should
+///   be rewritten.
+///
+/// - **`.pure` method call** (suppress): the token immediately before `pure`
+///   is `.`, AND the token before that is NOT `.`.  A `..` (range / struct
+///   update), where the preceding token IS `.`, must NOT suppress —
+///   `..pure(base)` should be rewritten.
+///
+/// - **next token is NOT `(`** (suppress): `pure` is not a call expression
+///   and is emitted unchanged.
+fn rewrite_pure(ts: TokenStream2, marker: &Type) -> TokenStream2 {
+    let mut out = TokenStream2::new();
+    // Peekable so we can inspect the token after `pure` without consuming it.
+    let mut iter = ts.into_iter().peekable();
+
+    // Two-token look-behind.
+    // `prev_*`  describes the most recently emitted token.
+    // `prev2_*` describes the token emitted before that.
+    let mut prev_is_colon = false;
+    let mut prev_colon_is_joint = false; // only meaningful when prev_is_colon
+    let mut prev_is_dot = false;
+    let mut prev2_is_colon_joint = false; // prev2 was `:` Spacing::Joint
+    let mut prev2_is_dot = false; // prev2 was `.`
+
+    while let Some(tt) = iter.next() {
+        // -- Detect bare `pure` ident eligible for rewriting ------------------
+        if let TokenTree::Ident(ref id) = tt {
+            if id == "pure" {
+                let next_is_paren = matches!(
+                    iter.peek(),
+                    Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Parenthesis
+                );
+                if next_is_paren {
+                    // `::pure`: prev is `:` AND prev2 is `:` Joint.
+                    // A lone `:` (struct-field) has prev2_is_colon_joint=false.
+                    let is_path_qual = prev_is_colon && prev2_is_colon_joint;
+                    // `.pure`: prev is `.` AND prev2 is NOT `.`.
+                    // `..pure` has prev2_is_dot=true, so it is NOT suppressed.
+                    let is_method = prev_is_dot && !prev2_is_dot;
+
+                    if !is_path_qual && !is_method {
+                        // Emit qualified UFCS path, carrying the ident's span
+                        // for better error locality.
+                        let span = id.span();
+                        let rewritten = quote_spanned! { span =>
+                            <#marker as ::monadify::Applicative<_>>::pure
+                        };
+                        out.extend(rewritten);
+                        // Update history: `pure` ident is not a `:` or `.`.
+                        prev2_is_colon_joint = prev_is_colon && prev_colon_is_joint;
+                        prev2_is_dot = prev_is_dot;
+                        prev_is_colon = false;
+                        prev_colon_is_joint = false;
+                        prev_is_dot = false;
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // -- Update two-token history with `tt` before emitting it ------------
+        prev2_is_colon_joint = prev_is_colon && prev_colon_is_joint;
+        prev2_is_dot = prev_is_dot;
+        prev_is_colon = is_colon(&tt);
+        prev_colon_is_joint = is_colon_joint(&tt);
+        prev_is_dot = is_dot(&tt);
+
+        // -- Recurse into groups; emit everything else verbatim ----------------
+        match tt {
+            TokenTree::Group(g) => {
+                let inner = rewrite_pure(g.stream(), marker);
+                let mut new_g = Group::new(g.delimiter(), inner);
+                new_g.set_span(g.span());
+                out.extend(std::iter::once(TokenTree::Group(new_g)));
+            }
+            other => {
+                out.extend(std::iter::once(other));
+            }
+        }
+    }
+
+    out
+}
+
 /// Returns the index of a top-level `<-` (a `<` joined to a following `-`).
 fn find_left_arrow(tokens: &[TokenTree]) -> Option<usize> {
     for i in 0..tokens.len().saturating_sub(1) {
@@ -66,7 +183,12 @@ fn find_left_arrow(tokens: &[TokenTree]) -> Option<usize> {
 }
 
 /// Classify one statement segment (tokens between top-level `;`) into a [`Stmt`].
-fn classify(tokens: Vec<TokenTree>) -> SynResult<Stmt> {
+///
+/// `marker` is the block's Kind marker type; it is forwarded to [`rewrite_pure`]
+/// so that bare `pure(…)` calls in Bind, Bare, and Guard positions are rewritten
+/// to `<marker as ::monadify::Applicative<_>>::pure(…)` before parsing.
+/// Plain `let` bodies are explicitly **not** rewritten (the spec carve-out).
+fn classify(tokens: Vec<TokenTree>, marker: &Type) -> SynResult<Stmt> {
     if tokens.is_empty() {
         return Err(Error::new(
             Span::call_site(),
@@ -77,25 +199,26 @@ fn classify(tokens: Vec<TokenTree>) -> SynResult<Stmt> {
     // 1. `pat <- expr` — highest priority (the `<-` is unambiguous).
     if let Some(idx) = find_left_arrow(&tokens) {
         let pat_ts: TokenStream2 = tokens[..idx].iter().cloned().collect();
-        let expr_ts: TokenStream2 = tokens[idx + 2..].iter().cloned().collect();
+        let raw_expr_ts: TokenStream2 = tokens[idx + 2..].iter().cloned().collect();
         if pat_ts.is_empty() {
             return Err(Error::new(
                 tokens[idx].span(),
                 "mdo! bind requires a pattern before `<-`",
             ));
         }
-        if expr_ts.is_empty() {
+        if raw_expr_ts.is_empty() {
             return Err(Error::new(
                 tokens[idx].span(),
                 "mdo! bind requires a monadic expression after `<-`",
             ));
         }
         let pat = Pat::parse_single.parse2(pat_ts)?;
+        let expr_ts = rewrite_pure(raw_expr_ts, marker);
         let expr: Expr = syn::parse2(expr_ts)?;
         return Ok(Stmt::Bind(pat, expr));
     }
 
-    // 2. `let …` — keep verbatim.
+    // 2. `let …` — keep verbatim (no bare-pure rewrite inside plain let bodies).
     if let TokenTree::Ident(id) = &tokens[0] {
         if id == "let" {
             return Ok(Stmt::Let(tokens.into_iter().collect()));
@@ -104,14 +227,16 @@ fn classify(tokens: Vec<TokenTree>) -> SynResult<Stmt> {
         if id == "guard" && tokens.len() == 2 {
             if let TokenTree::Group(g) = &tokens[1] {
                 if g.delimiter() == Delimiter::Parenthesis {
-                    return Ok(Stmt::Guard(g.stream()));
+                    return Ok(Stmt::Guard(rewrite_pure(g.stream(), marker)));
                 }
             }
         }
     }
 
-    // 4. bare expression (sequencing).
-    let expr: Expr = syn::parse2(tokens.into_iter().collect())?;
+    // 4. bare expression (sequencing) — rewrite pure before parsing.
+    let raw_ts: TokenStream2 = tokens.into_iter().collect();
+    let expr_ts = rewrite_pure(raw_ts, marker);
+    let expr: Expr = syn::parse2(expr_ts)?;
     Ok(Stmt::Bare(expr))
 }
 
@@ -183,11 +308,13 @@ impl Parse for MdoInput {
                 "the final line of an mdo! block must be a raw monadic value, not a `<-` bind",
             ));
         }
-        let final_expr: Expr = syn::parse2(final_tokens.into_iter().collect())?;
+        // Apply bare-pure rewriting to the final expression before parsing it.
+        let final_raw_ts: TokenStream2 = final_tokens.into_iter().collect();
+        let final_expr: Expr = syn::parse2(rewrite_pure(final_raw_ts, &marker))?;
 
         let mut stmts = Vec::with_capacity(segments.len());
         for (tokens, _) in segments {
-            stmts.push(classify(tokens)?);
+            stmts.push(classify(tokens, &marker)?);
         }
 
         Ok(MdoInput {
@@ -217,6 +344,31 @@ impl Parse for MdoInput {
 /// Each non-final monadic right-hand side is cloned (`(expr).clone()`) because
 /// `bind`'s closure is `FnMut + Clone + 'static` and `VecKind::bind` re-invokes
 /// it per element. The final expression is returned raw as `Marker::Of<B>`.
+///
+/// # The `pure` keyword
+///
+/// Inside an `mdo!` block, any bare call of the form `pure(expr)` — where
+/// `pure` appears as a free identifier immediately followed by a `(`-group —
+/// is automatically rewritten to
+/// `<Marker as ::monadify::Applicative<_>>::pure(expr)`.
+///
+/// The rewriter uses two-token look-behind to avoid false positives:
+///
+/// - `pure` is **not** rewritten when `::` -qualified: `Marker::pure(x)` is
+///   left verbatim (the two preceding `:` tokens form the `::` digraph).
+/// - `pure` is **not** rewritten when called as a method: `x.pure(y)` is
+///   left verbatim (a lone `.` precedes `pure` and the token before that is
+///   not another `.`).
+/// - `pure` in a struct-field position (`Foo { f: pure(x) }`) **is**
+///   rewritten — the single `:` before `pure` is distinct from `::` because
+///   no Joint `:` precedes it.
+/// - `pure` after `..` (`..pure(base)`) **is** rewritten — the double `.`
+///   forms a range/struct-update digraph, not a method receiver.
+/// - `pure::<T>(x)` is **not** rewritten — the next token after `pure` is
+///   `<`, not `(`, so the call-shape guard prevents rewriting.
+/// - `let`-body carve-out is statement-level only: `let x = pure(v)` inside
+///   an `mdo!` block is a `Stmt::Let` and the right-hand side is **not**
+///   rewritten. Use `x <- pure(v)` (bind) instead.
 ///
 /// # Limitations
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,10 +83,13 @@ pub mod do_notation;
 ///     x <- Some(2);
 ///     y <- Some(3);
 ///     guard(x + y > 0);
-///     OptionKind::pure(x + y)      // raw monadic value, == Some(5)
+///     pure(x + y)      // bare `pure(...)` resolves to OptionKind::pure, == Some(5)
 /// };
 /// assert_eq!(r, Some(5));
 /// ```
+///
+/// Inside an `mdo!` block, any bare `pure(expr)` — not `::` -qualified or a
+/// method call — is automatically rewritten to the block's marker's `Applicative::pure`.
 ///
 /// # Limitations
 ///

--- a/tests/kind/do_notation/auto_pure.rs
+++ b/tests/kind/do_notation/auto_pure.rs
@@ -1,0 +1,887 @@
+//! `mdo!` bare-`pure` auto-lift tests — **RED phase**.
+//!
+//! These tests verify the *not-yet-implemented* feature where a bare `pure(expr)`
+//! call inside an `mdo!` block is automatically rewritten by the macro to
+//! `<Marker as ::monadify::Applicative>::pure(expr)`.
+//!
+//! ## RED rationale
+//!
+//! The current `mdo!` macro passes each monadic-position expression through
+//! verbatim — it has no special handling for the identifier `pure`.  A bare
+//! `pure(…)` call therefore references a nonexistent free function and fails:
+//!
+//! ```text
+//! error[E0425]: cannot find function `pure` in this scope
+//! ```
+//!
+//! Every `#[test]` function that uses bare `pure(…)` will produce this compile
+//! error until the macro's token-walk rewriter is implemented.  The
+//! backward-compatibility tests use only `Marker::pure(…)`, which already
+//! compiles in isolation, but they reside in the same file, so the entire file
+//! fails to compile in the RED phase.
+//!
+//! ## Covered monadic-expression positions
+//!
+//! For each instance the tests exercise bare `pure(…)` in all four positions
+//! mandated by the feature specification:
+//!
+//! 1. **Final line** — `pure(expr)` as the trailing, non-`;` expression.
+//! 2. **Bind RHS** — `x <- pure(expr)`.
+//! 3. **Bare sequencing** — `pure(())` as a semicolon-terminated statement with
+//!    no bind variable (the value is discarded via the `move |_|` continuation).
+//! 4. **Nested** — `pure(expr)` as a sub-expression inside another call, e.g.
+//!    `x <- std::convert::identity(pure(3))`.  The macro must recursively walk
+//!    the token stream of the bind RHS to reach it.
+//!
+//! Plus backward-compatibility (qualified `Marker::pure(…)` unchanged) and,
+//! for `OptionKind` and `VecKind`, guard interaction.
+//!
+//! ## Instances covered
+//!
+//! - `OptionKind` (7 tests + guard interaction × 2)
+//! - `ResultKind<String>` (5 tests)
+//! - `VecKind` (5 tests + guard interaction × 2)
+//! - `IdentityKind` (5 tests)
+//! - `ReaderTKind<Config, IdentityKind>` (5 tests)
+
+use monadify::applicative::kind::Applicative;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::kind_based::kind::{OptionKind, ResultKind, VecKind};
+use monadify::mdo;
+use monadify::monad::kind::Bind;
+use monadify::transformers::reader::{Reader, ReaderT, ReaderTKind};
+
+// ── ReaderT test infrastructure ───────────────────────────────────────────────
+
+/// Minimal read-only configuration environment for all `ReaderT` tests in this file.
+#[derive(Clone, Debug, PartialEq)]
+struct Config {
+    base: i32,
+    factor: i32,
+}
+
+/// Kind marker alias for `ReaderTKind<Config, IdentityKind>`.
+type ReaderKind = ReaderTKind<Config, IdentityKind>;
+
+/// `ReaderT<Config, IdentityKind, A>` — a computation `Config -> Identity<A>`.
+type ConfigReader<A> = Reader<Config, A>;
+
+/// Run a `ConfigReader<i32>` against `cfg` and unwrap the `Identity`.
+fn run_i32(computation: &ConfigReader<i32>, cfg: Config) -> i32 {
+    let Identity(value) = (computation.run_reader_t)(cfg);
+    value
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// OptionKind
+// ═════════════════════════════════════════════════════════════════════════════
+//
+// RED: all tests below that use bare `pure(…)` fail with E0425 today.
+
+// ── 1. Final-position bare pure ───────────────────────────────────────────────
+
+/// Bare `pure(x + y)` in the final line must resolve to `OptionKind::pure(x + y)`
+/// and yield the same result as the hand-written nested bind with qualified pure.
+///
+/// RED: `pure(x + y)` → E0425 until the token-walk rewriter is implemented.
+#[test]
+fn option_final_bare_pure_eq_qualified() {
+    // LHS: bare pure in final position — the new feature under test.
+    let lhs: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(2i32);
+        y <- Some(3i32);
+        pure(x + y)
+    };
+    // RHS: hand-written nested bind with fully-qualified pure.
+    let rhs: Option<i32> = OptionKind::bind(Some(2i32), move |x| {
+        OptionKind::bind(Some(3i32), move |y| OptionKind::pure(x + y))
+    });
+    assert_eq!(lhs, Some(5));
+    assert_eq!(lhs, rhs);
+}
+
+// ── 2. Bind-position + bare sequencing ───────────────────────────────────────
+
+/// `x <- pure(2)` (bind RHS) and bare sequencing `pure(())` must each resolve
+/// to the `OptionKind` applicative, leaving the final `Some(5)` intact.
+///
+/// RED: `pure(2i32)` and `pure(())` → E0425.
+#[test]
+fn option_bind_position_bare_pure_and_sequencing() {
+    let lhs: Option<i32> = mdo! {
+        OptionKind;
+        x <- pure(2i32);   // bind position: OptionKind::pure(2) = Some(2)
+        pure(());            // sequencing:   OptionKind::pure(()) = Some(()), discarded
+        pure(x + 3)         // final
+    };
+    // Equivalent hand-written form using qualified pure throughout.
+    let rhs: Option<i32> = OptionKind::bind(OptionKind::pure(2i32), move |x| {
+        OptionKind::bind(OptionKind::pure(()), move |_| OptionKind::pure(x + 3))
+    });
+    assert_eq!(lhs, Some(5));
+    assert_eq!(lhs, rhs);
+}
+
+// ── 3. Mixed two-depth bare pure ──────────────────────────────────────────────
+
+/// Bare `pure` in BOTH a bind position AND the final position within the same
+/// block — exercises per-position rewriting at two nesting levels.
+///
+/// `x: i32` is `Copy`, so it crosses the generated `move` closures freely.
+///
+/// RED: both bare `pure` occurrences → E0425.
+#[test]
+fn option_mixed_two_depth_bare_pure() {
+    let lhs: Option<i32> = mdo! {
+        OptionKind;
+        x <- pure(10i32);  // bind: OptionKind::pure(10) = Some(10), x = 10
+        y <- Some(5i32);
+        pure(x - y)        // final: OptionKind::pure(5) = Some(5)
+    };
+    assert_eq!(lhs, Some(5));
+}
+
+// ── 4. Nested bare pure inside a function call ────────────────────────────────
+
+/// `pure(4)` is nested as an argument inside `std::convert::identity(…)` in the
+/// bind RHS.  The macro token-walk must recurse into the argument list to rewrite
+/// the inner `pure`.
+///
+/// Once implemented: `identity(pure(4))` → `identity(OptionKind::pure(4))`
+///                   = `identity(Some(4))` = `Some(4)`.
+///
+/// RED: `pure(4i32)` → E0425.
+#[test]
+fn option_nested_bare_pure_in_bind_rhs() {
+    let lhs: Option<i32> = mdo! {
+        OptionKind;
+        x <- std::convert::identity(pure(4i32));
+        pure(x + 1)
+    };
+    assert_eq!(lhs, Some(5));
+}
+
+// ── 5. Backward-compat: fully-qualified `Marker::pure` unchanged ──────────────
+
+/// Fully-qualified `OptionKind::pure(…)` in BOTH bind and final positions must
+/// compile and produce correct results unchanged after the feature is added.
+///
+/// The rewriter must not touch `::``-prefixed path calls.
+///
+/// NOTE: this test would compile fine in isolation today. It fails to compile in
+/// the RED phase only because other tests in this file trigger a file-level error.
+#[test]
+fn option_backward_compat_qualified_pure() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- OptionKind::pure(2i32);
+        y <- OptionKind::pure(3i32);
+        OptionKind::pure(x + y)
+    };
+    assert_eq!(result, Some(5));
+}
+
+// ── 6–7. Guard interaction ────────────────────────────────────────────────────
+
+/// `guard(x > 0)` passes when `x = 7`; the bare `pure(x * 2)` final is reached.
+///
+/// RED: `pure(x * 2)` → E0425.
+#[test]
+fn option_guard_true_with_bare_pure_final() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(7i32);
+        guard(x > 0);
+        pure(x * 2)
+    };
+    assert_eq!(result, Some(14));
+}
+
+/// `guard(x < 0)` fails when `x = 7` → `None`; the bare `pure(x * 2)` final
+/// is never reached (short-circuit semantics).
+///
+/// RED: `pure(x * 2)` → E0425.
+#[test]
+fn option_guard_false_with_bare_pure_final() {
+    let result: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(7i32);
+        guard(x < 0);
+        pure(x * 2)
+    };
+    assert_eq!(result, None);
+}
+
+// ── 8. Struct-field colon does NOT suppress bare-pure rewrite ────────────────
+
+/// A bare `pure(7)` used as the value of a struct-literal field (e.g.
+/// `Wrap { v: pure(7) }`) must be rewritten to `OptionKind::pure(7)`.
+///
+/// The lone `:` that separates the field name from its value is NOT the `::` path
+/// separator — the two-token look-behind guard must distinguish them.  Before the
+/// fix a single-`:` check caused `pure(7)` here to be silently left alone,
+/// producing E0425 ("cannot find function `pure`").
+#[test]
+fn option_struct_field_colon_does_not_suppress_bare_pure() {
+    struct Wrap {
+        v: Option<i32>,
+    }
+
+    let r: Option<i32> = mdo! {
+        OptionKind;
+        w <- {
+            let p = Wrap { v: pure(7i32) };
+            p.v
+        };
+        pure(w)
+    };
+    assert_eq!(r, Some(7));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// ResultKind<String>
+// ═════════════════════════════════════════════════════════════════════════════
+//
+// `guard` is intentionally absent: `ResultKind` has no lawful zero element.
+// RED: all bare `pure(…)` occurrences fail with E0425 today.
+
+// ── 1. Final-position bare pure ───────────────────────────────────────────────
+
+/// Bare `pure(x + y)` in the final line must resolve to
+/// `ResultKind::<String>::pure(x + y)` and agree with the hand-written form.
+///
+/// RED: `pure(x + y)` → E0425.
+#[test]
+fn result_final_bare_pure_eq_qualified() {
+    let lhs: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- Ok(2i32);
+        y <- Ok(3i32);
+        pure(x + y)
+    };
+    let rhs: Result<i32, String> = ResultKind::<String>::bind(Ok(2i32), move |x| {
+        ResultKind::<String>::bind(Ok(3i32), move |y| ResultKind::<String>::pure(x + y))
+    });
+    assert_eq!(lhs, Ok(5));
+    assert_eq!(lhs, rhs);
+}
+
+// ── 2. Bind-position + bare sequencing ───────────────────────────────────────
+
+/// `x <- pure(2)` (bind RHS) and bare sequencing `pure(())` with
+/// `ResultKind::<String>` as the block marker.
+///
+/// RED: `pure(2i32)` and `pure(())` → E0425.
+#[test]
+fn result_bind_position_bare_pure_and_sequencing() {
+    let lhs: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- pure(2i32);  // ResultKind::<String>::pure(2) = Ok(2)
+        pure(());          // Ok(()), discarded
+        pure(x + 3)       // final
+    };
+    let rhs: Result<i32, String> =
+        ResultKind::<String>::bind(ResultKind::<String>::pure(2i32), move |x| {
+            ResultKind::<String>::bind(ResultKind::<String>::pure(()), move |_| {
+                ResultKind::<String>::pure(x + 3)
+            })
+        });
+    assert_eq!(lhs, Ok(5));
+    assert_eq!(lhs, rhs);
+}
+
+// ── 3. Mixed two-depth bare pure ──────────────────────────────────────────────
+
+/// Bare `pure` in BOTH bind and final positions in a `ResultKind` block.
+///
+/// RED: both bare `pure` occurrences → E0425.
+#[test]
+fn result_mixed_two_depth_bare_pure() {
+    let lhs: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- pure(10i32);  // bind: Ok(10)
+        y <- Ok(3i32);
+        pure(x + y)        // final: Ok(13)
+    };
+    assert_eq!(lhs, Ok(13));
+}
+
+// ── 4. Nested bare pure inside a function call ────────────────────────────────
+
+/// `pure(5)` nested inside `std::convert::identity(…)` in the bind RHS.
+///
+/// Once implemented: `identity(pure(5))` → `identity(Ok(5))` = `Ok(5)`.
+///
+/// RED: `pure(5i32)` → E0425.
+#[test]
+fn result_nested_bare_pure_in_bind_rhs() {
+    let lhs: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- std::convert::identity(pure(5i32));
+        pure(x + 1)
+    };
+    assert_eq!(lhs, Ok(6));
+}
+
+// ── 5. Backward-compat: fully-qualified `Marker::pure` unchanged ──────────────
+
+/// Fully-qualified `ResultKind::<String>::pure(…)` in both bind and final
+/// positions must be left verbatim and continue to produce `Ok(10)`.
+#[test]
+fn result_backward_compat_qualified_pure() {
+    let result: Result<i32, String> = mdo! {
+        ResultKind::<String>;
+        x <- ResultKind::<String>::pure(4i32);
+        y <- ResultKind::<String>::pure(6i32);
+        ResultKind::<String>::pure(x + y)
+    };
+    assert_eq!(result, Ok(10));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// VecKind
+// ═════════════════════════════════════════════════════════════════════════════
+//
+// RED: all bare `pure(…)` occurrences fail with E0425 today.
+
+// ── 1. Final-position bare pure ───────────────────────────────────────────────
+
+/// Bare `pure(x + y)` in the final line of a `VecKind` block.
+/// `VecKind::bind` is `flat_map`; the result is the Cartesian product.
+///
+/// RED: `pure(x + y)` → E0425.
+#[test]
+fn vec_final_bare_pure_eq_qualified() {
+    let lhs: Vec<i32> = mdo! {
+        VecKind;
+        x <- vec![1i32, 2];
+        y <- vec![10i32, 20];
+        pure(x + y)
+    };
+    let rhs: Vec<i32> = VecKind::bind(vec![1i32, 2], move |x| {
+        VecKind::bind(vec![10i32, 20], move |y| VecKind::pure(x + y))
+    });
+    // flat_map order: x=1→[11,21], x=2→[12,22]
+    assert_eq!(lhs, vec![11, 21, 12, 22]);
+    assert_eq!(lhs, rhs);
+}
+
+// ── 2. Bind-position + bare sequencing ───────────────────────────────────────
+
+/// `x <- pure(3)` (bind RHS) and bare sequencing `pure(())` with `VecKind`.
+/// `VecKind::pure(3)` = `vec![3]` (singleton); the flat_map yields one element.
+///
+/// RED: `pure(3i32)` and `pure(())` → E0425.
+#[test]
+fn vec_bind_position_bare_pure_and_sequencing() {
+    let lhs: Vec<i32> = mdo! {
+        VecKind;
+        x <- pure(3i32);   // VecKind::pure(3) = vec![3]
+        pure(());           // VecKind::pure(()) = vec![()], sequencing
+        pure(x + 2)        // final: vec![5]
+    };
+    let rhs: Vec<i32> = VecKind::bind(VecKind::pure(3i32), move |x| {
+        VecKind::bind(VecKind::pure(()), move |_| VecKind::pure(x + 2))
+    });
+    assert_eq!(lhs, vec![5]);
+    assert_eq!(lhs, rhs);
+}
+
+// ── 3. Mixed two-depth bare pure ──────────────────────────────────────────────
+
+/// Bare `pure` in BOTH bind and final positions in a `VecKind` block.
+/// `pure(2)` in bind position yields `vec![2]`; the Cartesian product with
+/// `vec![1, 2]` then produces `vec![3, 4]`.
+///
+/// RED: both bare `pure` occurrences → E0425.
+#[test]
+fn vec_mixed_two_depth_bare_pure() {
+    let lhs: Vec<i32> = mdo! {
+        VecKind;
+        x <- pure(2i32);        // bind: vec![2], x = 2
+        y <- vec![1i32, 2i32];  // Cartesian with x = 2
+        pure(x + y)             // final: vec![3, 4]
+    };
+    assert_eq!(lhs, vec![3, 4]);
+}
+
+// ── 4. Nested bare pure inside a function call ────────────────────────────────
+
+/// `pure(3)` nested inside `std::convert::identity(…)` in the bind RHS.
+///
+/// Once implemented: `identity(VecKind::pure(3))` = `identity(vec![3])` = `vec![3]`.
+///
+/// RED: `pure(3i32)` → E0425.
+#[test]
+fn vec_nested_bare_pure_in_bind_rhs() {
+    let lhs: Vec<i32> = mdo! {
+        VecKind;
+        x <- std::convert::identity(pure(3i32));
+        pure(x * 10)
+    };
+    assert_eq!(lhs, vec![30]);
+}
+
+// ── 5. Backward-compat: fully-qualified `Marker::pure` unchanged ──────────────
+
+/// Fully-qualified `VecKind::pure(…)` in both bind and final positions must be
+/// preserved verbatim, yielding the same singleton Cartesian product.
+#[test]
+fn vec_backward_compat_qualified_pure() {
+    let result: Vec<i32> = mdo! {
+        VecKind;
+        x <- VecKind::pure(2i32);
+        y <- VecKind::pure(3i32);
+        VecKind::pure(x + y)
+    };
+    assert_eq!(result, vec![5]);
+}
+
+// ── 6–7. Guard interaction ────────────────────────────────────────────────────
+
+/// `guard(x % 2 == 0)` retains only even elements; bare `pure(x)` final.
+///
+/// RED: `pure(x)` → E0425.
+#[test]
+fn vec_guard_true_with_bare_pure_final() {
+    let result: Vec<i32> = mdo! {
+        VecKind;
+        x <- vec![1i32, 2, 3, 4];
+        guard(x % 2 == 0);
+        pure(x)
+    };
+    assert_eq!(result, vec![2, 4]);
+}
+
+/// `guard(false)` eliminates every element; bare `pure(x)` final is never reached.
+///
+/// RED: `pure(x)` → E0425.
+#[test]
+fn vec_guard_false_with_bare_pure_final() {
+    let result: Vec<i32> = mdo! {
+        VecKind;
+        x <- vec![1i32, 2, 3];
+        guard(false);
+        pure(x)
+    };
+    assert_eq!(result, vec![]);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// IdentityKind
+// ═════════════════════════════════════════════════════════════════════════════
+//
+// `guard` is absent: `Identity` has no lawful zero / short-circuit semantics.
+// RED: all bare `pure(…)` occurrences fail with E0425 today.
+
+// ── 1. Final-position bare pure ───────────────────────────────────────────────
+
+/// Bare `pure(x + y)` in the final line of an `IdentityKind` block.
+///
+/// RED: `pure(x + y)` → E0425.
+#[test]
+fn identity_final_bare_pure_eq_qualified() {
+    let lhs: Identity<i32> = mdo! {
+        IdentityKind;
+        x <- Identity(2i32);
+        y <- Identity(3i32);
+        pure(x + y)
+    };
+    let rhs: Identity<i32> = IdentityKind::bind(Identity(2i32), move |x| {
+        IdentityKind::bind(Identity(3i32), move |y| IdentityKind::pure(x + y))
+    });
+    assert_eq!(lhs, Identity(5));
+    assert_eq!(lhs, rhs);
+}
+
+// ── 2. Bind-position + bare sequencing ───────────────────────────────────────
+
+/// `x <- pure(2)` (bind) and bare sequencing `pure(())` with `IdentityKind`.
+///
+/// RED: `pure(2i32)` and `pure(())` → E0425.
+#[test]
+fn identity_bind_position_bare_pure_and_sequencing() {
+    let lhs: Identity<i32> = mdo! {
+        IdentityKind;
+        x <- pure(2i32);  // IdentityKind::pure(2) = Identity(2)
+        pure(());          // Identity(()), discarded
+        pure(x + 8)       // final: Identity(10)
+    };
+    let rhs: Identity<i32> = IdentityKind::bind(IdentityKind::pure(2i32), move |x| {
+        IdentityKind::bind(IdentityKind::pure(()), move |_| IdentityKind::pure(x + 8))
+    });
+    assert_eq!(lhs, Identity(10));
+    assert_eq!(lhs, rhs);
+}
+
+// ── 3. Mixed two-depth bare pure ──────────────────────────────────────────────
+
+/// Bare `pure` in BOTH bind and final positions within the same `IdentityKind` block.
+/// `x: i32` is `Copy`, so crossing the generated `move` closures is safe.
+///
+/// RED: both bare `pure` occurrences → E0425.
+#[test]
+fn identity_mixed_two_depth_bare_pure() {
+    let lhs: Identity<i32> = mdo! {
+        IdentityKind;
+        x <- pure(7i32);  // bind: Identity(7)
+        pure(x * 3)       // final: Identity(21)
+    };
+    assert_eq!(lhs, Identity(21));
+}
+
+// ── 4. Nested bare pure inside a function call ────────────────────────────────
+
+/// `pure(7)` nested inside `std::convert::identity(…)` in the bind RHS.
+///
+/// Once implemented: `identity(IdentityKind::pure(7))` = `identity(Identity(7))`
+///                   = `Identity(7)`.
+///
+/// RED: `pure(7i32)` → E0425.
+#[test]
+fn identity_nested_bare_pure_in_bind_rhs() {
+    let lhs: Identity<i32> = mdo! {
+        IdentityKind;
+        x <- std::convert::identity(pure(7i32));
+        pure(x + 3)
+    };
+    assert_eq!(lhs, Identity(10));
+}
+
+// ── 5. Backward-compat: fully-qualified `Marker::pure` unchanged ──────────────
+
+/// Fully-qualified `IdentityKind::pure(…)` in both bind and final positions must
+/// be preserved verbatim after the feature is added.
+#[test]
+fn identity_backward_compat_qualified_pure() {
+    let result: Identity<i32> = mdo! {
+        IdentityKind;
+        x <- IdentityKind::pure(5i32);
+        y <- IdentityKind::pure(5i32);
+        IdentityKind::pure(x + y)
+    };
+    assert_eq!(result, Identity(10));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// ReaderTKind<Config, IdentityKind>
+// ═════════════════════════════════════════════════════════════════════════════
+//
+// `guard` is absent: `ReaderT` has no lawful zero.
+//
+// Non-Copy capture constraint: `ReaderT` is `Clone` but not `Copy`; values bound
+// from `ReaderT` steps are typically `i32` (Copy) and cross `move` closures
+// freely.  The constraint applies to *external* non-Copy values — see the macro
+// docs.  All tests below keep bound values as `i32` to stay within this limit.
+//
+// RED: all bare `pure(…)` occurrences fail with E0425 today.
+
+// ── 1. Final-position bare pure ───────────────────────────────────────────────
+
+/// Bare `pure(b + f)` in the final line of a `ReaderKind` block.
+/// Both `b` and `f` are `i32` (Copy); they thread freely through the closures.
+///
+/// Equivalence is verified by running both lhs and rhs against the same concrete
+/// environments (ReaderT values are functions, not comparable directly).
+///
+/// RED: `pure(b + f)` → E0425.
+#[test]
+fn reader_final_bare_pure_eq_qualified() {
+    let lhs: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        b <- ReaderT::new(|cfg: Config| Identity(cfg.base));
+        f <- ReaderT::new(|cfg: Config| Identity(cfg.factor));
+        pure(b + f)   // bare pure — must become ReaderKind::pure(b + f)
+    };
+    let rhs: ConfigReader<i32> =
+        ReaderKind::bind(ReaderT::new(|cfg: Config| Identity(cfg.base)), move |b| {
+            ReaderKind::bind(ReaderT::new(|cfg: Config| Identity(cfg.factor)), move |f| {
+                ReaderKind::pure(b + f)
+            })
+        });
+    // Compare by running both against the same environments.
+    assert_eq!(
+        run_i32(&lhs, Config { base: 4, factor: 6 }),
+        run_i32(&rhs, Config { base: 4, factor: 6 }),
+    );
+    assert_eq!(
+        run_i32(
+            &lhs,
+            Config {
+                base: -3,
+                factor: 10
+            }
+        ),
+        run_i32(
+            &rhs,
+            Config {
+                base: -3,
+                factor: 10
+            }
+        ),
+    );
+    assert_eq!(run_i32(&lhs, Config { base: 4, factor: 6 }), 10);
+}
+
+// ── 2. Bind-position + bare sequencing ───────────────────────────────────────
+
+/// `x <- pure(10)` (bind) and bare sequencing `pure(())` with `ReaderKind`.
+/// All computations are pure (environment-independent), so any `Config` yields 15.
+///
+/// RED: `pure(10i32)` and `pure(())` → E0425.
+#[test]
+fn reader_bind_position_bare_pure_and_sequencing() {
+    let computation: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        x <- pure(10i32);  // ReaderKind::pure(10) — const reader returning 10
+        pure(());           // ReaderKind::pure(()) — sequencing, value discarded
+        pure(x + 5)        // final: ReaderKind::pure(15)
+    };
+    // The environment is irrelevant since all steps are pure.
+    assert_eq!(run_i32(&computation, Config { base: 0, factor: 0 }), 15);
+    assert_eq!(
+        run_i32(
+            &computation,
+            Config {
+                base: 99,
+                factor: -7
+            }
+        ),
+        15
+    );
+}
+
+// ── 3. Mixed two-depth bare pure ──────────────────────────────────────────────
+
+/// Bare `pure` in BOTH bind and final positions within the same `ReaderKind` block.
+/// `b: i32` (Copy) and `x: i32` (Copy) cross closure boundaries freely.
+///
+/// RED: both bare `pure` occurrences → E0425.
+#[test]
+fn reader_mixed_two_depth_bare_pure() {
+    let computation: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        b <- ReaderT::new(|cfg: Config| Identity(cfg.base));
+        x <- pure(10i32);   // bind: const reader, x = 10 (Copy)
+        pure(b + x)         // final: ReaderKind::pure(b + 10)
+    };
+    // b = 5, x = 10 → 15
+    assert_eq!(run_i32(&computation, Config { base: 5, factor: 0 }), 15);
+    // b = 0, x = 10 → 10
+    assert_eq!(
+        run_i32(
+            &computation,
+            Config {
+                base: 0,
+                factor: 99
+            }
+        ),
+        10
+    );
+}
+
+// ── 4. Nested bare pure inside a function call ────────────────────────────────
+
+/// `pure(42)` nested inside `std::convert::identity(…)` in the bind RHS.
+/// `ReaderKind::pure(42)` is a `ConfigReader<i32>` — Clone via Rc, so the
+/// `.clone()` the macro emits is valid.
+///
+/// Once implemented: `identity(ReaderKind::pure(42))` = `ReaderKind::pure(42)`.
+///
+/// RED: `pure(42i32)` → E0425.
+#[test]
+fn reader_nested_bare_pure_in_bind_rhs() {
+    let computation: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        x <- std::convert::identity(pure(42i32));
+        pure(x + 1)
+    };
+    // x = 42 (from pure) → final = 43; environment plays no role.
+    assert_eq!(run_i32(&computation, Config { base: 0, factor: 0 }), 43);
+    assert_eq!(
+        run_i32(
+            &computation,
+            Config {
+                base: 99,
+                factor: -1
+            }
+        ),
+        43
+    );
+}
+
+// ── 5. Backward-compat: fully-qualified `Marker::pure` unchanged ──────────────
+
+/// Fully-qualified `ReaderKind::pure(…)` in both bind and final positions must
+/// be preserved verbatim (the `::` path-join guard prevents rewriting).
+#[test]
+fn reader_backward_compat_qualified_pure() {
+    let computation: ConfigReader<i32> = mdo! {
+        ReaderKind;
+        x <- ReaderKind::pure(10i32);
+        y <- ReaderKind::pure(5i32);
+        ReaderKind::pure(x + y)
+    };
+    assert_eq!(run_i32(&computation, Config { base: 0, factor: 0 }), 15);
+    assert_eq!(
+        run_i32(
+            &computation,
+            Config {
+                base: 99,
+                factor: -1
+            }
+        ),
+        15
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Coverage-gap regression tests (bare-pure feature completeness)
+// ═════════════════════════════════════════════════════════════════════════════
+
+// ── R1. `..pure(` is NOT suppressed (two-dot look-behind) ────────────────────
+
+/// Proves that the `..` double-dot prefix does NOT trigger the method-call
+/// suppression guard, so `..pure(x)` inside a bind-RHS block is rewritten.
+///
+/// The suppression guard fires only when a SINGLE `.` immediately precedes
+/// `pure` AND the token before THAT is not also `.`.  With `..`, both the
+/// preceding token and the one before it are `.`, so:
+///
+/// ```text
+/// prev_is_dot = true   (second `.`)
+/// prev2_is_dot = true  (first  `.`)
+/// is_method = prev_is_dot && !prev2_is_dot = true && false = false
+/// ```
+///
+/// → NOT suppressed → `pure(x)` is rewritten to `OptionKind::pure(x)` = `Some(x)`.
+///
+/// Verification: the rewritten expression `..pure(x)` becomes
+/// `..OptionKind::pure(x)` = `..Some(x)`, a `RangeTo<Option<i32>>`.
+/// Reading its `.end` field yields `Some(x)`.  The assertion `rto.end == Some(42)`
+/// holds only if `pure` resolved via the marker (not a free function, which would
+/// not compile, and not an identity that drops the `Some` wrapper).
+#[test]
+fn option_struct_update_does_not_suppress_bare_pure() {
+    let r: Option<bool> = mdo! {
+        OptionKind;
+        x <- Some(42i32);
+        b <- {
+            // `..pure(x)` in token stream — double-dot precedes `pure`.
+            // After rewrite: `..OptionKind::pure(x)` = `..Some(42)` = RangeTo<Option<i32>>.
+            // rto.end == Some(42) proves pure was dispatched via the marker.
+            let rto = ..pure(x);
+            Some(rto.end == Some(42i32))
+        };
+        pure(b)
+    };
+    assert_eq!(r, Some(true));
+}
+
+// ── R2. Monad left/right identity through bare `pure` ────────────────────────
+
+/// Exercises the monad identity laws expressed entirely through the NEW bare
+/// `pure(…)` syntax.  The existing `laws.rs` property tests use only the
+/// qualified `OptionKind::pure`; this test closes that gap for the bare form.
+///
+/// **Left identity** (`mdo!{M; x <- pure(a); k(x)} == k(a)`):
+///   `mdo!{OptionKind; x <- pure(5i32); pure(f(x))}` must equal `Some(f(5))`
+///   and agree with the hand-written `OptionKind::bind(OptionKind::pure(5), …)`.
+///
+/// **Right identity** (`mdo!{M; x <- m; pure(x)} == m`):
+///   `mdo!{OptionKind; x <- Some(7i32); pure(x)}` must equal `Some(7)`.
+#[test]
+fn option_law_left_right_identity_with_bare_pure() {
+    let f = |x: i32| x + 1;
+
+    // Left identity via bare pure.
+    let lhs_left: Option<i32> = mdo! {
+        OptionKind;
+        x <- pure(5i32);   // bare pure → OptionKind::pure(5) = Some(5)
+        pure(f(x))         // bare pure → OptionKind::pure(f(5)) = Some(6)
+    };
+    // Hand-written equivalent using qualified pure for cross-check.
+    let rhs_left: Option<i32> =
+        OptionKind::bind(OptionKind::pure(5i32), move |x| OptionKind::pure(f(x)));
+    assert_eq!(lhs_left, Some(6));
+    assert_eq!(lhs_left, rhs_left);
+
+    // Right identity via bare pure.
+    let lhs_right: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(7i32);
+        pure(x)  // bare pure → OptionKind::pure(7) = Some(7)
+    };
+    assert_eq!(lhs_right, Some(7));
+}
+
+// ── R3. Bare `pure` inside `guard(…)` condition ───────────────────────────────
+
+/// The `guard(cond)` statement forwards `cond` through `rewrite_pure` before
+/// evaluating it.  This test verifies that a bare `pure(x)` inside the
+/// condition expression is rewritten to `OptionKind::pure(x)` = `Some(x)`,
+/// making the condition a `bool` comparison between two `Option<i32>` values.
+///
+/// - True case: `x = 7`, `guard(pure(7) == Some(7))` → `guard(true)` → `Some(())`
+///   → computation continues → `pure(x)` = `Some(7)`.
+/// - False case: `x = 42`, `guard(pure(42) == Some(7))` → `guard(false)` → `None`
+///   → short-circuit → result is `None`.
+#[test]
+fn option_bare_pure_inside_guard_cond() {
+    // True branch: guard passes, result reaches the final pure.
+    let r_true: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(7i32);
+        guard(pure(x) == Some(7i32));  // pure(x) → OptionKind::pure(x) = Some(x); Some(7)==Some(7)
+        pure(x)
+    };
+    assert_eq!(r_true, Some(7));
+
+    // False branch: guard short-circuits to None.
+    let r_false: Option<i32> = mdo! {
+        OptionKind;
+        x <- Some(42i32);
+        guard(pure(x) == Some(7i32));  // Some(42) == Some(7) = false → guard returns None
+        pure(x)
+    };
+    assert_eq!(r_false, None);
+}
+
+// ── R4. Method call `.pure(…)` is left verbatim (suppressed) ─────────────────
+
+/// Proves the suppression branch: `obj.pure(x)` — where `pure` is an ordinary
+/// method, not a bare call — is left untouched by the rewriter.
+///
+/// Look-behind at the point where `pure` is encountered:
+/// ```text
+/// prev_is_dot  = true   (the single `.` method-call dot)
+/// prev2_is_dot = false  (the token before that is the `obj` ident, not `.`)
+/// is_method    = prev_is_dot && !prev2_is_dot = true && true = true  → SUPPRESS
+/// ```
+///
+/// The local `HasPure::pure` method multiplies its argument by 100.  If the
+/// macro had rewritten `obj.pure(3)` the expression would be a compile error
+/// (UFCS applied via method dispatch is invalid syntax).  The runtime assertion
+/// `Some(300)` distinguishes method dispatch (`3 * 100`) from any other path.
+#[test]
+fn option_method_pure_is_not_rewritten() {
+    struct HasPure;
+    impl HasPure {
+        fn pure(&self, x: i32) -> i32 {
+            x * 100
+        }
+    }
+
+    let r: Option<i32> = mdo! {
+        OptionKind;
+        m <- {
+            // `obj.pure(3)` — single `.` before `pure`, token before that is `obj` (not `.`)
+            // → is_method = true → suppressed → dispatches to HasPure::pure → 3 * 100 = 300
+            let obj = HasPure;
+            Some(obj.pure(3))
+        };
+        pure(m)  // bare pure → OptionKind::pure(300) = Some(300)
+    };
+    assert_eq!(r, Some(300));
+}

--- a/tests/kind/do_notation/mod.rs
+++ b/tests/kind/do_notation/mod.rs
@@ -15,6 +15,7 @@
 // intentional here for cross-instance test symmetry.
 #![allow(clippy::clone_on_copy)]
 
+pub mod auto_pure;
 pub mod cfn_unsupported;
 pub mod identity;
 pub mod laws;


### PR DESCRIPTION
## Summary

`mdo!` blocks no longer need the fully-qualified `Marker::pure(x)` — a bare **`pure(x)`** now resolves to the block's marker:

```rust
mdo! { OptionKind;
    x <- pure(2);          // bind position  → <OptionKind as Applicative>::pure(2)
    y <- Some(3);
    guard(x + y > 0);
    pure(x + y)            // final position → Some(5)
}
```

The rewrite applies **recursively** in every monadic-expression position — final line, bind RHS, bare sequencing, guard conditions, and nested calls (`foo(pure(3))`).

### Why this shape

The macro has no type information, so a *type-driven* auto-pure (wrap a bare value only when it isn't already monadic) is **impossible** — the same non-injective GAT `Of<Arg>` wall (E0284) that forces the explicit marker. This PR is the reachable, **syntactic** alternative: a marker-resolved path rewrite, mirroring the existing `guard(..)` pseudo-keyword.

### Implementation

A recursive `rewrite_pure` token walk with a **two-token look-behind**, so a bare `pure(...)` call-head is rewritten only when it is **not** `::`-qualified (`Marker::pure`) and **not** a method call (`x.pure`). `pure` becomes a reserved free-call head inside the block; plain-Rust `let` bodies are the only carve-out.

### Backward compatibility

Fully compatible — qualified `Marker::pure(..)`, `.pure()` methods, and raw monadic finals (`Some(..)`, `vec![..]`, `ReaderT`, `Identity(..)`) are left untouched. The change is a pure syntactic substitution, so the monad laws are unaffected.

## Changes

- `monadify-macros/src/lib.rs` — `rewrite_pure` helper + `# The pure keyword` docs
- `tests/kind/do_notation/auto_pure.rs` — **33 tests** (final / bind / bare-seq / mixed-depth / nested / guard / backward-compat / struct-field / method-suppression) across Option/Result/Vec/Identity/ReaderT, incl. monad-law equivalence through the bare form
- `src/lib.rs`, `README.md`, `examples/*` — switched to bare `pure(...)`

## Test plan

All gates green:
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test` (default) · `cargo test --features legacy` · `cargo test --features do-notation` (309 tests, monad laws hold)
- [x] MSRV 1.66 on a fresh lock: `rm Cargo.lock && cargo +1.66.0 check --workspace --all-features`
- [x] `cargo doc --workspace --all-features` clean
- [x] zero-dep guard — default features still resolve to `monadify` alone; proc-macro deps only under `do-notation`