### PR TITLE
feat(function): native Clone-able RcFn / RcFnKind (Rc-backed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ plus profunctor-encoded optics. v0.1.1, MIT, edition 2021, MSRV 1.66.
 The defining design simulates **Higher-Kinded Types (HKTs)** using Generic
 Associated Types: a `Kind` trait with `type Of<Arg>` plus lightweight marker
 structs (`OptionKind`, `VecKind`, `ResultKind<E>`, `CFnKind<X>`, `CFnOnceKind<X>`,
-`IdentityKind`, `ReaderTKind`). Traits are generic over the *marker*, and
+`RcFnKind<X>`, `IdentityKind`, `ReaderTKind`). Traits are generic over the *marker*, and
 `Self::Of<A>` resolves to the concrete type (e.g. `OptionKind::Of<i32> == Option<i32>`).
 Core infrastructure lives in `src/kind_based/kind.rs`.
 
@@ -22,7 +22,7 @@ Core infrastructure lives in `src/kind_based/kind.rs`.
   `Functor → Apply → Applicative → Bind/Monad`, defined over Kind markers.
 - `src/profunctor.rs` — `Profunctor`/`Strong`/`Choice` and van-Laarhoven optics
   (`Lens`/`Getter`/`Fold`, `_1`/`_2`/`_key`, `view`, `lcmap`/`rmap`, `Forget`).
-- `src/function.rs` — `CFn`/`CFnOnce` boxed-closure wrappers + composition (`>>`/`<<`).
+- `src/function.rs` — `CFn`, `RcFn`, `CFnOnce` function wrappers + composition (`>>`/`<<`).
 - `src/identity.rs` — `Identity` monad. `src/transformers/reader.rs` — `ReaderT` +
   `MonadReader` (`ask`/`local`). `src/utils.rs` — `fn0!`..`fn3!` macros.
 - `src/legacy/` — the older associated-type implementation, behind the `legacy`
@@ -31,7 +31,7 @@ Core infrastructure lives in `src/kind_based/kind.rs`.
   criterion benchmarks comparing kind-based vs native vs legacy.
 
 Concrete instances implementing the full hierarchy (where lawful): `Option`,
-`Result`, `Vec`, `Identity`, `CFn`/`CFnOnce`, `ReaderT`.
+`Result`, `Vec`, `Identity`, `CFn`, `RcFn`, `CFnOnce`, `ReaderT`.
 
 ## Conventions
 
@@ -39,9 +39,11 @@ Concrete instances implementing the full hierarchy (where lawful): `Option`,
   identity/composition, Applicative, Monad left/right-identity + associativity,
   Profunctor). New instances must add law tests.
 - Map/bind closures require `FnMut(A) -> B + Clone + 'static`.
-- **Known constraint:** `CFn` is **not `Clone`**, which blocks some abstractions
-  (e.g. `lift_a1` for `VecKind` is commented out in `applicative.rs`). Keep this
-  in mind before adding `Clone`-dependent generic helpers.
+- **Function wrappers:** `CFn` is the unique-ownership, non-`Clone` wrapper (Box-backed).
+  `RcFn` is the shared-ownership, `Clone`-able alternative (Rc-backed); it re-enables
+  `lift_a1::<VecKind>` and works in `mdo!`. `CFnOnce` is intentionally non-`Clone`
+  (FnOnce semantics cannot be cloned). For `Clone`-dependent helpers, use `RcFn` or
+  bound generically over types that are `Clone`.
 - `#![deny(missing_docs)]` is enforced — all public items need docs.
 
 ## Quality gates
@@ -62,6 +64,15 @@ cargo bench                 # criterion benchmarks
 ```
 
 ## Memory (Hindsight)
+
+> **MANDATORY (user directive, 2026-06-27):** The Hindsight bank `monadify` is the
+> **sole memory of record**. At the **start of every session**, before other work,
+> `recall(tags=["project:monadify"])`; at the **end of durable work**, `retain` new
+> facts there. Use Hindsight for **all** long-term storage and retrieval — do **not**
+> accumulate durable knowledge in the file-based auto-memory (`MEMORY.md`), which
+> holds only a one-line breadcrumb pointing here. If the `hindsight` MCP server is
+> unavailable (e.g. an unauthenticated headless/cron run), say so explicitly rather
+> than silently falling back to file memory.
 
 This project has a dedicated [Hindsight](https://github.com/vectorize-io/hindsight)
 memory bank (`monadify`) holding the project's long-term context: git history

--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ The library defines and implements the following core functional programming tra
 *   **`Choice`**: Extends `Profunctor`. Provides `left` and `right` for operating on sum types (`Result`).
     *   Implemented for `CFn<A, B>`.
 
-The library also includes `CFn` and `CFnOnce` wrappers for heap-allocated closures, and various helper functions and macros (e.g., `lift2`, `lift_a1`, `fn0!`, `fn1!`, `_1`, `_2`, `view`) for working with these abstractions. Optical structures like `Lens` and `Getter` (using `Profunctor` encoding) are also explored.
+The library also includes function wrappers for heap-allocated closures:
+- **`CFn<A, B>`**: A `Box`-backed, unique-ownership, non-`Clone` wrapper.
+- **`RcFn<A, B>`**: An `Rc`-backed, shared-ownership, `Clone`-able sibling that unblocks `lift_a1::<VecKind>` and enables `mdo!` over function monads. Cloning is O(1).
+- **`CFnOnce<A, B>`**: A `Box`-backed wrapper for once-callable closures (intentionally not `Clone`).
+
+The library also includes various helper functions and macros (e.g., `lift2`, `lift_a1`, `fn0!`, `fn1!`, `_1`, `_2`, `view`) for working with these abstractions. Optical structures like `Lens` and `Getter` (using `Profunctor` encoding) are also explored.
 
 ## Project Goals
 - To explore and understand monads and other functional patterns from a practical Rust implementation perspective.
@@ -112,7 +117,7 @@ Run with: `cargo run --example validation --features do-notation`
 
 **Limitations and notes**:
 - `pure` is a reserved free-call head inside `mdo!` blocks (rewritten to `Marker::pure`); use `::pure`-qualified or `.pure()` method syntax to bypass
-- `CFn` / `CFnOnce` unsupported (they are not `Clone`)
+- `CFn` / `CFnOnce` unsupported (not `Clone`); use `RcFn` instead for a `Clone`-able, shared-ownership function monad
 - At most one non-`Copy` external value per `mdo!` nesting level (closure capture constraint)
 
 See [`monadify::mdo`](https://docs.rs/monadify) documentation for full details.

--- a/src/applicative.rs
+++ b/src/applicative.rs
@@ -42,11 +42,12 @@ pub mod kind {
     //! this `monadify` library's `apply` takes `(value_context, function_context)`.
     //! The `lift_a1` function in this module demonstrates this pattern.
 
-    use crate::apply::kind::Apply; // Kind-based Apply
-    use crate::function::{CFn, CFnOnce};
+    use crate::apply::kind::{Apply, ApplyRc}; // Kind-based Apply
+    use crate::function::{CFn, CFnOnce, RcFn};
     use crate::kind_based::kind::{
-        CFnKind, CFnOnceKind, Kind, Kind1, OptionKind, ResultKind, VecKind,
+        CFnKind, CFnOnceKind, Kind, Kind1, OptionKind, RcFnKind, ResultKind, VecKind,
     };
+    use std::rc::Rc;
 
     /// Represents a Kind-encoded type that is an Applicative Functor.
     ///
@@ -152,6 +153,61 @@ pub mod kind {
         }
     }
 
+    // Applicative for RcFnKind<X> — generic Clone case.
+    // Lifts a value `T: Clone` into `RcFn<X, T>` which always returns `value.clone()`.
+    impl<X, T> Applicative<T> for RcFnKind<X>
+    where
+        X: 'static,
+        T: 'static + Clone,
+        Self: Apply<T, T>,
+        Self: Kind<Of<T> = RcFn<X, T>>,
+    {
+        /// Lifts a value `T` into an `RcFn<X, T>` (a function `X -> T`).
+        ///
+        /// The resulting function, when called with any input of type `X`,
+        /// ignores that input and always returns a clone of the original `value`.
+        ///
+        /// Requires `T: Clone` because the lifted value is cloned by the returned function.
+        fn pure(value: T) -> Self::Of<T> {
+            RcFn(Rc::new(move |_x: X| value.clone()))
+        }
+    }
+
+    // Applicative for RcFnKind<X> — specialized CFn case.
+    //
+    // `CFn<A,B>` is not `Clone` (it wraps `Box<dyn Fn>`), so the generic
+    // `Applicative<T: Clone>` impl above does not cover it. This impl provides
+    // `pure` for `CFn<A,B>` by converting the inner `Box` to `Rc` (enabling
+    // O(1) cloning) and creating a new delegating `CFn` wrapper on each call.
+    //
+    // Coherence note: the two impls do NOT overlap because `CFn<A,B>` does not
+    // implement `Clone` in this crate, and — due to the orphan rules — no
+    // downstream crate can add `impl Clone for CFn<A,B>` either.
+    impl<X, A, B> Applicative<CFn<A, B>> for RcFnKind<X>
+    where
+        X: 'static,
+        A: 'static,
+        B: 'static,
+        Self: Apply<CFn<A, B>, CFn<A, B>>,
+        Self: Kind<Of<CFn<A, B>> = RcFn<X, CFn<A, B>>>,
+    {
+        /// Lifts a `CFn<A,B>` into `RcFn<X, CFn<A,B>>`.
+        ///
+        /// Because `CFn` is not `Clone`, the inner `Box<dyn Fn(A)->B>` is first
+        /// converted to `Rc<dyn Fn(A)->B>`. On each call to the resulting `RcFn`,
+        /// a new `CFn` is created that delegates to the shared `Rc`, costing only
+        /// one `Rc` reference-count bump per call.
+        fn pure(value: CFn<A, B>) -> RcFn<X, CFn<A, B>> {
+            // Convert Box → Rc so the underlying function can be shared cheaply.
+            let shared: Rc<dyn Fn(A) -> B + 'static> = Rc::from(value.0);
+            RcFn(Rc::new(move |_x: X| {
+                // Clone the Rc (O(1)) and wrap in a new CFn that delegates.
+                let rc_clone = Rc::clone(&shared);
+                CFn(Box::new(move |a: A| (rc_clone.as_ref())(a)))
+            }))
+        }
+    }
+
     // Applicative for CFnOnceKind
     // Lifts a value `T` into `CFnOnce<X, T>`
     impl<X, T> Applicative<T> for CFnOnceKind<X>
@@ -189,8 +245,8 @@ pub mod kind {
     /// ## Example
     ///
     /// ```
-    /// use monadify::applicative::kind::lift_a1;
-    /// use monadify::kind_based::kind::{OptionKind, VecKind}; // For context type
+    /// use monadify::applicative::kind::{lift_a1, lift_a1_rc};
+    /// use monadify::kind_based::kind::{OptionKind, VecKind};
     ///
     /// // Using lift_a1 with Option
     /// let opt_val: Option<i32> = Some(5);
@@ -201,21 +257,15 @@ pub mod kind {
     /// );
     /// assert_eq!(lifted_opt, Some("10".to_string()));
     ///
-    /// // Using lift_a1 with Vec
-    /// // Note: This example would fail if `CFn` needed to be cloned by `Applicative::pure`
-    /// // for `VecKind`, as `CFn` is not `Clone`.
-    /// // The current `lift_a1` requires `F: Applicative<CFn<A, B>>`.
-    /// // `VecKind`'s `Applicative<T>` impl requires `T: Clone`.
-    /// // Thus, `VecKind` needs `Applicative<CFn<A,B>>` where `CFn<A,B>: Clone`.
-    /// // Since `CFn` is not `Clone`, this specific example is commented out.
-    /// /*
+    /// // Using lift_a1_rc with Vec — re-enabled via RcFn (which IS Clone).
+    /// // `lift_a1` over VecKind required `CFn<A,B>: Clone`, which `CFn` cannot satisfy.
+    /// // `lift_a1_rc` uses `RcFn<A,B>` instead, which derives `Clone`.
     /// let vec_val: Vec<i32> = vec![1, 2, 3];
-    /// let lifted_vec: Vec<bool> = lift_a1::<VecKind, _, _, _>(
+    /// let lifted_vec: Vec<bool> = lift_a1_rc::<VecKind, _, _, _>(
     ///     |x: i32| x % 2 == 0,
     ///     vec_val
     /// );
     /// assert_eq!(lifted_vec, vec![false, true, false]);
-    /// */
     /// ```
     pub fn lift_a1<F, A, B, FuncImpl>(
         func: FuncImpl,
@@ -238,6 +288,45 @@ pub mod kind {
         //    `F::apply(fa, f_in_context)` where `fa` is `F::Of<A>`.
         //    This requires `F` to be `Apply<A, B>`.
         F::apply(fa, f_in_context)
+    }
+
+    /// Lifts a unary function `A -> B` to operate on Kind `Applicative` values using
+    /// [`RcFn`] as the function container.
+    ///
+    /// This is the `RcFn`-backed sibling of [`lift_a1`].  [`lift_a1`] builds
+    /// `F::pure(CFn::new(func))`, requiring `CFn<A,B>: Clone` — a bound `CFn`
+    /// cannot satisfy.  `lift_a1_rc` builds `F::pure(RcFn::new(func))` instead;
+    /// [`RcFn`] derives `Clone`, so `VecKind::Applicative<RcFn<A,B>>` compiles.
+    ///
+    /// # Parameters
+    /// - `F`: The Kind marker; must implement `Applicative<RcFn<A,B>>` and `ApplyRc<A,B>`.
+    /// - `func`: The function `A -> B` to lift.
+    /// - `fa`: The applicative value `F::Of<A>`.
+    ///
+    /// # Returns
+    /// The result `F::Of<B>`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use monadify::applicative::kind::lift_a1_rc;
+    /// use monadify::kind_based::kind::VecKind;
+    ///
+    /// let fa: Vec<i32> = vec![1, 2, 3];
+    /// let result: Vec<bool> = lift_a1_rc::<VecKind, _, _, _>(|x: i32| x % 2 == 0, fa);
+    /// assert_eq!(result, vec![false, true, false]);
+    /// ```
+    pub fn lift_a1_rc<F, A, B, FuncImpl>(func: FuncImpl, fa: F::Of<A>) -> F::Of<B>
+    where
+        F: Applicative<RcFn<A, B>> + ApplyRc<A, B> + Kind1,
+        FuncImpl: Fn(A) -> B + 'static,
+        A: 'static,
+        B: 'static,
+    {
+        // 1. Wrap the function in RcFn (Clone-able) and lift it into the context.
+        let fc: F::Of<RcFn<A, B>> = F::pure(RcFn::new(func));
+        // 2. Apply the wrapped function to the wrapped value via apply_rc.
+        F::apply_rc(fa, fc)
     }
 }
 

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -14,11 +14,12 @@ pub mod kind {
     //! - `A`: The input type of the function `A -> B` and the type of value in `Self::Of<A>`.
     //! - `B`: The output type of the function `A -> B` and the type of value in `Self::Of<B>`.
 
-    use crate::function::{CFn, CFnOnce};
+    use crate::function::{CFn, CFnOnce, RcFn};
     use crate::functor::Functor; // Kind-based Functor
     use crate::kind_based::kind::{
-        CFnKind, CFnOnceKind, Kind, Kind1, OptionKind, ResultKind, VecKind,
+        CFnKind, CFnOnceKind, Kind, Kind1, OptionKind, RcFnKind, ResultKind, VecKind,
     };
+    use std::rc::Rc;
 
     /// Represents a Kind-encoded type that can apply a wrapped function to a wrapped value.
     ///
@@ -163,6 +164,99 @@ pub mod kind {
                 let val_a = value_container.call_once(x_val); // val_a is A
                 func_ab.call(val_a)
             })
+        }
+    }
+
+    // Apply for RcFnKind<X>
+    // The function container is RcFn<X, CFn<A,B>> (outer Rc-backed, inner CFn),
+    // mirroring CFnKind where the container is CFn<X, CFn<A,B>>.
+    impl<X, A, B> Apply<A, B> for RcFnKind<X>
+    where
+        X: 'static + Clone,
+        A: 'static,
+        B: 'static,
+        Self: Functor<A, B>,
+        Self: Kind<Of<A> = RcFn<X, A>>,
+        Self: Kind<Of<CFn<A, B>> = RcFn<X, CFn<A, B>>>,
+        Self: Kind<Of<B> = RcFn<X, B>>,
+    {
+        /// Applies an `RcFn<X, CFn<A,B>>` (a function from environment to a function
+        /// `A -> B`) to an `RcFn<X, A>` (a function from environment to `A`),
+        /// producing `RcFn<X, B>`.  This is the S combinator: `(f x)(g x)`.
+        fn apply(
+            value_container: Self::Of<A>,            // RcFn<X, A>
+            function_container: Self::Of<CFn<A, B>>, // RcFn<X, CFn<A,B>>
+        ) -> Self::Of<B> {
+            let f_rc = function_container.0.clone();
+            let v_rc = value_container.0.clone();
+            RcFn(Rc::new(move |x_val: X| {
+                let func_ab: CFn<A, B> = f_rc(x_val.clone());
+                let val_a: A = v_rc(x_val);
+                func_ab.call(val_a)
+            }))
+        }
+    }
+
+    /// A variant of [`Apply`] where the function container holds [`RcFn<A, B>`]
+    /// instead of [`CFn<A, B>`].
+    ///
+    /// This is needed to implement [`crate::applicative::kind::lift_a1_rc`], which
+    /// wraps a plain `A -> B` function in `RcFn` (not `CFn`) so that the resulting
+    /// value satisfies `T: Clone` — a requirement of `VecKind`'s `Applicative<T>`.
+    ///
+    /// Implemented for [`OptionKind`], [`ResultKind<E>`], and [`VecKind`].
+    pub trait ApplyRc<A, B>: Kind1 {
+        /// Applies a Kind-wrapped `RcFn<A, B>` to a Kind-wrapped `A`, producing `B`.
+        fn apply_rc(value: Self::Of<A>, func: Self::Of<RcFn<A, B>>) -> Self::Of<B>;
+    }
+
+    impl<A: 'static, B: 'static> ApplyRc<A, B> for OptionKind {
+        /// Applies `Option<RcFn<A,B>>` to `Option<A>`.
+        fn apply_rc(value: Self::Of<A>, func: Self::Of<RcFn<A, B>>) -> Self::Of<B> {
+            value.and_then(|val_a| func.map(|f| f.call(val_a)))
+        }
+    }
+
+    impl<A: 'static, B: 'static, E: 'static + Clone> ApplyRc<A, B> for ResultKind<E> {
+        /// Applies `Result<RcFn<A,B>, E>` to `Result<A, E>`.
+        fn apply_rc(value: Self::Of<A>, func: Self::Of<RcFn<A, B>>) -> Self::Of<B> {
+            value.and_then(|val_a| func.map(|f| f.call(val_a)))
+        }
+    }
+
+    impl<A: 'static + Clone, B: 'static> ApplyRc<A, B> for VecKind {
+        /// Applies `Vec<RcFn<A,B>>` to `Vec<A>`, producing the Cartesian product.
+        ///
+        /// Each `RcFn` in `func` is applied to every element of `value`.  Because
+        /// `RcFn` is `Clone`, iterating over `value` multiple times works without
+        /// additional allocation.
+        fn apply_rc(value: Self::Of<A>, func: Self::Of<RcFn<A, B>>) -> Self::Of<B> {
+            func.into_iter()
+                .flat_map(|f_fn| value.iter().map(move |val_a| f_fn.call(val_a.clone())))
+                .collect()
+        }
+    }
+
+    impl<X, A, B> ApplyRc<A, B> for RcFnKind<X>
+    where
+        X: 'static + Clone,
+        A: 'static,
+        B: 'static,
+    {
+        /// Applies `RcFn<X, RcFn<A,B>>` to `RcFn<X, A>`, producing `RcFn<X, B>`.
+        ///
+        /// This is the S-combinator (`apply_rc(v, f)(x) = f(x)(v(x))`) expressed
+        /// through `RcFn` wrappers at every layer.  Because both the outer carrier
+        /// and the inner function wrapper are `RcFn` (and therefore `Clone`), no
+        /// `Box`-to-`Rc` conversion is needed — both `Rc` handles are cheaply shared.
+        fn apply_rc(value: Self::Of<A>, func: Self::Of<RcFn<A, B>>) -> Self::Of<B> {
+            let f_rc = func.0.clone();
+            let v_rc = value.0.clone();
+            RcFn(Rc::new(move |x_val: X| {
+                let inner_fn: RcFn<A, B> = f_rc(x_val.clone());
+                let val_a: A = v_rc(x_val);
+                inner_fn.call(val_a)
+            }))
         }
     }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,9 +1,14 @@
 use std::ops::Deref;
+use std::rc::Rc;
 
 /// Type alias for a boxed, dynamically dispatched, repeatable closure.
 /// `BFn<A, B>` is equivalent to `Box<dyn Fn(A) -> B + 'static>`.
 /// This represents a heap-allocated closure that can be called multiple times.
 type BFn<A, B> = Box<dyn Fn(A) -> B + 'static>;
+
+/// Type alias for an `Rc`-backed, dynamically dispatched, repeatable closure.
+/// `RFn<A, B>` is equivalent to `Rc<dyn Fn(A) -> B + 'static>`.
+type RFn<A, B> = Rc<dyn Fn(A) -> B + 'static>;
 
 /// Type alias for a boxed, dynamically dispatched, once-callable closure.
 /// `BFnOnce<A, B>` is equivalent to `Box<dyn FnOnce(A) -> B + 'static>`.
@@ -16,9 +21,10 @@ type BFnOnce<A, B> = Box<dyn FnOnce(A) -> B + 'static>;
 /// which is useful for storing them in structs or passing them as arguments
 /// where a concrete type is needed (e.g., in trait implementations like `Functor` for functions).
 ///
-/// `CFn` stands for "Clonable Function" or "Composable Function", though it's not inherently `Clone`
-/// unless the underlying boxed closure captures only `Clone` data (which `Box<dyn Fn>` doesn't guarantee).
-/// The primary purpose here is to provide a newtype wrapper.
+/// `CFn` wraps `Box<dyn Fn(A) -> B + 'static>` and is therefore **not** `Clone`
+/// (unique-ownership, box-backed). For a shared-ownership, cheaply-cloneable
+/// sibling, see [`RcFn`], which wraps `Rc<dyn Fn(A) -> B + 'static>` and
+/// implements `Clone` in O(1).
 ///
 /// # Examples
 /// ```
@@ -187,5 +193,115 @@ impl<A: 'static, B: 'static, C: 'static> std::ops::Shl<CFnOnce<A, B>> for CFnOnc
     type Output = CFnOnce<A, C>;
     fn shl(self, rhs: CFnOnce<A, B>) -> Self::Output {
         CFnOnce(compose_fn_once(rhs.0, self.0))
+    }
+}
+
+// ── RcFn ──────────────────────────────────────────────────────────────────────
+
+/// A Clone-able, shared-ownership function wrapper backed by
+/// `Rc<dyn Fn(A) -> B + 'static>`.
+///
+/// `RcFn<A, B>` is the **Clone-able, shared-ownership** sibling of [`CFn`].
+/// While [`CFn`] wraps `Box<dyn Fn(A) -> B + 'static>` and is therefore
+/// **not** `Clone`, `RcFn` wraps `Rc<dyn Fn(A) -> B + 'static>` and
+/// implements `Clone`. Cloning an `RcFn` bumps the `Rc` reference count
+/// in O(1) — the closure body is **not** duplicated.
+///
+/// Unlike `#[derive(Clone)]` (which would add bounds `A: Clone, B: Clone`),
+/// the `Clone` impl here only requires `Rc<dyn Fn(A)->B+'static>: Clone`,
+/// which is always satisfied regardless of `A` and `B`. This allows
+/// `RcFn<X, CFn<A,B>>` to be `Clone` even though `CFn<A,B>` is not.
+///
+/// This makes `RcFn` law-equivalent to a deep copy **only for
+/// referentially-transparent `Fn`** closures (no observable interior
+/// mutability such as `Cell`/`RefCell`). This is the same pattern
+/// [`crate::transformers::reader::ReaderT`] already uses internally with
+/// `Rc<dyn Fn>`.
+///
+/// # Examples
+/// ```
+/// use monadify::function::RcFn;
+///
+/// let f: RcFn<i32, i32> = RcFn::new(|x: i32| x + 1);
+/// let g = f.clone(); // O(1) — shares the underlying closure
+/// assert_eq!(f.call(3), 4);
+/// assert_eq!(g.call(3), 4);
+/// ```
+pub struct RcFn<A, B>(pub RFn<A, B>);
+
+/// Manual `Clone` impl that does NOT add `A: Clone` or `B: Clone` bounds.
+///
+/// `Rc<dyn Fn(A)->B+'static>` is always `Clone` (it just bumps the reference
+/// count), so we can implement `Clone for RcFn<A,B>` unconditionally.
+/// This means `RcFn<X, CFn<A,B>>` is `Clone` even though `CFn<A,B>` is not.
+impl<A, B> Clone for RcFn<A, B> {
+    fn clone(&self) -> Self {
+        RcFn(Rc::clone(&self.0))
+    }
+}
+
+impl<A, B> RcFn<A, B> {
+    /// Creates a new `RcFn` by wrapping the given closure in an `Rc`.
+    ///
+    /// # Parameters
+    /// - `f`: A closure that implements `Fn(A) -> B` and is `'static`.
+    ///
+    /// # Returns
+    /// A new `RcFn<A, B>` instance whose clone shares the same closure allocation.
+    pub fn new<F>(f: F) -> Self
+    where
+        F: Fn(A) -> B + 'static,
+    {
+        RcFn(Rc::new(f))
+    }
+
+    /// Calls the wrapped closure with `arg`.
+    ///
+    /// This method takes `&self`, so the same `RcFn` can be called multiple times.
+    ///
+    /// # Parameters
+    /// - `arg`: The argument of type `A` to pass to the closure.
+    ///
+    /// # Returns
+    /// The result of type `B` from calling the closure.
+    pub fn call(&self, arg: A) -> B {
+        // `self.0.as_ref()` coerces `&Rc<dyn Fn(A)->B>` → `&dyn Fn(A)->B`,
+        // which implements `Fn(A)->B` via the blanket `impl<F: Fn+?Sized> Fn for &F`.
+        (self.0.as_ref())(arg)
+    }
+}
+
+/// Allows `RcFn<A, B>` to be dereferenced to `&Rc<dyn Fn(A) -> B + 'static>`.
+impl<A, B> Deref for RcFn<A, B> {
+    type Target = Rc<dyn Fn(A) -> B + 'static>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Implements `f >> g` (forward composition) for `RcFn`.
+/// `(self >> rhs)(x)` is equivalent to `rhs(self(x))`.
+/// `RcFn<A,B> >> RcFn<B,C>` results in `RcFn<A,C>`.
+impl<A: 'static, B: 'static, C: 'static> std::ops::Shr<RcFn<B, C>> for RcFn<A, B> {
+    type Output = RcFn<A, C>;
+    fn shr(self, rhs: RcFn<B, C>) -> Self::Output {
+        let f = self.0;
+        let g = rhs.0;
+        // Both `f` and `g` are owned `Rc<dyn Fn>` moved into the closure.
+        // Calling `f(x)` auto-derefs `Rc<dyn Fn(A)->B>` → `dyn Fn(A)->B`.
+        RcFn(Rc::new(move |x: A| g(f(x))))
+    }
+}
+
+/// Implements `g << f` (backward composition) for `RcFn`.
+/// `(self << rhs)(x)` is equivalent to `self(rhs(x))`.
+/// `RcFn<B,C> << RcFn<A,B>` results in `RcFn<A,C>`.
+impl<A: 'static, B: 'static, C: 'static> std::ops::Shl<RcFn<A, B>> for RcFn<B, C> {
+    type Output = RcFn<A, C>;
+    fn shl(self, rhs: RcFn<A, B>) -> Self::Output {
+        let f = rhs.0;
+        let g = self.0;
+        RcFn(Rc::new(move |x: A| g(f(x))))
     }
 }

--- a/src/functor.rs
+++ b/src/functor.rs
@@ -16,8 +16,11 @@ pub mod kind {
     //! It relies on the [`Kind1`] trait from `crate::kind_based::kind` to relate the
     //! marker `Self` to its concrete type application `Self::Of<T>`.
 
-    use crate::function::{CFn, CFnOnce};
-    use crate::kind_based::kind::{CFnKind, CFnOnceKind, Kind1, OptionKind, ResultKind, VecKind};
+    use crate::function::{CFn, CFnOnce, RcFn};
+    use crate::kind_based::kind::{
+        CFnKind, CFnOnceKind, Kind1, OptionKind, RcFnKind, ResultKind, VecKind,
+    };
+    use std::rc::Rc;
 
     /// Represents a type constructor that can be mapped over, using the Kind pattern.
     ///
@@ -94,6 +97,26 @@ pub mod kind {
             // result is CFn<X, B>
             // To create a new CFn, the captured 'func' needs to be Clone if 'input' is called multiple times.
             CFn::new(move |x: X| func.clone()(input.call(x))) // func.clone() for new CFn
+        }
+    }
+
+    // Functor impl for RcFnKind (maps over the output type of RcFn)
+    // A is the original output type, B is the new output type.
+    impl<X, A, B> Functor<A, B> for RcFnKind<X>
+    where
+        X: 'static,
+        A: 'static,
+        B: 'static,
+    {
+        /// Maps a function `A -> B` over the output of an `RcFn<X, A>`,
+        /// producing an `RcFn<X, B>`.
+        ///
+        /// The inner `Rc` is cloned (O(1)) to capture the original function in
+        /// the new closure. `func` is `Clone`-d on each invocation to satisfy
+        /// the `Fn` (not `FnMut`) requirement of `Rc<dyn Fn>`.
+        fn map(input: Self::Of<A>, func: impl FnMut(A) -> B + Clone + 'static) -> Self::Of<B> {
+            let inner = input.0.clone();
+            RcFn(Rc::new(move |x: X| func.clone()(inner(x))))
         }
     }
 

--- a/src/kind_based/kind.rs
+++ b/src/kind_based/kind.rs
@@ -16,7 +16,7 @@
 //! the marker's `Of<Arg>` GAT, they can refer to the concrete type
 //! (e.g., `Option<String>`, `Vec<i32>`).
 
-use crate::function::{CFn, CFnOnce};
+use crate::function::{CFn, CFnOnce, RcFn};
 use std::marker::PhantomData;
 
 /// Represents a type constructor, often referred to as a Kind.
@@ -97,6 +97,19 @@ pub struct CFnOnceKind<X>(PhantomData<X>);
 
 impl<X> Kind for CFnOnceKind<X> {
     type Of<Output> = CFnOnce<X, Output>;
+}
+
+/// Kind Marker for `RcFn<X, _>`. `X` is the fixed input type of the function.
+///
+/// Implements [`Kind`] such that `RcFnKind<X>::Of<Output>` resolves to `RcFn<X, Output>`.
+///
+/// Unlike [`CFnKind<X>`], the resolved type `RcFn<X, Output>` is `Clone` (O(1) `Rc` bump),
+/// which enables `Applicative` laws over `VecKind` and `mdo!` do-notation blocks.
+#[derive(Default)]
+pub struct RcFnKind<X>(PhantomData<X>);
+
+impl<X> Kind for RcFnKind<X> {
+    type Of<Output> = RcFn<X, Output>;
 }
 
 // --- Arity Markers ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 pub mod applicative;
 /// Provides the Kind-based `Apply` trait (an extension of `Functor`) and its implementations.
 pub mod apply;
-/// Defines `CFn` and `CFnOnce` for heap-allocated, callable function wrappers.
+/// Defines `CFn`, `RcFn`, and `CFnOnce` for heap-allocated, callable function wrappers.
 pub mod function;
 /// Provides the Kind-based `Functor` trait and its implementations.
 pub mod functor;
@@ -40,7 +40,7 @@ pub use profunctor::{Choice, Profunctor, Strong};
 pub use transformers::reader::MonadReader; // Points to transformers::reader::kind::MonadReader
 
 // Public re-exports of key structs/types (optional, but can be convenient)
-pub use function::{CFn, CFnOnce};
+pub use function::{CFn, CFnOnce, RcFn};
 pub use identity::Identity; // Points to identity::kind::Identity
 pub use transformers::reader::{Reader, ReaderT}; // Points to transformers::reader::kind::ReaderT etc.
 
@@ -53,6 +53,7 @@ pub use kind_based::kind::{
     Kind,
     Kind1, // Core Kind traits
     OptionKind,
+    RcFnKind,
     ResultKind,
     VecKind,
 }; // Changed from ReaderTHKTMarker
@@ -93,12 +94,12 @@ pub mod do_notation;
 ///
 /// # Limitations
 ///
-/// **`CFnKind` / `CFnOnceKind` are not supported.** `CFn` and `CFnOnce` are
-/// not `Clone` (they wrap `Box<dyn Fn(…)>`). Because the desugaring emits
-/// `(expr).clone()` on every monadic right-hand side, any `mdo!` block over
-/// these markers fails with `E0599` at depth ≥ 1. See
-/// `tests/kind/do_notation/cfn_unsupported.rs` and the `monadify-macros`
-/// documentation for the full explanation and the future `Rc`-backed lift.
+/// **`CFnKind` and `CFnOnceKind` are not supported** (not `Clone`; they wrap
+/// `Box<dyn Fn(…)>`). The desugaring emits `(expr).clone()` on every monadic
+/// right-hand side, which fails with `E0599` at depth ≥ 1.
+/// **`RcFnKind` is supported** — it is the `Clone`-able, shared-ownership
+/// sibling backed by `Rc<dyn Fn(…)>`. See `tests/kind/do_notation/cfn_unsupported.rs`
+/// for details.
 ///
 /// At most **one non-`Copy` external value may be captured per `mdo!` nesting
 /// level**. Because the desugaring emits nested `move` closures bound by

--- a/src/monad.rs
+++ b/src/monad.rs
@@ -43,10 +43,11 @@ pub mod kind {
 
     use crate::applicative::kind::Applicative; // Kind-based Applicative
     use crate::apply::kind::Apply; // Kind-based Apply
-    use crate::function::{CFn, CFnOnce};
+    use crate::function::{CFn, CFnOnce, RcFn};
     use crate::kind_based::kind::{
-        CFnKind, CFnOnceKind, Kind, Kind1, OptionKind, ResultKind, VecKind,
+        CFnKind, CFnOnceKind, Kind, Kind1, OptionKind, RcFnKind, ResultKind, VecKind,
     };
+    use std::rc::Rc;
 
     /// Kind-based `Monad` trait.
     ///
@@ -220,6 +221,36 @@ pub mod kind {
         }
     }
 
+    // Bind for RcFnKind<R> (Kleisli composition for R -> _)
+    // input: RcFn<R, A>; func: A -> RcFn<R, B>; result: RcFn<R, B>
+    impl<R, A, B: 'static> Bind<A, B> for RcFnKind<R>
+    where
+        R: 'static + Clone,
+        A: 'static,
+        Self: Apply<A, B>,
+        Self: Kind<Of<A> = RcFn<R, A>>,
+        Self: Kind<Of<B> = RcFn<R, B>>,
+    {
+        /// Implements Kleisli composition for `RcFn<R, A>` and `A -> RcFn<R, B>`.
+        ///
+        /// The resulting `RcFn<R, B>`, when called with `r: R`:
+        /// 1. Calls `input(r.clone())` to get `a: A`.
+        /// 2. Calls `func(a)` to get `rcfn_r_b: RcFn<R, B>`.
+        /// 3. Calls `rcfn_r_b(r)` to get `b: B`.
+        fn bind(
+            input: Self::Of<A>,
+            func: impl FnMut(A) -> Self::Of<B> + Clone + 'static,
+        ) -> Self::Of<B> {
+            let inner = input.0.clone();
+            RcFn(Rc::new(move |r: R| {
+                let a_val = inner(r.clone());
+                let mut func_clone = func.clone();
+                let rcfn_r_b: RcFn<R, B> = func_clone(a_val);
+                rcfn_r_b.call(r)
+            }))
+        }
+    }
+
     impl<R, A, B: 'static> Bind<A, B> for CFnOnceKind<R>
     // Changed CFnOnceHKTMarker to CFnOnceKind
     where
@@ -300,6 +331,21 @@ pub mod kind {
             // mma is CFn<R, CFn<R,A>>. Changed Applied to Of
             // Bind<Self::Of<A>, A> means Bind<CFn<R,A>, A>
             <Self as Bind<Self::Of<A>, A>>::bind(mma, |ma: Self::Of<A>| ma) // Changed Applied to Of
+        }
+    }
+
+    impl<R, A> Monad<A> for RcFnKind<R>
+    where
+        R: 'static + Clone,
+        A: 'static + Clone, // required by Applicative<A> supertrait for RcFnKind<R>
+    {
+        /// Flattens `RcFn<R, RcFn<R, A>>` to `RcFn<R, A>`.
+        ///
+        /// Implemented via `bind` with the identity function `|ma: RcFn<R,A>| ma`.
+        /// Because `RcFn` is `Clone`, the inner type `A = RcFn<R, A>` satisfies
+        /// the `Clone` constraint that prevented this from working with `CFnKind`.
+        fn join(mma: Self::Of<Self::Of<A>>) -> Self::Of<A> {
+            <Self as Bind<Self::Of<A>, A>>::bind(mma, |ma: Self::Of<A>| ma)
         }
     }
 

--- a/tests/kind/cfn_clonable.rs
+++ b/tests/kind/cfn_clonable.rs
@@ -1,0 +1,659 @@
+//! Tests for `RcFn<A,B>` — the `Rc`-backed, cheaply-clone-able function wrapper —
+//! and `RcFnKind<X>` — its Kind marker implementing the full `Functor`/`Apply`/
+//! `Applicative`/`Bind`/`Monad` hierarchy.
+//!
+//! # RED-phase notice
+//!
+//! `RcFn`, `RcFnKind`, and `lift_a1_rc` do **not yet exist** in `monadify`.
+//! This file causes a compile error until the implementer adds them. That is the
+//! intended RED state of the ATDD/TDD cycle.
+//!
+//! # Why `RcFn` and not `CFn`
+//!
+//! `CFn<A,B>` wraps `Box<dyn Fn(A)->B + 'static>`. `Box<dyn Fn(…)>` is **not
+//! `Clone`**, so `CFn` is not `Clone` either. This blocks:
+//!
+//! - `VecKind`'s `Applicative<CFn<A,B>>` impl (needs `CFn: Clone`).
+//! - `mdo!` blocks over `CFnKind` (desugaring emits `.clone()` on every RHS).
+//! - Any law test that needs to reuse the same `CFn` value on both sides.
+//!
+//! `RcFn<A,B>` wraps `Rc<dyn Fn(A)->B + 'static>` and derives `Clone`. Cloning
+//! bumps the reference count in O(1) — the closure body is **not** duplicated.
+//! This resolves all three blockers.
+//!
+//! # Running
+//!
+//! ```text
+//! cargo test --all-features cfn_clonable
+//! cargo test --features do-notation cfn_clonable
+//! ```
+
+use core::convert::identity;
+// NOTE: `lift_a1_rc` is the expected export name. The implementer may choose a
+// different sibling name (e.g. a generic `lift_a1` overload taking `RcFn`). The
+// assertion in the test below pins the VALUE, not the name.
+use monadify::applicative::kind::{lift_a1, lift_a1_rc, Applicative};
+use monadify::apply::kind::Apply;
+use monadify::function::{CFn, CFnOnce, RcFn};
+use monadify::functor::kind::Functor;
+use monadify::kind_based::kind::{RcFnKind, VecKind};
+use monadify::monad::kind::{Bind, Monad};
+use std::rc::Rc;
+
+// ── 1. Clone is shared & O(1) ─────────────────────────────────────────────────
+
+/// Cloning an `RcFn` bumps the outer `Rc` reference count — it does NOT
+/// duplicate the closure body. We prove this using a sentinel `Rc` captured
+/// inside the closure: if clone were deep (like `Box`-clone), the sentinel's
+/// `strong_count` would increase. With `Rc`-backed sharing it stays constant.
+///
+/// Closures are PURE (no interior mutability) per the law-safety contract.
+#[test]
+fn cfn_clonable_rcfn_clone_is_shared_o1() {
+    // A sentinel lets us observe whether the closure allocation is shared.
+    let sentinel: Rc<u32> = Rc::new(42);
+    let inner = Rc::clone(&sentinel); // strong_count == 2
+
+    let f: RcFn<i32, i32> = RcFn::new(move |x: i32| {
+        let _ = &inner; // force capture; `inner` stays alive inside the closure
+        x + 1 // pure — no mutation of captured state
+    });
+
+    // Before cloning: sentinel strong_count == 2 (this binding + `inner` inside f).
+    assert_eq!(Rc::strong_count(&sentinel), 2);
+
+    // Clone the RcFn: O(1) Rc bump on the outer wrapper, NOT on `inner`.
+    let g = f.clone();
+
+    // After cloning: still 2 — the closure body was NOT duplicated.
+    assert_eq!(
+        Rc::strong_count(&sentinel),
+        2,
+        "RcFn::clone must share the underlying closure; sentinel strong_count must not increase"
+    );
+
+    // Both handles produce the same result.
+    assert_eq!(f.call(3), 4);
+    assert_eq!(g.call(3), 4);
+    assert_eq!(f.call(10), 11);
+    assert_eq!(g.call(10), 11);
+
+    // Dropping g releases its share of the outer Rc; f still holds `inner`.
+    drop(g);
+    assert_eq!(Rc::strong_count(&sentinel), 2);
+
+    // Dropping f releases the shared closure; `inner` inside it is gone.
+    drop(f);
+    assert_eq!(
+        Rc::strong_count(&sentinel),
+        1,
+        "after dropping all RcFn handles, only the local `sentinel` remains"
+    );
+}
+
+/// Calling the same `RcFn` multiple times via `&self` gives consistent results
+/// (Fn semantics, not FnOnce).
+#[test]
+fn cfn_clonable_rcfn_call_is_repeatable() {
+    let f: RcFn<i32, i32> = RcFn::new(|x: i32| x * 3);
+    assert_eq!(f.call(4), 12);
+    assert_eq!(f.call(4), 12); // same value — pure closure
+    assert_eq!(f.call(7), 21);
+}
+
+/// Forward composition `>>` mirrors `CFn`'s `Shr` impl.
+/// `(f >> g)(x) == g(f(x))`.
+#[test]
+fn cfn_clonable_rcfn_forward_compose_shr() {
+    let f: RcFn<i32, i32> = RcFn::new(|x: i32| x + 1);
+    let g: RcFn<i32, String> = RcFn::new(|x: i32| x.to_string());
+    let h: RcFn<i32, String> = f >> g; // (f >> g)(4) == g(f(4)) == "5"
+    assert_eq!(h.call(4), "5".to_string());
+    assert_eq!(h.call(0), "1".to_string());
+}
+
+/// Backward composition `<<` mirrors `CFn`'s `Shl` impl.
+/// `(g << f)(x) == g(f(x))`.
+#[test]
+fn cfn_clonable_rcfn_backward_compose_shl() {
+    let f: RcFn<i32, i32> = RcFn::new(|x: i32| x + 1);
+    let g: RcFn<i32, String> = RcFn::new(|x: i32| x.to_string());
+    let h: RcFn<i32, String> = g << f; // (g << f)(4) == g(f(4)) == "5"
+    assert_eq!(h.call(4), "5".to_string());
+    assert_eq!(h.call(9), "10".to_string());
+}
+
+/// `Deref` exposes the underlying `Rc<dyn Fn(A)->B + 'static>`.
+#[test]
+fn cfn_clonable_rcfn_deref_exposes_inner_rc() {
+    let f: RcFn<i32, i32> = RcFn::new(|x: i32| x * 2);
+    // Deref should give us a reference to the inner Rc.
+    let rc_ref: &Rc<dyn Fn(i32) -> i32 + 'static> = &f;
+    // The Rc is uniquely owned (strong_count == 1) before any clone.
+    assert_eq!(Rc::strong_count(rc_ref), 1);
+    assert_eq!(f.call(6), 12);
+}
+
+// ── 2. Functor laws for RcFnKind ──────────────────────────────────────────────
+
+mod rcfn_kind_functor_laws {
+    use super::*;
+    type Env = i32;
+
+    /// Functor identity: `map(fa, |x| x)(env) == fa(env)` for all `env`.
+    ///
+    /// `RcFn` being `Clone` lets us hold `fa` and compare both sides directly —
+    /// a capability `CFn` lacked.
+    #[test]
+    fn cfn_clonable_rcfn_kind_functor_identity() {
+        let env_val: Env = 7;
+        let fa: RcFn<Env, i32> = RcFn::new(|env: Env| env * 3); // fa(7) == 21
+
+        let mapped = RcFnKind::<Env>::map(fa.clone(), |x: i32| x);
+
+        assert_eq!(mapped.call(env_val), fa.call(env_val));
+        assert_eq!(mapped.call(env_val), 21);
+    }
+
+    /// Functor composition: `map(map(fa, f), g)(env) == map(fa, g∘f)(env)`.
+    #[test]
+    fn cfn_clonable_rcfn_kind_functor_composition() {
+        let env_val: Env = 4;
+        let fa: RcFn<Env, i32> = RcFn::new(|env: Env| env + 1); // fa(4) == 5
+
+        let f = |x: i32| x * 2; // f(5) == 10
+        let g = |y: i32| y.to_string(); // g(10) == "10"
+
+        // Sequential map (lhs)
+        let lhs = RcFnKind::<Env>::map(RcFnKind::<Env>::map(fa.clone(), f), g);
+        // Single composed map (rhs)
+        let rhs = RcFnKind::<Env>::map(fa.clone(), move |x| g(f(x)));
+
+        assert_eq!(lhs.call(env_val), rhs.call(env_val));
+        assert_eq!(lhs.call(env_val), "10".to_string());
+    }
+
+    /// Composition with type change (string length), demonstrating `A != B`.
+    #[test]
+    fn cfn_clonable_rcfn_kind_functor_composition_type_change() {
+        let env_val: Env = 3;
+        let fa: RcFn<Env, &str> = RcFn::new(|_env: Env| "hello");
+
+        let f = |s: &str| s.to_uppercase(); // f("hello") == "HELLO"
+        let g = |s: String| s.len(); // g("HELLO") == 5
+
+        let lhs = RcFnKind::<Env>::map(RcFnKind::<Env>::map(fa.clone(), f), g);
+        let rhs = RcFnKind::<Env>::map(fa, move |s| g(f(s)));
+
+        assert_eq!(lhs.call(env_val), rhs.call(env_val));
+        assert_eq!(lhs.call(env_val), 5_usize);
+    }
+}
+
+// ── 3. Applicative laws for RcFnKind ──────────────────────────────────────────
+
+mod rcfn_kind_applicative_laws {
+    use super::*;
+    type Env = i32;
+
+    /// Applicative identity: `apply(v, pure(id)) == v`.
+    ///
+    /// `RcFn` being `Clone` lets us hold `v` and compare both sides.
+    #[test]
+    fn cfn_clonable_rcfn_kind_applicative_law_identity() {
+        let env_val: Env = 11;
+        let v: RcFn<Env, i32> = RcFn::new(|env: Env| env + 100); // v(11) == 111
+
+        let id_cfn = CFn::new(identity::<i32>);
+        let pure_id: RcFn<Env, CFn<i32, i32>> = RcFnKind::<Env>::pure(id_cfn);
+
+        let applied = RcFnKind::<Env>::apply(v.clone(), pure_id);
+
+        assert_eq!(applied.call(env_val), v.call(env_val));
+        assert_eq!(applied.call(env_val), 111);
+    }
+
+    /// Applicative homomorphism: `apply(pure(x), pure(f)) == pure(f(x))`.
+    ///
+    /// `pure` ignores the environment, so any `env_val` produces the same result.
+    #[test]
+    fn cfn_clonable_rcfn_kind_applicative_law_homomorphism() {
+        let env_val: Env = 0; // pure ignores env
+        let x: i32 = 10;
+        let f = |val: i32| val * 2;
+
+        let lhs =
+            RcFnKind::<Env>::apply(RcFnKind::<Env>::pure(x), RcFnKind::<Env>::pure(CFn::new(f)));
+        let rhs: RcFn<Env, i32> = RcFnKind::<Env>::pure(f(x)); // pure(20)
+
+        assert_eq!(lhs.call(env_val), rhs.call(env_val));
+        assert_eq!(lhs.call(env_val), 20);
+    }
+
+    /// Applicative composition law: `apply(apply(w, v), u)` equals the
+    /// ground-truth `u_fn(v_fn(w(env)))`, the right-associated form
+    /// `u <*> (v <*> w)`.
+    ///
+    /// This was untestable for `CFnKind` (CFn not Clone) but IS testable for
+    /// `RcFnKind` because all three readers (`w`, `v`, `u`) can be cloned and
+    /// evaluated at multiple environments without rebuilding from scratch.
+    #[test]
+    fn cfn_clonable_rcfn_kind_applicative_law_composition() {
+        // w: RcFn<Env, i32> — value reader: w(env) = env * 2
+        let w: RcFn<Env, i32> = RcFn::new(|env: Env| env * 2);
+        // v: RcFn<Env, CFn<i32, i32>> — first function reader: v(env)(x) = x + env
+        let v: RcFn<Env, CFn<i32, i32>> = RcFn::new(|env: Env| CFn::new(move |x: i32| x + env));
+        // u: RcFn<Env, CFn<i32, String>> — second function reader: u(env)(y) = (y * env).to_string()
+        let u: RcFn<Env, CFn<i32, String>> =
+            RcFn::new(|env: Env| CFn::new(move |y: i32| (y * env).to_string()));
+
+        // apply(apply(w, v), u) — right-associated: u <*> (v <*> w)
+        let inner: RcFn<Env, i32> = RcFnKind::<Env>::apply(w.clone(), v.clone());
+        let result: RcFn<Env, String> = RcFnKind::<Env>::apply(inner, u.clone());
+
+        // env = 5: w(5)=10, v(5)(10)=15, u(5)(15)="75"
+        assert_eq!(result.call(5), "75".to_string());
+        // env = 3: w(3)=6, v(3)(6)=9, u(3)(9)="27"
+        assert_eq!(result.call(3), "27".to_string());
+        // env = 1: w(1)=2, v(1)(2)=3, u(1)(3)="3"
+        assert_eq!(result.call(1), "3".to_string());
+    }
+
+    /// Applicative interchange: `apply(pure(y), u) == apply(u, pure(|f_fn| f_fn(y)))`.
+    ///
+    /// LHS uses `Apply<A, B>`; RHS uses `Apply<CFn<A,B>, B>`. The `u` value is
+    /// shared via `Clone` (not rebuilt from a factory), demonstrating the advantage
+    /// of `RcFn` over `CFn`.
+    #[test]
+    fn cfn_clonable_rcfn_kind_applicative_law_interchange() {
+        type A = i32;
+        type B = String;
+        let env_val: Env = 99; // constant env; u ignores it (pure-like)
+
+        let y_val: A = 10;
+
+        // u: an RcFn<Env, CFn<A,B>> that always returns the same concrete CFn.
+        // Because RcFn is Clone, we can share `u` between lhs and rhs.
+        let u: RcFn<Env, CFn<A, B>> =
+            RcFn::new(move |_env: Env| CFn::new(|val: A| format!("val:{}", val)));
+
+        let pure_y: RcFn<Env, A> = RcFnKind::<Env>::pure(y_val);
+
+        // LHS: apply(pure(y), u)  — Apply<A, B>
+        let lhs = RcFnKind::<Env>::apply(pure_y, u.clone());
+
+        // RHS: apply(u, pure(|f_fn| f_fn(y)))  — Apply<CFn<A,B>, B>
+        let interchange = CFn::new(move |f_fn: CFn<A, B>| f_fn.call(y_val));
+        let pure_interchange: RcFn<Env, CFn<CFn<A, B>, B>> = RcFnKind::<Env>::pure(interchange);
+        let rhs = RcFnKind::<Env>::apply(u, pure_interchange);
+
+        assert_eq!(lhs.call(env_val), rhs.call(env_val));
+        assert_eq!(lhs.call(env_val), "val:10".to_string());
+    }
+}
+
+// ── 4. Monad laws for RcFnKind ────────────────────────────────────────────────
+
+mod rcfn_kind_monad_laws {
+    use super::*;
+    type Env = i32;
+
+    /// Monad left identity: `bind(pure(a), f)(env) == f(a)(env)`.
+    ///
+    /// `RcFn` being `Clone` lets us run both sides against the same env rather
+    /// than relying on a creator factory (as `CFnKind` tests required).
+    #[test]
+    fn cfn_clonable_rcfn_kind_monad_left_identity() {
+        let env_val: Env = 5;
+        let a: i32 = 10;
+
+        let f =
+            move |x: i32| -> RcFn<Env, String> { RcFn::new(move |env: Env| (x + env).to_string()) };
+
+        let pure_a: RcFn<Env, i32> = RcFnKind::<Env>::pure(a);
+        let lhs: RcFn<Env, String> = RcFnKind::<Env>::bind(pure_a, f);
+        let rhs: RcFn<Env, String> = f(a);
+
+        // Both sides are Clone; compare by running at the same env.
+        assert_eq!(lhs.call(env_val), rhs.call(env_val));
+        assert_eq!(lhs.call(env_val), "15".to_string()); // 10 + 5
+    }
+
+    /// Monad right identity: `bind(m, pure)(env) == m(env)`.
+    ///
+    /// `m` is `Clone` — no factory needed.
+    #[test]
+    fn cfn_clonable_rcfn_kind_monad_right_identity() {
+        let env_val: Env = 7;
+        let m: RcFn<Env, i32> = RcFn::new(|env: Env| env * 2); // m(7) == 14
+
+        let pure_fn = move |val: i32| RcFnKind::<Env>::pure(val);
+        let lhs: RcFn<Env, i32> = RcFnKind::<Env>::bind(m.clone(), pure_fn);
+
+        assert_eq!(lhs.call(env_val), m.call(env_val));
+        assert_eq!(lhs.call(env_val), 14);
+    }
+
+    /// Monad associativity: `bind(bind(m, f), g) == bind(m, |x| bind(f(x), g))`.
+    ///
+    /// All three of `m`, the intermediate result, and both sides are `Clone`,
+    /// so we never need duplicate creator lambdas.
+    #[test]
+    fn cfn_clonable_rcfn_kind_monad_associativity() {
+        let env_val: Env = 3;
+        // m(3) == 4
+        let m: RcFn<Env, i32> = RcFn::new(|env: Env| env + 1);
+
+        // f(4)(3) == (4 * 3) as f64 == 12.0
+        let f = move |x: i32| -> RcFn<Env, f64> { RcFn::new(move |env: Env| (x * env) as f64) };
+        // g(12.0)(3) == (12.0 + 3.0).to_string() == "15"
+        let g = move |y: f64| -> RcFn<Env, String> {
+            RcFn::new(move |env: Env| (y + env as f64).to_string())
+        };
+
+        // LHS: bind(bind(m, f), g)
+        let lhs: RcFn<Env, String> = RcFnKind::<Env>::bind(RcFnKind::<Env>::bind(m.clone(), f), g);
+
+        // RHS: bind(m, |x| bind(f(x), g))
+        let rhs: RcFn<Env, String> =
+            RcFnKind::<Env>::bind(m.clone(), move |x| RcFnKind::<Env>::bind(f(x), g));
+
+        assert_eq!(lhs.call(env_val), rhs.call(env_val));
+        assert_eq!(lhs.call(env_val), "15".to_string());
+    }
+
+    /// Monad join law 1: `join(pure(pure(x)))(env) == pure(x)(env) == x`.
+    ///
+    /// **This is the key capability `CFnKind` lacked**: `Monad<A>` for `RcFnKind<R>`
+    /// requires `A: Clone` (via the `Applicative` supertrait). For `join` over
+    /// `RcFn<R, RcFn<R, i32>>`, the type `A` is `RcFn<R, i32>` — which IS
+    /// `Clone` because `RcFn` derives `Clone`. `CFn` could not be `A` here.
+    #[test]
+    fn cfn_clonable_rcfn_kind_monad_join_law1() {
+        let env_val: Env = 5;
+        let x: i32 = 10;
+
+        // inner: RcFn<Env, i32> — Clone, so Monad<RcFn<Env,i32>> compiles.
+        let inner: RcFn<Env, i32> = RcFnKind::<Env>::pure(x);
+        // outer: RcFn<Env, RcFn<Env, i32>> — pure needs T: Clone, which holds.
+        let outer: RcFn<Env, RcFn<Env, i32>> = RcFnKind::<Env>::pure(inner.clone());
+
+        let lhs: RcFn<Env, i32> = RcFnKind::<Env>::join(outer);
+        let rhs: RcFn<Env, i32> = RcFnKind::<Env>::pure(x);
+
+        assert_eq!(lhs.call(env_val), rhs.call(env_val));
+        assert_eq!(lhs.call(env_val), x);
+    }
+
+    /// Monad join law 2: `join(map(m, pure))(env) == m(env)`.
+    #[test]
+    fn cfn_clonable_rcfn_kind_monad_join_law2() {
+        let env_val: Env = 7;
+        let m: RcFn<Env, i32> = RcFn::new(|env: Env| env * 3); // m(7) == 21
+
+        let pure_fn = move |val: i32| RcFnKind::<Env>::pure(val);
+        // map(m, pure) :: RcFn<Env, RcFn<Env, i32>>  — works because RcFn is Clone
+        let mapped: RcFn<Env, RcFn<Env, i32>> = RcFnKind::<Env>::map(m.clone(), pure_fn);
+        let lhs: RcFn<Env, i32> = RcFnKind::<Env>::join(mapped);
+
+        assert_eq!(lhs.call(env_val), m.call(env_val));
+        assert_eq!(lhs.call(env_val), 21);
+    }
+
+    /// Monad join law 3: `join(pure(m))(env) == m(env)`.
+    #[test]
+    fn cfn_clonable_rcfn_kind_monad_join_law3() {
+        let env_val: Env = 4;
+        let m: RcFn<Env, i32> = RcFn::new(|env: Env| env + 10); // m(4) == 14
+
+        // pure(m) :: RcFn<Env, RcFn<Env, i32>> — needs m: Clone, which holds.
+        let pure_m: RcFn<Env, RcFn<Env, i32>> = RcFnKind::<Env>::pure(m.clone());
+        let lhs: RcFn<Env, i32> = RcFnKind::<Env>::join(pure_m);
+
+        assert_eq!(lhs.call(env_val), m.call(env_val));
+        assert_eq!(lhs.call(env_val), 14);
+    }
+}
+
+// ── 5. Re-enabled lift_a1::<VecKind> via RcFn ────────────────────────────────
+
+/// `lift_a1::<VecKind>` was blocked because the existing `lift_a1` builds
+/// `F::pure(CFn::new(func))` and `VecKind::pure` requires `T: Clone`; since
+/// `CFn<A,B>` is not `Clone`, the call fails to compile (the commented-out
+/// example at `src/applicative.rs:211-218`).
+///
+/// An `RcFn`-based sibling (`lift_a1_rc` or an `RcFn`-generic `lift_a1`) builds
+/// `F::pure(RcFn::new(func))` instead. `RcFn<A,B>` IS `Clone`, so
+/// `VecKind::Applicative<RcFn<A,B>>` compiles and the path is unblocked.
+///
+/// NOTE: The exact name of the sibling function (`lift_a1_rc` or a renamed
+/// generic `lift_a1`) is **to be finalized by the implementer**. The call below
+/// uses `lift_a1_rc` as a placeholder; the assertion pins the VALUE, not the name.
+#[test]
+fn cfn_clonable_vec_lift_a1_rc_reenabled() {
+    let fa: Vec<i32> = vec![1, 2, 3];
+    // 1 % 2 == 1 => false, 2 % 2 == 0 => true, 3 % 2 == 1 => false
+    let result: Vec<bool> = lift_a1_rc::<VecKind, i32, bool, _>(|x: i32| x % 2 == 0, fa);
+    assert_eq!(result, vec![false, true, false]);
+}
+
+// ── 5b. lift_a1::<RcFnKind<Env>> — newly unlocked ────────────────────────────
+
+/// `lift_a1::<RcFnKind<Env>>` now compiles because the specialized
+/// `Applicative<CFn<A,B>> for RcFnKind<X>` impl provides a `pure` for
+/// `CFn<A,B>` (the non-Clone type used as the function container) by converting
+/// the inner `Box` to `Rc`. This unblocks the `lift_a1` code path, which calls
+/// `F::pure(CFn::new(func))` internally, for `RcFnKind`.
+///
+/// The resulting `RcFn<Env, B>` maps over the environment via the standard
+/// S-combinator `Apply` instance: `result(env) = func(fa(env))`.
+#[test]
+fn cfn_clonable_rcfn_kind_lift_a1_reenabled() {
+    type Env = i32;
+    let env_val: Env = 5;
+
+    // fa: RcFn<Env, i32> — reader: fa(5) = 10
+    let fa: RcFn<Env, i32> = RcFn::new(|env: Env| env * 2);
+
+    // lift_a1::<RcFnKind<Env>> lifts |x| x.to_string() to operate on RcFn
+    let result: RcFn<Env, String> =
+        lift_a1::<RcFnKind<Env>, i32, String, _>(|x: i32| x.to_string(), fa);
+
+    // result(5) = (5 * 2).to_string() = "10"
+    assert_eq!(result.call(env_val), "10".to_string());
+    assert_eq!(result.call(1), "2".to_string());
+    assert_eq!(result.call(0), "0".to_string());
+}
+
+// ── 6. CFnOnce: intentionally stays non-Clone ─────────────────────────────────
+
+/// `CFnOnce` wraps `Box<dyn FnOnce(A) -> B + 'static>`. `Box<dyn FnOnce(…)>` is
+/// **not `Clone`** — trait objects cannot be cloned generically — so `CFnOnce`
+/// must NOT derive `Clone`. This is an intentional API contract:
+///
+/// - `CFnOnce` models single-shot, move-only computations.
+/// - Adding `Clone` would require knowing the concrete closure type at compile
+///   time, which contradicts the dynamic-dispatch boxing.
+/// - `mdo!` blocks over `CFnOnceKind` therefore remain unsupported; see
+///   `tests/kind/do_notation/cfn_unsupported.rs` for the full explanation.
+///
+/// Compile-fail evidence (no `trybuild` dev-dep needed — kept as a doc comment):
+///
+/// ```compile_fail
+/// use monadify::function::CFnOnce;
+/// let f: CFnOnce<i32, i32> = CFnOnce::new(|x| x + 1);
+/// let _g = f.clone(); // E0599: CFnOnce does not implement Clone
+/// ```
+///
+/// The runtime test below confirms single-shot semantics are intact and that
+/// no accidental `Clone` impl was added (which would have allowed double-call).
+///
+// CFnOnce: NOT Clone by design — this is an intentional design decision.
+#[test]
+fn cfn_clonable_cfnonce_stays_non_clone_guard() {
+    let f: CFnOnce<i32, i32> = CFnOnce::new(|x: i32| x * 7);
+    // Single-shot call works as expected.
+    assert_eq!(f.call_once(6), 42);
+    // `f` is consumed after `call_once`; no `.clone()` is available.
+    // The compile_fail doc comment above documents the compile-time enforcement.
+    //
+    // CFnOnce: NOT Clone by design.
+}
+
+// ── 7. RcFn through mdo! (feature-gated) ────────────────────────────────────
+//
+// Gated exactly like the existing do-notation tests (`tests/kind/do_notation/`):
+// the parent `mod.rs` gate is `#[cfg(feature = "do-notation")]`.
+//
+// `RcFn` is `Clone`, so the `mdo!` desugaring's automatic `.clone()` on every
+// bind RHS compiles — the blocker that excluded `CFn`/`CFnOnce` is resolved.
+
+#[cfg(feature = "do-notation")]
+mod rcfn_kind_mdo {
+    //! `mdo!` do-block tests for `RcFnKind` (the function / reader monad).
+    //!
+    //! These tests exercise the gap `CFn` could NOT fill: because `mdo!` emits
+    //! `(expr).clone()` on every monadic RHS, any monad whose carrier is not
+    //! `Clone` cannot appear in a do-block. `RcFn` derives `Clone` (O(1) Rc
+    //! bump), so `RcFnKind` works transparently with `mdo!`.
+
+    use monadify::applicative::kind::Applicative;
+    use monadify::function::RcFn;
+    use monadify::kind_based::kind::RcFnKind;
+    use monadify::mdo;
+    use monadify::monad::kind::Bind;
+
+    /// Environment type threaded through the do-block.
+    type Env = i32;
+    /// Kind-marker alias so `mdo! { RcReaderKind; … }` is readable — mirrors the
+    /// `type ReaderKind = ReaderTKind<Config, IdentityKind>` alias in `reader.rs`.
+    type RcReaderKind = RcFnKind<Env>;
+
+    /// Two `RcFn` steps bound in sequence both read from the same environment.
+    ///
+    /// `x <- RcFn::new(|env| env * 2)` binds `x = env * 2`.
+    /// `y <- RcFn::new(|env| env + 1)` binds `y = env + 1`.
+    /// Final: `x + y`.
+    ///
+    /// At env = 5: x = 10, y = 6, result = 16.
+    #[test]
+    fn cfn_clonable_rcfn_kind_mdo_two_bindings() {
+        let computation: RcFn<Env, i32> = mdo! {
+            RcReaderKind;
+            x <- RcFn::new(|env: Env| env * 2);
+            y <- RcFn::new(|env: Env| env + 1);
+            RcReaderKind::pure(x.wrapping_add(y))
+        };
+
+        assert_eq!(computation.call(5), 16); // 10 + 6
+        assert_eq!(computation.call(0), 1); // 0 + 1
+        assert_eq!(computation.call(-1), -2); // -2 + 0
+    }
+
+    /// The `mdo!` desugaring must produce the same result as an equivalent
+    /// hand-written nested `Bind::bind` chain for every concrete environment.
+    ///
+    /// Closures cannot be compared structurally; we compare by running both
+    /// against the same set of environment values (mirroring `reader.rs`).
+    #[test]
+    fn cfn_clonable_rcfn_kind_mdo_equivalence_matches_hand_written_bind() {
+        // lhs: built by the macro.
+        let lhs: RcFn<Env, i32> = mdo! {
+            RcReaderKind;
+            x <- RcFn::new(|env: Env| env.wrapping_mul(2));
+            y <- RcFn::new(|env: Env| env.wrapping_add(1));
+            RcReaderKind::pure(x.wrapping_add(y))
+        };
+
+        // rhs: the exact desugared form `mdo!` emits.
+        let rhs: RcFn<Env, i32> =
+            RcReaderKind::bind(RcFn::new(|env: Env| env.wrapping_mul(2)), move |x| {
+                RcReaderKind::bind(RcFn::new(|env: Env| env.wrapping_add(1)), move |y| {
+                    RcReaderKind::pure(x.wrapping_add(y))
+                })
+            });
+
+        let envs: &[Env] = &[0, 1, -3, 5, i32::MAX / 2, i32::MIN / 2];
+        for &env in envs {
+            assert_eq!(
+                lhs.call(env),
+                rhs.call(env),
+                "mdo! and hand-written bind disagree at env = {}",
+                env
+            );
+        }
+    }
+
+    /// Three-binding chain confirms desugaring depth > 2 is correct.
+    ///
+    /// `a + b + c` where `a = env`, `b = 2*env`, `c = 3*env`, so result = `6*env`.
+    #[test]
+    fn cfn_clonable_rcfn_kind_mdo_three_bindings_chain() {
+        let computation: RcFn<Env, i32> = mdo! {
+            RcReaderKind;
+            a <- RcFn::new(|env: Env| env);
+            b <- RcFn::new(|env: Env| env.wrapping_mul(2));
+            c <- RcFn::new(|env: Env| env.wrapping_mul(3));
+            RcReaderKind::pure(a.wrapping_add(b).wrapping_add(c))
+        };
+
+        assert_eq!(computation.call(4), 24); // 4 + 8 + 12
+        assert_eq!(computation.call(0), 0);
+        assert_eq!(computation.call(-1), -6); // -1 + -2 + -3
+    }
+
+    /// A `let` binding inside the block introduces a pure local name.
+    #[test]
+    fn cfn_clonable_rcfn_kind_mdo_let_binding_inside_block() {
+        let computation: RcFn<Env, i32> = mdo! {
+            RcReaderKind;
+            x <- RcFn::new(|env: Env| env * 3);
+            let scaled = x * 10;
+            RcReaderKind::pure(scaled)
+        };
+
+        // env = 2: x = 6, scaled = 60
+        assert_eq!(computation.call(2), 60);
+        // env = -1: x = -3, scaled = -30
+        assert_eq!(computation.call(-1), -30);
+    }
+
+    /// Bare `pure(x)` in the final position of an `mdo!` block over `RcFnKind`.
+    ///
+    /// The macro rewrites the bare `pure(x + y)` to
+    /// `<RcReaderKind as ::monadify::applicative::kind::Applicative<_>>::pure(x + y)`.
+    /// This resolves to `RcFnKind::<Env>::pure(x + y)` — a constant reader
+    /// ignoring `env` and always returning `x + y`.
+    ///
+    /// This exercises the macro's `pure` rewrite for the `RcFnKind` marker.
+    #[cfg(feature = "do-notation")]
+    #[test]
+    fn cfn_clonable_rcfn_kind_mdo_bare_pure_final_position() {
+        let computation: RcFn<Env, i32> = mdo! {
+            RcReaderKind;
+            x <- RcFn::new(|env: Env| env * 2);
+            y <- RcFn::new(|env: Env| env + 1);
+            pure(x + y)
+        };
+
+        // env = 5: x = 10, y = 6, result = 16
+        assert_eq!(computation.call(5), 16);
+        // env = 0: x = 0, y = 1, result = 1
+        assert_eq!(computation.call(0), 1);
+        // Cross-check: must agree with the hand-written qualified form.
+        let reference: RcFn<Env, i32> =
+            RcReaderKind::bind(RcFn::new(|env: Env| env * 2), move |x| {
+                RcReaderKind::bind(RcFn::new(|env: Env| env + 1), move |y| {
+                    RcReaderKind::pure(x + y)
+                })
+            });
+        for &env in &[0i32, 1, 5, -3, 100] {
+            assert_eq!(
+                computation.call(env),
+                reference.call(env),
+                "bare pure and qualified pure disagree at env = {}",
+                env
+            );
+        }
+    }
+}

--- a/tests/kind/mod.rs
+++ b/tests/kind/mod.rs
@@ -1,5 +1,8 @@
 pub mod applicative;
 pub mod apply;
+// RcFn / RcFnKind tests — RED phase (types not yet implemented).
+// Will compile once the implementer adds RcFn, RcFnKind, and lift_a1_rc.
+pub mod cfn_clonable;
 pub mod functor;
 pub mod identity;
 // The `kind` submodule intentionally mirrors the crate's `kind_based::kind` path.

--- a/tests/kind/proptest_laws/mod.rs
+++ b/tests/kind/proptest_laws/mod.rs
@@ -18,6 +18,7 @@ pub mod applicative;
 pub mod apply;
 pub mod functor;
 pub mod monad;
+pub mod rcfn;
 
 // --- Arbitrary strategies (reusable across the law-family modules) ---
 

--- a/tests/kind/proptest_laws/rcfn.rs
+++ b/tests/kind/proptest_laws/rcfn.rs
@@ -1,0 +1,165 @@
+//! Property-based law tests for `RcFnKind<i32>` (the function / Reader monad).
+//!
+//! Because closures cannot implement `PartialEq`, two `RcFn<Env, A>` values are
+//! compared by **evaluating both at a generated environment** — the same technique
+//! the example-based tests in `tests/kind/cfn_clonable.rs` use. A single generated
+//! `env: i32` is sufficient to distinguish the two sides for all linear
+//! materializations used here.
+//!
+//! `RcFn` is `Clone`, so Kleisli arrows and function containers can be cloned and
+//! reused across both sides without rebuilding from parameters — this was the key
+//! gap that made `CFnKind` untestable for property-based laws.
+//!
+//! Covered laws (Functor + Monad; twelve cells total):
+//! - **Functor identity:** `map(fa, id)(env) == fa(env)`
+//! - **Functor composition:** `map(map(fa, f), g)(env) == map(fa, g∘f)(env)`
+//! - **Monad left identity:** `bind(pure(a), k)(env) == k(a)(env)`
+//! - **Monad right identity:** `bind(m, pure)(env) == m(env)`
+//! - **Monad associativity:**
+//!   `bind(bind(m, f), g)(env) == bind(m, |x| bind(f(x), g))(env)`
+
+use super::arb_linear_closure_params;
+use monadify::applicative::kind::Applicative;
+use monadify::function::RcFn;
+use monadify::functor::kind::Functor;
+use monadify::kind_based::kind::RcFnKind;
+use monadify::monad::kind::Bind;
+use proptest::prelude::*;
+
+/// Materialise a deterministic linear `RcFn<i32, i32>` from slope/intercept params.
+///
+/// `fa(env) = env.wrapping_mul(a).wrapping_add(b)`.
+fn make_rcfn(a: i32, b: i32) -> RcFn<i32, i32> {
+    RcFn::new(move |env: i32| env.wrapping_mul(a).wrapping_add(b))
+}
+
+/// A Kleisli arrow returning an `RcFn<i32, i32>` whose output depends on
+/// both the bound value `x` and the environment.
+///
+/// `k(x)(env) = env.wrapping_add(x.wrapping_mul(p)).wrapping_add(q)`.
+fn make_kleisli(p: i32, q: i32) -> impl Fn(i32) -> RcFn<i32, i32> + Clone + 'static {
+    move |x: i32| RcFn::new(move |env: i32| env.wrapping_add(x.wrapping_mul(p)).wrapping_add(q))
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    // ── Functor identity ──────────────────────────────────────────────────────
+
+    /// Functor identity for `RcFnKind<i32>`:
+    /// `map(fa, |x| x)(env) == fa(env)` for all generated `env` and `fa`.
+    #[test]
+    fn rcfn_kind_functor_identity(
+        env in any::<i32>(),
+        (a, b) in arb_linear_closure_params(),
+    ) {
+        let fa = make_rcfn(a, b);
+        let mapped = RcFnKind::<i32>::map(fa.clone(), |x: i32| x);
+        prop_assert_eq!(mapped.call(env), fa.call(env));
+    }
+
+    // ── Functor composition ───────────────────────────────────────────────────
+
+    /// Functor composition for `RcFnKind<i32>`:
+    /// `map(map(fa, f), g)(env) == map(fa, g∘f)(env)`.
+    ///
+    /// Both `f` and `g` are linear closures materialised from generated params.
+    #[test]
+    fn rcfn_kind_functor_composition(
+        env in any::<i32>(),
+        (a, b) in arb_linear_closure_params(),
+        (fa_p, fa_q) in arb_linear_closure_params(),
+        (ga_p, ga_q) in arb_linear_closure_params(),
+    ) {
+        let fa = make_rcfn(a, b);
+
+        // f: i32 -> i32 — first mapping
+        let f = move |x: i32| x.wrapping_mul(fa_p).wrapping_add(fa_q);
+        // g: i32 -> i32 — second mapping
+        let g = move |y: i32| y.wrapping_mul(ga_p).wrapping_add(ga_q);
+
+        // Sequential map
+        let sequential =
+            RcFnKind::<i32>::map(RcFnKind::<i32>::map(fa.clone(), f), g);
+
+        // Single composed map
+        let composed = RcFnKind::<i32>::map(fa.clone(), move |x| g(f(x)));
+
+        prop_assert_eq!(sequential.call(env), composed.call(env));
+    }
+
+    // ── Monad left identity ───────────────────────────────────────────────────
+
+    /// Monad left identity for `RcFnKind<i32>`:
+    /// `bind(pure(a), k)(env) == k(a)(env)`.
+    ///
+    /// `pure(a)` is a constant reader ignoring its environment; `k` is a Kleisli
+    /// arrow whose result still reads the environment.
+    #[test]
+    fn rcfn_kind_monad_left_identity(
+        env in any::<i32>(),
+        a in any::<i32>(),
+        (p, q) in arb_linear_closure_params(),
+    ) {
+        let k = make_kleisli(p, q);
+        let pure_a: RcFn<i32, i32> = RcFnKind::<i32>::pure(a);
+
+        let lhs = RcFnKind::<i32>::bind(pure_a, k.clone());
+        let rhs = k(a);
+
+        prop_assert_eq!(lhs.call(env), rhs.call(env));
+    }
+
+    // ── Monad right identity ──────────────────────────────────────────────────
+
+    /// Monad right identity for `RcFnKind<i32>`:
+    /// `bind(m, pure)(env) == m(env)`.
+    ///
+    /// `bind(m, |x| pure(x))` wraps each output of `m` back into a constant
+    /// reader; the net effect must equal `m` itself.
+    #[test]
+    fn rcfn_kind_monad_right_identity(
+        env in any::<i32>(),
+        (a, b) in arb_linear_closure_params(),
+    ) {
+        let m = make_rcfn(a, b);
+        let lhs =
+            RcFnKind::<i32>::bind(m.clone(), |x: i32| RcFnKind::<i32>::pure(x));
+        prop_assert_eq!(lhs.call(env), m.call(env));
+    }
+
+    // ── Monad associativity ───────────────────────────────────────────────────
+
+    /// Monad associativity for `RcFnKind<i32>`:
+    /// `bind(bind(m, f), g)(env) == bind(m, |x| bind(f(x), g))(env)`.
+    ///
+    /// `m`, `f`, and `g` are all materialised from generated scalar params.
+    /// Because `RcFn` is `Clone`, both `f` and `g` can be shared between the two
+    /// sides without rebuilding from parameters.
+    #[test]
+    fn rcfn_kind_monad_associativity(
+        env in any::<i32>(),
+        (a, b) in arb_linear_closure_params(),
+        (fp, fq) in arb_linear_closure_params(),
+        (gp, gq) in arb_linear_closure_params(),
+    ) {
+        let m = make_rcfn(a, b);
+        let f = make_kleisli(fp, fq);
+        let g = make_kleisli(gp, gq);
+
+        // LHS: bind(bind(m, f), g)
+        let lhs = RcFnKind::<i32>::bind(
+            RcFnKind::<i32>::bind(m.clone(), f.clone()),
+            g.clone(),
+        );
+
+        // RHS: bind(m, |x| bind(f(x), g))
+        let f_rhs = f.clone();
+        let g_rhs = g.clone();
+        let rhs = RcFnKind::<i32>::bind(m.clone(), move |x: i32| {
+            RcFnKind::<i32>::bind(f_rhs.clone()(x), g_rhs.clone())
+        });
+
+        prop_assert_eq!(lhs.call(env), rhs.call(env));
+    }
+}


### PR DESCRIPTION
## Summary

`CFn` wraps `Box<dyn Fn>`, which owns uniquely and has no clone slot, so **`CFn` is not `Clone`** (despite its "Clonable Function" doc misnomer). That blocked:

- `lift_a1::<VecKind>` — commented out (`VecKind::pure` needs `T: Clone`),
- CFn-valued monads in `mdo!` — the desugar clones every bind RHS,
- and forced the blanket `FnMut + Clone + 'static` bound on `map`/`bind`.

Unlike the do-notation marker-inference question, the non-injective-GAT / E0284 wall does **not** apply here — this is a type-representation problem with a real native fix. The answer to "any native Rust way?" is **yes: shared ownership** (`Rc<dyn Fn>`), the same pattern `ReaderT` already uses.

## What this adds (additive, zero-dependency — `Rc` is std)

- **`RcFn<A,B>` = `Rc<dyn Fn(A)->B>`** with a *manual* `Clone` impl (not `#[derive]`, to avoid spurious `A: Clone, B: Clone` bounds so `RcFn<X, CFn<..>>` is `Clone`) + `new`/`call`/`Deref`/`>>`/`<<`.
- **`RcFnKind<X>`** marker mirroring `CFnKind`, with the full `Functor → Apply → Applicative → Bind → Monad` hierarchy.
- **`ApplyRc<A,B>`** (`apply_rc`) for `Vec`/`Option`/`Result`/`RcFnKind`, plus a **`lift_a1_rc`** free fn — **re-enabling the previously-commented `lift_a1::<VecKind>`**.
- A specialized `Applicative<CFn<A,B>>` for `RcFnKind` (`Rc::from(Box)` delegation; coherent because `CFn` is crate-local, so orphan rules forbid a downstream `Clone for CFn`).
- `RcFn` now **flows through `mdo!`** (the gap `CFn` could not satisfy), exactly as `ReaderT` does.

`CFn`/`CFnOnce` and their public fields are **untouched**. **`CFnOnce` stays intentionally non-`Clone`** — a clone-able `FnOnce` is contradictory and `Rc<dyn FnOnce>` isn't callable. `ArcFn` (Send+Sync) and per-instance bound-relaxation are noted as optional follow-ups.

## Clone-safety contract

Rc-shared clone is law-equivalent to deep-copy **only for referentially-transparent `Fn`** (no observable interior mutability — no `Cell`/`RefCell`/`Mutex`). A pure `Fn` honors this by construction. Verified adversarially (the only counterexample needs both interior mutability *and* a `.clone()` path the law tests structurally never take) and corroborated by `ReaderT`'s green Rc-based suite. Documented on `RcFn`.

## Tests & gates

- `tests/kind/cfn_clonable.rs` — full Functor/Applicative (incl. the **composition law**, newly testable because `RcFn` is `Clone`) / Monad law suite for `RcFnKind`, `lift_a1_rc::<VecKind>` == `vec![false,true,false]`, `lift_a1::<RcFnKind>`, `RcFn`-through-`mdo!` (incl. bare `pure`), and a `CFnOnce`-stays-non-Clone guard.
- `tests/kind/proptest_laws/rcfn.rs` — property-based law coverage.

All green: `fmt`; `clippy --all-targets --all-features -D warnings`; `default`+`legacy`+`do-notation`; `--all-features` (330+84+13+23, 1 ignored = the CFnOnce guard); doc-tests (24, incl. re-enabled `lift_a1::<VecKind>`); **MSRV 1.66 on a fresh lock — warning-free**; zero-dep guard (no `syn`/`quote`/`proc-macro2` in default features).

## Docs

Corrects the `CFn` "Clonable Function" misnomer, documents `RcFn` vs `CFn` + the clone contract, refines the `CLAUDE.md` known-constraint note, and (incidentally) adds the standing Hindsight memory-of-record directive to `CLAUDE.md`.