### PR TITLE
feat(function)!: remove CFn; RcFn is the sole multi-call wrapper (0.2.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [package]
 name = "monadify"
 description = "A library for functional programming abstractions in Rust, focusing on Monads, Functors, Applicatives, and related concepts."
-version = "0.1.1"
+version = "0.2.0"
 authors = ["jarnura"]
 edition = "2021"
 rust-version = "1.66" # Minimum supported Rust version

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -102,7 +102,7 @@ pub fn map_vec(c: &mut Criterion) {
 }
 
 use monadify::apply::Apply;
-use monadify::function::CFn;
+use monadify::function::RcFn;
 #[cfg(feature = "legacy")]
 use monadify::legacy::apply::Apply as LegacyApply;
 #[cfg(feature = "legacy")]
@@ -124,7 +124,7 @@ pub fn apply_option(c: &mut Criterion) {
         val_opt_ref,
         |b, &val_s| {
             b.iter(|| {
-                let func_opt: Option<CFn<i32, i32>> = Some(CFn::new(|x: i32| x + 1));
+                let func_opt: Option<RcFn<i32, i32>> = Some(RcFn::new(|x: i32| x + 1));
                 OptionKind::apply(val_s, func_opt) // Call on marker type
             })
         },
@@ -153,7 +153,7 @@ pub fn apply_option(c: &mut Criterion) {
         val_opt_ref,
         |b, &val_s| {
             b.iter(|| {
-                let func_opt: Option<CFn<i32, i32>> = Some(CFn::new(|x: i32| x + 1));
+                let func_opt: Option<RcFn<i32, i32>> = Some(RcFn::new(|x: i32| x + 1));
                 <Option<i32> as LegacyApply<i32>>::apply(val_s, func_opt) // Call as instance method
             })
         },
@@ -209,7 +209,7 @@ pub fn apply_result(c: &mut Criterion) {
         val_res_ref,
         |b, val_s_ref: &Result<i32, String>| {
             b.iter(|| {
-                let func_res: Result<CFn<i32, i32>, String> = Ok(CFn::new(|x: i32| x + 1));
+                let func_res: Result<RcFn<i32, i32>, String> = Ok(RcFn::new(|x: i32| x + 1));
                 ResultKind::<String>::apply(val_s_ref.clone(), func_res) // Call on marker type
             })
         },
@@ -238,7 +238,7 @@ pub fn apply_result(c: &mut Criterion) {
         val_res_ref,
         |b, val_s_ref: &Result<i32, String>| {
             b.iter(|| {
-                let func_res: Result<CFn<i32, i32>, String> = Ok(CFn::new(|x: i32| x + 1));
+                let func_res: Result<RcFn<i32, i32>, String> = Ok(RcFn::new(|x: i32| x + 1));
                 <Result<i32, String> as LegacyApply<i32>>::apply(val_s_ref.clone(), func_res)
                 // Call as instance method
             })
@@ -302,7 +302,7 @@ pub fn apply_vec(c: &mut Criterion) {
         val_vec_ref,
         |b, val_s_vec_ref: &Vec<i32>| {
             b.iter(|| {
-                let func_vec: Vec<CFn<i32, i32>> = vec![CFn::new(|x: i32| x + 1)];
+                let func_vec: Vec<RcFn<i32, i32>> = vec![RcFn::new(|x: i32| x + 1)];
                 VecKind::apply(val_s_vec_ref.clone(), func_vec) // Call on marker type
             })
         },
@@ -335,7 +335,7 @@ pub fn apply_vec(c: &mut Criterion) {
         val_vec_ref,
         |b, val_s_vec_ref: &Vec<i32>| {
             b.iter(|| {
-                let func_vec: Vec<CFn<i32, i32>> = vec![CFn::new(|x: i32| x + 1)];
+                let func_vec: Vec<RcFn<i32, i32>> = vec![RcFn::new(|x: i32| x + 1)];
                 <Vec<i32> as LegacyApply<i32>>::apply(val_s_vec_ref.clone(), func_vec)
                 // Call as instance method
             })

--- a/src/applicative.rs
+++ b/src/applicative.rs
@@ -1,5 +1,4 @@
 pub mod kind {
-    // Renamed from hkt to kind
     //! # Kind-based Applicative Functor for the `monadify` library
     //!
     //! This module defines the `Applicative` trait for Kind-encoded types, which extends `Apply`.
@@ -14,14 +13,14 @@ pub mod kind {
     //! ## Example
     //!
     //! ```
-    //! use monadify::applicative::kind::{Applicative, lift_a1}; // Applicative for ::pure
-    //! use monadify::apply::kind::Apply; // for .apply() method
+    //! use monadify::applicative::kind::{Applicative, lift_a1};
+    //! use monadify::apply::kind::Apply;
     //! use monadify::kind_based::kind::OptionKind;
-    //! use monadify::function::CFn;
+    //! use monadify::function::RcFn;
     //!
     //! // Using pure and apply directly
     //! let val_opt: Option<i32> = OptionKind::pure(10); // Some(10)
-    //! let fn_opt: Option<CFn<i32, i32>> = OptionKind::pure(CFn::new(|x| x + 1)); // Some(CFn)
+    //! let fn_opt: Option<RcFn<i32, i32>> = OptionKind::pure(RcFn::new(|x| x + 1)); // Some(RcFn)
     //!
     //! // Need to specify the marker for apply
     //! let result_opt: Option<i32> = OptionKind::apply(val_opt, fn_opt);
@@ -36,16 +35,11 @@ pub mod kind {
     //!
     //! `Applicative` builds upon `Apply` by adding the `pure` method. This allows
     //! functions and values to be lifted into the context before application.
-    //! A common pattern, often called `lift_a1` or similar, is equivalent to
-    //! `map` from `Functor` but implemented using `pure` and `apply`:
-    //! `map f fa == apply(fa, pure(f))`. Note: The order of arguments in `apply` can vary;
-    //! this `monadify` library's `apply` takes `(value_context, function_context)`.
-    //! The `lift_a1` function in this module demonstrates this pattern.
 
-    use crate::apply::kind::{Apply, ApplyRc}; // Kind-based Apply
-    use crate::function::{CFn, CFnOnce, RcFn};
+    use crate::apply::kind::Apply;
+    use crate::function::{CFnOnce, RcFn};
     use crate::kind_based::kind::{
-        CFnKind, CFnOnceKind, Kind, Kind1, OptionKind, RcFnKind, ResultKind, VecKind,
+        CFnOnceKind, Kind, Kind1, OptionKind, RcFnKind, ResultKind, VecKind,
     };
     use std::rc::Rc;
 
@@ -79,77 +73,42 @@ pub mod kind {
     /// 2.  **Homomorphism**: `apply(pure(x), pure(f_fn)) == pure(f(x))`
     /// 3.  **Interchange**: `apply(pure(y), u) == apply(u, pure(|f_fn| f_fn(y)))`
     /// 4.  **Composition (derived)**: `map f x == apply(x, pure(f))` (often shown as `lift_a1`)
-    ///     (Note: The exact formulation of composition can vary, often involving `apply` and `pure`.)
     pub trait Applicative<T>: Apply<T, T>
     where
-        Self: Sized + Kind1, // Changed HKT1 to Kind1
+        Self: Sized + Kind1,
         T: 'static,
     {
         /// Lifts a value into the applicative context.
         ///
         /// # Parameters
         /// - `value`: The value of type `T` to be lifted.
-        ///   The `T: 'static` bound is common. Many `pure` implementations also require `T: Clone`
-        ///   (e.g., for [`CFnKind`], [`VecKind`]) if the `value` needs to be cloned
-        ///   into the new context, especially if the context itself might be "called" or
-        ///   iterated multiple times. This can make some applicative laws involving `pure`
-        ///   of non-`Clone` function types (like `CFn`) untestable.
         ///
         /// # Returns
         /// The value wrapped in the Kind applicative structure, `Self::Of<T>`.
-        fn pure(value: T) -> Self::Of<T>; // Changed Applied to Of
+        fn pure(value: T) -> Self::Of<T>;
     }
 
     impl<T: 'static> Applicative<T> for OptionKind {
-        // Changed OptionHKTMarker to OptionKind
         /// Lifts a value `T` into `Some(T)`.
         fn pure(value: T) -> Self::Of<T> {
-            // Self::Of<T> is Option<T>
             Some(value)
         }
     }
 
     impl<T: 'static, E: 'static + Clone> Applicative<T> for ResultKind<E> {
-        // Changed ResultHKTMarker to ResultKind
         /// Lifts a value `T` into `Ok(T)`.
         fn pure(value: T) -> Self::Of<T> {
-            // Self::Of<T> is Result<T, E>
             Ok(value)
         }
     }
 
     impl<T: 'static + Clone> Applicative<T> for VecKind {
-        // Changed VecHKTMarker to VecKind
         /// Lifts a value `T` into `vec![T]`.
         ///
         /// The `T: Clone` bound on this `impl` block is due to `Vec`'s `pure`
         /// creating a new vector with the element.
         fn pure(value: T) -> Self::Of<T> {
-            // Self::Of<T> is Vec<T>
             vec![value]
-        }
-    }
-
-    // Applicative for CFnKind
-    // Lifts a value `T` into `CFn<X, T>` which always returns `value.clone()`
-    impl<X, T> Applicative<T> for CFnKind<X>
-    // Changed CFnHKTMarker to CFnKind
-    where
-        X: 'static,
-        T: 'static + Clone,            // T needs to be Clone for the closure
-        Self: Apply<T, T>,             // Ensure Apply<T,T> for CFnKind<X> is defined
-        Self: Kind<Of<T> = CFn<X, T>>, // Changed HKT to Kind, Applied to Of
-    {
-        /// Lifts a value `T` into a `CFn<X, T>` (a function `X -> T`).
-        ///
-        /// The resulting function, when called with any input of type `X`,
-        /// will ignore that input and always return a clone of the original `value`.
-        ///
-        /// Requires `T: Clone` because the lifted value is cloned by the returned function.
-        fn pure(value: T) -> Self::Of<T> {
-            // Changed Applied to Of
-            // Self::Of<T> is CFn<X, T> as per Kind1 impl for CFnKind
-            CFn::new(move |_x: X| value.clone())
         }
     }
 
@@ -173,50 +132,14 @@ pub mod kind {
         }
     }
 
-    // Applicative for RcFnKind<X> — specialized CFn case.
-    //
-    // `CFn<A,B>` is not `Clone` (it wraps `Box<dyn Fn>`), so the generic
-    // `Applicative<T: Clone>` impl above does not cover it. This impl provides
-    // `pure` for `CFn<A,B>` by converting the inner `Box` to `Rc` (enabling
-    // O(1) cloning) and creating a new delegating `CFn` wrapper on each call.
-    //
-    // Coherence note: the two impls do NOT overlap because `CFn<A,B>` does not
-    // implement `Clone` in this crate, and — due to the orphan rules — no
-    // downstream crate can add `impl Clone for CFn<A,B>` either.
-    impl<X, A, B> Applicative<CFn<A, B>> for RcFnKind<X>
-    where
-        X: 'static,
-        A: 'static,
-        B: 'static,
-        Self: Apply<CFn<A, B>, CFn<A, B>>,
-        Self: Kind<Of<CFn<A, B>> = RcFn<X, CFn<A, B>>>,
-    {
-        /// Lifts a `CFn<A,B>` into `RcFn<X, CFn<A,B>>`.
-        ///
-        /// Because `CFn` is not `Clone`, the inner `Box<dyn Fn(A)->B>` is first
-        /// converted to `Rc<dyn Fn(A)->B>`. On each call to the resulting `RcFn`,
-        /// a new `CFn` is created that delegates to the shared `Rc`, costing only
-        /// one `Rc` reference-count bump per call.
-        fn pure(value: CFn<A, B>) -> RcFn<X, CFn<A, B>> {
-            // Convert Box → Rc so the underlying function can be shared cheaply.
-            let shared: Rc<dyn Fn(A) -> B + 'static> = Rc::from(value.0);
-            RcFn(Rc::new(move |_x: X| {
-                // Clone the Rc (O(1)) and wrap in a new CFn that delegates.
-                let rc_clone = Rc::clone(&shared);
-                CFn(Box::new(move |a: A| (rc_clone.as_ref())(a)))
-            }))
-        }
-    }
-
     // Applicative for CFnOnceKind
     // Lifts a value `T` into `CFnOnce<X, T>`
     impl<X, T> Applicative<T> for CFnOnceKind<X>
-    // Changed CFnOnceHKTMarker to CFnOnceKind
     where
         X: 'static,
         T: 'static + Clone,
         Self: Apply<T, T>,
-        Self: Kind<Of<T> = CFnOnce<X, T>>, // Changed HKT to Kind, Applied to Of
+        Self: Kind<Of<T> = CFnOnce<X, T>>,
     {
         /// Lifts a value `T` into a `CFnOnce<X, T>` (a function `X -> T` called once).
         ///
@@ -225,17 +148,15 @@ pub mod kind {
         ///
         /// Requires `T: Clone` as the lifted value is cloned by the returned function.
         fn pure(value: T) -> Self::Of<T> {
-            // Changed Applied to Of
-            // Self::Of<T> is CFnOnce<X, T> as per Kind1 impl for CFnOnceKind
             CFnOnce::new(move |_x: X| value.clone())
         }
     }
 
     /// Lifts a unary function `A -> B` to operate on Kind `Applicative` values: `F::Of<A> -> F::Of<B>`.
-    /// This is `map` defined via `pure` and `apply`: `map f fa == apply(fa, pure(CFn::new(f)))`.
+    /// This is `map` defined via `pure` and `apply`: `map f fa == apply(fa, pure(RcFn::new(f)))`.
     ///
     /// # Parameters
-    /// - `F`: The Kind marker, must implement `Applicative<CFn<A,B>>` and `Apply<A,B>`.
+    /// - `F`: The Kind marker, must implement `Applicative<RcFn<A,B>>` and `Apply<A,B>`.
     /// - `func`: The function `A -> B`.
     /// - `fa`: The applicative value `F::Of<A>`.
     ///
@@ -245,90 +166,41 @@ pub mod kind {
     /// ## Example
     ///
     /// ```
-    /// use monadify::applicative::kind::{lift_a1, lift_a1_rc};
+    /// use monadify::applicative::kind::lift_a1;
     /// use monadify::kind_based::kind::{OptionKind, VecKind};
     ///
     /// // Using lift_a1 with Option
     /// let opt_val: Option<i32> = Some(5);
-    /// // Provide the Kind marker via turbofish if type inference needs help
     /// let lifted_opt: Option<String> = lift_a1::<OptionKind, _, _, _>(
     ///     |x: i32| (x * 2).to_string(),
     ///     opt_val
     /// );
     /// assert_eq!(lifted_opt, Some("10".to_string()));
     ///
-    /// // Using lift_a1_rc with Vec — re-enabled via RcFn (which IS Clone).
-    /// // `lift_a1` over VecKind required `CFn<A,B>: Clone`, which `CFn` cannot satisfy.
-    /// // `lift_a1_rc` uses `RcFn<A,B>` instead, which derives `Clone`.
+    /// // Using lift_a1 with Vec — enabled via RcFn (which IS Clone).
     /// let vec_val: Vec<i32> = vec![1, 2, 3];
-    /// let lifted_vec: Vec<bool> = lift_a1_rc::<VecKind, _, _, _>(
+    /// let lifted_vec: Vec<bool> = lift_a1::<VecKind, _, _, _>(
     ///     |x: i32| x % 2 == 0,
     ///     vec_val
     /// );
     /// assert_eq!(lifted_vec, vec![false, true, false]);
     /// ```
-    pub fn lift_a1<F, A, B, FuncImpl>(
-        func: FuncImpl,
-        fa: F::Of<A>, // Changed Applied to Of
-    ) -> F::Of<B>
-    // Changed Applied to Of
+    pub fn lift_a1<F, A, B, FuncImpl>(func: FuncImpl, fa: F::Of<A>) -> F::Of<B>
     where
-        F: Applicative<CFn<A, B>> + Apply<A, B> + Kind1, // Changed HKT1 to Kind1
+        F: Applicative<RcFn<A, B>> + Apply<A, B> + Kind1,
         FuncImpl: Fn(A) -> B + 'static,
         A: 'static,
         B: 'static,
-        CFn<A, B>: 'static, // Ensure the lifted function type is 'static
     {
-        // 1. Lift the function `func: A -> B` into the context using `CFn`.
-        //    `F::pure(CFn::new(func))` results in `F::Of<CFn<A, B>>`.
-        //    This requires `F` to be `Applicative` for the type `CFn<A, B>`.
-        let f_in_context: F::Of<CFn<A, B>> = F::pure(CFn::new(func)); // Changed Applied to Of
+        // 1. Lift the function `func: A -> B` into the context using `RcFn`.
+        //    `F::pure(RcFn::new(func))` results in `F::Of<RcFn<A, B>>`.
+        //    This requires `F` to be `Applicative` for the type `RcFn<A, B>`.
+        let f_in_context: F::Of<RcFn<A, B>> = F::pure(RcFn::new(func));
 
         // 2. Apply the wrapped function to the wrapped value.
-        //    `F::apply(fa, f_in_context)` where `fa` is `F::Of<A>`.
-        //    This requires `F` to be `Apply<A, B>`.
         F::apply(fa, f_in_context)
-    }
-
-    /// Lifts a unary function `A -> B` to operate on Kind `Applicative` values using
-    /// [`RcFn`] as the function container.
-    ///
-    /// This is the `RcFn`-backed sibling of [`lift_a1`].  [`lift_a1`] builds
-    /// `F::pure(CFn::new(func))`, requiring `CFn<A,B>: Clone` — a bound `CFn`
-    /// cannot satisfy.  `lift_a1_rc` builds `F::pure(RcFn::new(func))` instead;
-    /// [`RcFn`] derives `Clone`, so `VecKind::Applicative<RcFn<A,B>>` compiles.
-    ///
-    /// # Parameters
-    /// - `F`: The Kind marker; must implement `Applicative<RcFn<A,B>>` and `ApplyRc<A,B>`.
-    /// - `func`: The function `A -> B` to lift.
-    /// - `fa`: The applicative value `F::Of<A>`.
-    ///
-    /// # Returns
-    /// The result `F::Of<B>`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use monadify::applicative::kind::lift_a1_rc;
-    /// use monadify::kind_based::kind::VecKind;
-    ///
-    /// let fa: Vec<i32> = vec![1, 2, 3];
-    /// let result: Vec<bool> = lift_a1_rc::<VecKind, _, _, _>(|x: i32| x % 2 == 0, fa);
-    /// assert_eq!(result, vec![false, true, false]);
-    /// ```
-    pub fn lift_a1_rc<F, A, B, FuncImpl>(func: FuncImpl, fa: F::Of<A>) -> F::Of<B>
-    where
-        F: Applicative<RcFn<A, B>> + ApplyRc<A, B> + Kind1,
-        FuncImpl: Fn(A) -> B + 'static,
-        A: 'static,
-        B: 'static,
-    {
-        // 1. Wrap the function in RcFn (Clone-able) and lift it into the context.
-        let fc: F::Of<RcFn<A, B>> = F::pure(RcFn::new(func));
-        // 2. Apply the wrapped function to the wrapped value via apply_rc.
-        F::apply_rc(fa, fc)
     }
 }
 
 // Directly export Kind-based Applicative and related functions
-pub use kind::*; // Renamed from hkt to kind
+pub use kind::*;

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -1,5 +1,4 @@
 pub mod kind {
-    // Renamed from hkt to kind
     //! # Kind-based Apply for the `monadify` library
     //!
     //! This module defines the `Apply` trait for Kind-encoded types, which extends `Functor`.
@@ -14,10 +13,10 @@ pub mod kind {
     //! - `A`: The input type of the function `A -> B` and the type of value in `Self::Of<A>`.
     //! - `B`: The output type of the function `A -> B` and the type of value in `Self::Of<B>`.
 
-    use crate::function::{CFn, CFnOnce, RcFn};
-    use crate::functor::Functor; // Kind-based Functor
+    use crate::function::{CFnOnce, RcFn};
+    use crate::functor::Functor;
     use crate::kind_based::kind::{
-        CFnKind, CFnOnceKind, Kind, Kind1, OptionKind, RcFnKind, ResultKind, VecKind,
+        CFnOnceKind, Kind, Kind1, OptionKind, RcFnKind, ResultKind, VecKind,
     };
     use std::rc::Rc;
 
@@ -27,18 +26,14 @@ pub mod kind {
     /// [`Kind1`] and [`Functor`].
     ///
     /// The `apply` method takes `Self::Of<A>` (e.g., `Option<A>`) and
-    /// `Self::Of<CFn<A, B>>` (e.g., `Option<CFn<A, B>>`), and produces
+    /// `Self::Of<RcFn<A, B>>` (e.g., `Option<RcFn<A, B>>`), and produces
     /// `Self::Of<B>` (e.g., `Option<B>`).
     ///
     /// ## Apply Laws
-    /// (Often defined in terms of `Applicative` which builds on `Apply`)
-    /// A key law related to `apply` is compositional:
-    /// `apply(apply(v, compose_pure_fn), pure_g_fn) == apply(v, apply(pure_f_fn, pure_compose_fn))`
-    /// where `compose_pure_fn` is `pure(.)` or `pure(|f| |g| |x| f(g(x)))`.
-    /// More commonly, laws are expressed with `Applicative`.
+    /// A key law related to `apply` is compositional.
     pub trait Apply<A, B>: Functor<A, B>
     where
-        Self: Sized + Kind1, // Changed HKT1 to Kind1
+        Self: Sized + Kind1,
         A: 'static,
         B: 'static,
     {
@@ -46,52 +41,46 @@ pub mod kind {
         ///
         /// # Type Parameters
         /// - `Self`: The Kind marker.
-        /// - `A`: The input type for the wrapped function `CFn<A, B>`.
+        /// - `A`: The input type for the wrapped function `RcFn<A, B>`.
         /// - `B`: The result type of the wrapped function and the output Kind structure.
         ///
         /// # Parameters
         /// - `value_container`: The Kind-structured value `Self::Of<A>`.
-        /// - `function_container`: The Kind-structured function `Self::Of<CFn<A, B>>`.
-        ///   Note: The function itself is wrapped in [`CFn`], which handles dynamic dispatch
-        ///   and necessary `'static` bounds for the function it wraps.
+        /// - `function_container`: The Kind-structured function `Self::Of<RcFn<A, B>>`.
+        ///   The function is wrapped in [`RcFn`], which provides shared-ownership, Clone-able,
+        ///   heap-allocated dispatch with `'static` bounds.
         ///
         /// # Returns
         /// A new Kind-structured value `Self::Of<B>`.
         fn apply(
-            value_container: Self::Of<A>,            // Changed Applied to Of
-            function_container: Self::Of<CFn<A, B>>, // Changed Applied to Of
-        ) -> Self::Of<B>; // Changed Applied to Of
+            value_container: Self::Of<A>,
+            function_container: Self::Of<RcFn<A, B>>,
+        ) -> Self::Of<B>;
     }
 
     impl<A: 'static, B: 'static> Apply<A, B> for OptionKind {
-        // Changed OptionHKTMarker to OptionKind
         fn apply(
-            value_container: Self::Of<A>,            // Changed Applied to Of
-            function_container: Self::Of<CFn<A, B>>, // Changed Applied to Of
+            value_container: Self::Of<A>,
+            function_container: Self::Of<RcFn<A, B>>,
         ) -> Self::Of<B> {
-            // Changed Applied to Of
             value_container.and_then(|val_a| function_container.map(|func_ab| func_ab.call(val_a)))
         }
     }
 
     impl<A: 'static, B: 'static, E: 'static + Clone> Apply<A, B> for ResultKind<E> {
-        // Changed ResultHKTMarker to ResultKind
         fn apply(
-            value_container: Self::Of<A>,            // Changed Applied to Of
-            function_container: Self::Of<CFn<A, B>>, // Changed Applied to Of
+            value_container: Self::Of<A>,
+            function_container: Self::Of<RcFn<A, B>>,
         ) -> Self::Of<B> {
-            // Changed Applied to Of
             value_container.and_then(|val_a| function_container.map(|func_ab| func_ab.call(val_a)))
         }
     }
 
     impl<A: 'static + Clone, B: 'static> Apply<A, B> for VecKind {
-        // Changed VecHKTMarker to VecKind
         fn apply(
-            value_container: Self::Of<A>,            // Changed Applied to Of
-            function_container: Self::Of<CFn<A, B>>, // Changed Applied to Of
+            value_container: Self::Of<A>,
+            function_container: Self::Of<RcFn<A, B>>,
         ) -> Self::Of<B> {
-            // Changed Applied to Of
             function_container
                 .into_iter()
                 .flat_map(|f_fn| {
@@ -103,73 +92,38 @@ pub mod kind {
         }
     }
 
-    // Apply for CFnKind<X>
-    // F::Of<A> is CFn<X, A>
-    // F::Of<CFn<A, B>> is CFn<X, CFn<A, B>>
-    // Result is CFn<X, B>
-    // This implements S f g x = (f x) (g x)
-    impl<X, A, B> Apply<A, B> for CFnKind<X>
-    // Changed CFnHKTMarker to CFnKind
-    where
-        X: 'static + Clone, // Clone for x_val in the closure
-        A: 'static,
-        B: 'static,
-        Self: Functor<A, B>,           // Ensure Functor constraint is met
-        Self: Kind<Of<A> = CFn<X, A>>, // HKT -> Kind, Applied -> Of
-        Self: Kind<Of<CFn<A, B>> = CFn<X, CFn<A, B>>>, // HKT -> Kind, Applied -> Of
-        Self: Kind<Of<B> = CFn<X, B>>, // HKT -> Kind, Applied -> Of
-                                       // Removed: CFn<X, CFn<A, B>>: Fn(X) -> CFn<A, B>,
-                                       // Removed: CFn<X, A>: Fn(X) -> A,
-                                       // The .call method on CFn struct does not require CFn itself to be Fn.
-                                       // A: 'static is from Apply trait. X: 'static + Clone for closure. B: 'static from Apply trait.
-    {
-        fn apply(
-            value_container: Self::Of<A>,            // This is c_x_a. Applied -> Of
-            function_container: Self::Of<CFn<A, B>>, // This is c_x_fab. Applied -> Of
-        ) -> Self::Of<B> {
-            // Applied -> Of
-            // Self::Of<A> is CFn<X, A>
-            // Self::Of<CFn<A, B>> is CFn<X, CFn<A, B>>
-            CFn::new(move |x_val: X| {
-                let func_ab = function_container.call(x_val.clone());
-                let val_a = value_container.call(x_val);
-                func_ab.call(val_a)
-            })
-        }
-    }
-
     // Apply for CFnOnceKind<X>
-    // Similar to CFnKind, but uses call_once and produces CFnOnce
+    // F::Of<A> is CFnOnce<X, A>
+    // F::Of<RcFn<A, B>> is CFnOnce<X, RcFn<A, B>>
+    // Result is CFnOnce<X, B>
     impl<X, A, B> Apply<A, B> for CFnOnceKind<X>
-    // Changed CFnOnceHKTMarker to CFnOnceKind
     where
-        X: 'static + Clone, // Clone for x_val in the closure
+        X: 'static + Clone,
         A: 'static,
         B: 'static,
         Self: Functor<A, B>,
-        Self: Kind<Of<A> = CFnOnce<X, A>>, // HKT -> Kind, Applied -> Of
-        Self: Kind<Of<CFn<A, B>> = CFnOnce<X, CFn<A, B>>>, // HKT -> Kind, Applied -> Of
-        Self: Kind<Of<B> = CFnOnce<X, B>>, // HKT -> Kind, Applied -> Of
-                                           // Comments about FnOnce bounds and GATs remain relevant.
+        Self: Kind<Of<A> = CFnOnce<X, A>>,
+        Self: Kind<Of<RcFn<A, B>> = CFnOnce<X, RcFn<A, B>>>,
+        Self: Kind<Of<B> = CFnOnce<X, B>>,
     {
         fn apply(
-            value_container: Self::Of<A>,            // CFnOnce<X,A>. Applied -> Of
-            function_container: Self::Of<CFn<A, B>>, // CFnOnce<X, CFn<A,B>>. Applied -> Of
+            value_container: Self::Of<A>,             // CFnOnce<X,A>
+            function_container: Self::Of<RcFn<A, B>>, // CFnOnce<X, RcFn<A,B>>
         ) -> Self::Of<B> {
-            // CFnOnce<X,B>. Applied -> Of
+            // CFnOnce<X,B>
             CFnOnce::new(move |x_val: X| {
-                // Self::Of<CFn<A,B>> is CFnOnce<X, CFn<A,B>>
-                // Self::Of<A> is CFnOnce<X,A>
-                let func_ab = function_container.call_once(x_val.clone()); // func_ab is CFn<A,B>
-                let val_a = value_container.call_once(x_val); // val_a is A
+                let func_ab: RcFn<A, B> = function_container.call_once(x_val.clone());
+                let val_a: A = value_container.call_once(x_val);
                 func_ab.call(val_a)
             })
         }
     }
 
     // Apply for RcFnKind<X>
-    // The function container is RcFn<X, CFn<A,B>> (outer Rc-backed, inner CFn),
-    // mirroring CFnKind where the container is CFn<X, CFn<A,B>>.
+    // F::Of<A> is RcFn<X, A>
+    // F::Of<RcFn<A, B>> is RcFn<X, RcFn<A, B>>
+    // Result is RcFn<X, B>
+    // This implements S f g x = (f x) (g x)
     impl<X, A, B> Apply<A, B> for RcFnKind<X>
     where
         X: 'static + Clone,
@@ -177,103 +131,38 @@ pub mod kind {
         B: 'static,
         Self: Functor<A, B>,
         Self: Kind<Of<A> = RcFn<X, A>>,
-        Self: Kind<Of<CFn<A, B>> = RcFn<X, CFn<A, B>>>,
+        Self: Kind<Of<RcFn<A, B>> = RcFn<X, RcFn<A, B>>>,
         Self: Kind<Of<B> = RcFn<X, B>>,
     {
-        /// Applies an `RcFn<X, CFn<A,B>>` (a function from environment to a function
+        /// Applies an `RcFn<X, RcFn<A,B>>` (a function from environment to a function
         /// `A -> B`) to an `RcFn<X, A>` (a function from environment to `A`),
         /// producing `RcFn<X, B>`.  This is the S combinator: `(f x)(g x)`.
         fn apply(
-            value_container: Self::Of<A>,            // RcFn<X, A>
-            function_container: Self::Of<CFn<A, B>>, // RcFn<X, CFn<A,B>>
+            value_container: Self::Of<A>,             // RcFn<X, A>
+            function_container: Self::Of<RcFn<A, B>>, // RcFn<X, RcFn<A,B>>
         ) -> Self::Of<B> {
             let f_rc = function_container.0.clone();
             let v_rc = value_container.0.clone();
             RcFn(Rc::new(move |x_val: X| {
-                let func_ab: CFn<A, B> = f_rc(x_val.clone());
+                let func_ab: RcFn<A, B> = f_rc(x_val.clone());
                 let val_a: A = v_rc(x_val);
                 func_ab.call(val_a)
             }))
         }
     }
 
-    /// A variant of [`Apply`] where the function container holds [`RcFn<A, B>`]
-    /// instead of [`CFn<A, B>`].
-    ///
-    /// This is needed to implement [`crate::applicative::kind::lift_a1_rc`], which
-    /// wraps a plain `A -> B` function in `RcFn` (not `CFn`) so that the resulting
-    /// value satisfies `T: Clone` — a requirement of `VecKind`'s `Applicative<T>`.
-    ///
-    /// Implemented for [`OptionKind`], [`ResultKind<E>`], and [`VecKind`].
-    pub trait ApplyRc<A, B>: Kind1 {
-        /// Applies a Kind-wrapped `RcFn<A, B>` to a Kind-wrapped `A`, producing `B`.
-        fn apply_rc(value: Self::Of<A>, func: Self::Of<RcFn<A, B>>) -> Self::Of<B>;
-    }
-
-    impl<A: 'static, B: 'static> ApplyRc<A, B> for OptionKind {
-        /// Applies `Option<RcFn<A,B>>` to `Option<A>`.
-        fn apply_rc(value: Self::Of<A>, func: Self::Of<RcFn<A, B>>) -> Self::Of<B> {
-            value.and_then(|val_a| func.map(|f| f.call(val_a)))
-        }
-    }
-
-    impl<A: 'static, B: 'static, E: 'static + Clone> ApplyRc<A, B> for ResultKind<E> {
-        /// Applies `Result<RcFn<A,B>, E>` to `Result<A, E>`.
-        fn apply_rc(value: Self::Of<A>, func: Self::Of<RcFn<A, B>>) -> Self::Of<B> {
-            value.and_then(|val_a| func.map(|f| f.call(val_a)))
-        }
-    }
-
-    impl<A: 'static + Clone, B: 'static> ApplyRc<A, B> for VecKind {
-        /// Applies `Vec<RcFn<A,B>>` to `Vec<A>`, producing the Cartesian product.
-        ///
-        /// Each `RcFn` in `func` is applied to every element of `value`.  Because
-        /// `RcFn` is `Clone`, iterating over `value` multiple times works without
-        /// additional allocation.
-        fn apply_rc(value: Self::Of<A>, func: Self::Of<RcFn<A, B>>) -> Self::Of<B> {
-            func.into_iter()
-                .flat_map(|f_fn| value.iter().map(move |val_a| f_fn.call(val_a.clone())))
-                .collect()
-        }
-    }
-
-    impl<X, A, B> ApplyRc<A, B> for RcFnKind<X>
-    where
-        X: 'static + Clone,
-        A: 'static,
-        B: 'static,
-    {
-        /// Applies `RcFn<X, RcFn<A,B>>` to `RcFn<X, A>`, producing `RcFn<X, B>`.
-        ///
-        /// This is the S-combinator (`apply_rc(v, f)(x) = f(x)(v(x))`) expressed
-        /// through `RcFn` wrappers at every layer.  Because both the outer carrier
-        /// and the inner function wrapper are `RcFn` (and therefore `Clone`), no
-        /// `Box`-to-`Rc` conversion is needed — both `Rc` handles are cheaply shared.
-        fn apply_rc(value: Self::Of<A>, func: Self::Of<RcFn<A, B>>) -> Self::Of<B> {
-            let f_rc = func.0.clone();
-            let v_rc = value.0.clone();
-            RcFn(Rc::new(move |x_val: X| {
-                let inner_fn: RcFn<A, B> = f_rc(x_val.clone());
-                let val_a: A = v_rc(x_val);
-                inner_fn.call(val_a)
-            }))
-        }
-    }
-
     /// Lifts a binary curried function to operate on Kind-encoded contexts.
     ///
-    /// Given `func: A -> (B -> C)` (represented as `A -> CFn<B, C>`),
-    /// `fa: F::Of<A>`, and `fb: F::Of<B>`, `lift2` produces `F::Of<C>`.
-    /// It's equivalent to `apply(map(fa, func), fb)` but expressed using the `Apply` trait's `apply` method.
+    /// Given `func: A -> RcFn<B, C>`, `fa: F::Of<A>`, and `fb: F::Of<B>`,
+    /// `lift2` produces `F::Of<C>`.
     pub fn lift2<F, A, B, C, FuncImpl>(
-        func: FuncImpl, // A -> CFn<B, C>
-        fa: F::Of<A>,   // Changed Applied to Of
-        fb: F::Of<B>,   // Changed Applied to Of
+        func: FuncImpl, // A -> RcFn<B, C>
+        fa: F::Of<A>,
+        fb: F::Of<B>,
     ) -> F::Of<C>
-    // Changed Applied to Of
     where
-        F: Apply<B, C> + Functor<A, CFn<B, C>> + Kind1, // Changed HKT1 to Kind1
-        FuncImpl: Fn(A) -> CFn<B, C> + Clone + 'static,
+        F: Apply<B, C> + Functor<A, RcFn<B, C>> + Kind1,
+        FuncImpl: Fn(A) -> RcFn<B, C> + Clone + 'static,
         A: 'static,
         B: 'static,
         C: 'static,
@@ -284,60 +173,51 @@ pub mod kind {
 
     /// Lifts a ternary curried function to operate on Kind-encoded contexts.
     ///
-    /// Given `func: A -> (B -> (C -> D))` (represented as `A -> CFn<B, CFn<C, D>>`),
-    /// `fa: F::Of<A>`, `fb: F::Of<B>`, and `fc: F::Of<C>`, `lift3` produces `F::Of<D>`.
+    /// Given `func: A -> RcFn<B, RcFn<C, D>>`, `fa: F::Of<A>`, `fb: F::Of<B>`,
+    /// and `fc: F::Of<C>`, `lift3` produces `F::Of<D>`.
     pub fn lift3<F, A, B, C, D, FuncImpl>(
-        func: FuncImpl, // A -> CFn<B, CFn<C, D>>
-        fa: F::Of<A>,   // Changed Applied to Of
-        fb: F::Of<B>,   // Changed Applied to Of
-        fc: F::Of<C>,   // Changed Applied to Of
+        func: FuncImpl, // A -> RcFn<B, RcFn<C, D>>
+        fa: F::Of<A>,
+        fb: F::Of<B>,
+        fc: F::Of<C>,
     ) -> F::Of<D>
-    // Changed Applied to Of
     where
-        F: Apply<C, D> + Apply<B, CFn<C, D>> + Functor<A, CFn<B, CFn<C, D>>> + Kind1, // Changed HKT1 to Kind1
-        FuncImpl: Fn(A) -> CFn<B, CFn<C, D>> + Clone + 'static,
+        F: Apply<C, D> + Apply<B, RcFn<C, D>> + Functor<A, RcFn<B, RcFn<C, D>>> + Kind1,
+        FuncImpl: Fn(A) -> RcFn<B, RcFn<C, D>> + Clone + 'static,
         A: 'static,
         B: 'static,
         C: 'static,
         D: 'static,
     {
         let f_b_to_c_to_d_in_f = F::map(fa, func);
-        let f_c_to_d_in_f = <F as Apply<B, CFn<C, D>>>::apply(fb, f_b_to_c_to_d_in_f);
+        let f_c_to_d_in_f = <F as Apply<B, RcFn<C, D>>>::apply(fb, f_b_to_c_to_d_in_f);
         <F as Apply<C, D>>::apply(fc, f_c_to_d_in_f)
     }
 
     /// Combines two Kind-encoded actions, keeping only the result of the first.
     /// Often denoted as `<*`.
-    pub fn apply_first<F, A, B>(
-        fa: F::Of<A>, // Changed Applied to Of
-        fb: F::Of<B>, // Changed Applied to Of
-    ) -> F::Of<A>
-    // Changed Applied to Of
+    pub fn apply_first<F, A, B>(fa: F::Of<A>, fb: F::Of<B>) -> F::Of<A>
     where
-        F: Apply<B, A> + Functor<A, CFn<B, A>> + Kind1, // Changed HKT1 to Kind1
+        F: Apply<B, A> + Functor<A, RcFn<B, A>> + Kind1,
         A: Copy + 'static,
         B: 'static,
     {
-        let map_fn = |x: A| CFn::new(move |_y: B| x);
+        let map_fn = |x: A| RcFn::new(move |_y: B| x);
         lift2::<F, A, B, A, _>(map_fn, fa, fb)
     }
 
     /// Combines two Kind-encoded actions, keeping only the result of the second.
     /// Often denoted as `*>`.
-    pub fn apply_second<F, A, B>(
-        fa: F::Of<A>, // Changed Applied to Of
-        fb: F::Of<B>, // Changed Applied to Of
-    ) -> F::Of<B>
-    // Changed Applied to Of
+    pub fn apply_second<F, A, B>(fa: F::Of<A>, fb: F::Of<B>) -> F::Of<B>
     where
-        F: Apply<B, B> + Functor<A, CFn<B, B>> + Kind1, // Changed HKT1 to Kind1
+        F: Apply<B, B> + Functor<A, RcFn<B, B>> + Kind1,
         A: 'static,
         B: Copy + 'static,
     {
-        let map_fn = |_: A| CFn::new(|y: B| y);
+        let map_fn = |_: A| RcFn::new(|y: B| y);
         lift2::<F, A, B, B, _>(map_fn, fa, fb)
     }
 }
 
 // Directly export Kind-based Apply and related functions
-pub use kind::*; // Renamed from hkt to kind
+pub use kind::*;

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,11 +1,6 @@
 use std::ops::Deref;
 use std::rc::Rc;
 
-/// Type alias for a boxed, dynamically dispatched, repeatable closure.
-/// `BFn<A, B>` is equivalent to `Box<dyn Fn(A) -> B + 'static>`.
-/// This represents a heap-allocated closure that can be called multiple times.
-type BFn<A, B> = Box<dyn Fn(A) -> B + 'static>;
-
 /// Type alias for an `Rc`-backed, dynamically dispatched, repeatable closure.
 /// `RFn<A, B>` is equivalent to `Rc<dyn Fn(A) -> B + 'static>`.
 type RFn<A, B> = Rc<dyn Fn(A) -> B + 'static>;
@@ -15,31 +10,9 @@ type RFn<A, B> = Rc<dyn Fn(A) -> B + 'static>;
 /// This represents a heap-allocated closure that can be called at most once.
 type BFnOnce<A, B> = Box<dyn FnOnce(A) -> B + 'static>;
 
-/// A wrapper around `BFn<A, B>` (a `Box<dyn Fn(A) -> B + 'static>`).
-///
-/// This struct provides a concrete type for heap-allocated, repeatable closures,
-/// which is useful for storing them in structs or passing them as arguments
-/// where a concrete type is needed (e.g., in trait implementations like `Functor` for functions).
-///
-/// `CFn` wraps `Box<dyn Fn(A) -> B + 'static>` and is therefore **not** `Clone`
-/// (unique-ownership, box-backed). For a shared-ownership, cheaply-cloneable
-/// sibling, see [`RcFn`], which wraps `Rc<dyn Fn(A) -> B + 'static>` and
-/// implements `Clone` in O(1).
-///
-/// # Examples
-/// ```
-/// use monadify::function::CFn;
-///
-/// let add_one = CFn::new(|x: i32| x + 1);
-/// assert_eq!(add_one.call(5), 6);
-/// assert_eq!(add_one.call(10), 11); // Can be called multiple times
-/// ```
-pub struct CFn<A, B>(pub BFn<A, B>);
-
 /// A wrapper around `BFnOnce<A, B>` (a `Box<dyn FnOnce(A) -> B + 'static>`).
 ///
 /// This struct provides a concrete type for heap-allocated, once-callable closures.
-/// Similar to `CFn`, it's useful for type concretization.
 ///
 /// # Examples
 /// ```
@@ -49,40 +22,8 @@ pub struct CFn<A, B>(pub BFn<A, B>);
 /// // This closure captures `s` by move, so it's FnOnce.
 /// let append_s_once = CFnOnce::new(move |x: i32| format!("{}-{}", s, x));
 /// assert_eq!(append_s_once.call_once(5), "hello-5");
-/// // append_s_once.call_once(10); // This would be a compile error (use of moved value) if not for Box
-///                               // but logically it's consumed.
 /// ```
 pub struct CFnOnce<A, B>(pub BFnOnce<A, B>);
-
-impl<A, B> CFn<A, B> {
-    /// Creates a new `CFn` by boxing the given closure.
-    ///
-    /// # Parameters
-    /// - `f`: A closure that implements `Fn(A) -> B` and is `'static`.
-    ///
-    /// # Returns
-    /// A new `CFn<A, B>` instance.
-    pub fn new<F>(f: F) -> Self
-    where
-        F: Fn(A) -> B + 'static,
-    {
-        CFn(Box::new(f))
-    }
-
-    /// Calls the wrapped closure.
-    ///
-    /// This method takes `&self` and the argument `arg` by value,
-    /// allowing the closure to be called multiple times.
-    ///
-    /// # Parameters
-    /// - `arg`: The argument of type `A` to pass to the closure.
-    ///
-    /// # Returns
-    /// The result of type `B` from calling the closure.
-    pub fn call(&self, arg: A) -> B {
-        (self.0)(arg)
-    }
-}
 
 impl<A, B> CFnOnce<A, B> {
     /// Creates a new `CFnOnce` by boxing the given closure.
@@ -114,17 +55,6 @@ impl<A, B> CFnOnce<A, B> {
     }
 }
 
-/// Allows `CFn<A, B>` to be dereferenced to `&Box<dyn Fn(A) -> B + 'static>`.
-/// This enables calling the boxed closure directly using `(*cfn_instance)(arg)` syntax
-/// if desired, though `cfn_instance.call(arg)` is generally preferred for clarity.
-impl<A, B> Deref for CFn<A, B> {
-    type Target = BFn<A, B>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 /// Allows `CFnOnce<A, B>` to be dereferenced to `&Box<dyn FnOnce(A) -> B + 'static>`.
 impl<A, B> Deref for CFnOnce<A, B> {
     type Target = BFnOnce<A, B>;
@@ -132,13 +62,6 @@ impl<A, B> Deref for CFnOnce<A, B> {
     fn deref(&self) -> &Self::Target {
         &self.0
     }
-}
-
-/// Composes two boxed `Fn` closures.
-/// Given `f: A -> B` and `g: B -> C`, returns a new boxed closure `h: A -> C`
-/// such that `h(x) = g(f(x))`.
-fn compose<A: 'static, B: 'static, C: 'static>(f: BFn<A, B>, g: BFn<B, C>) -> BFn<A, C> {
-    Box::new(move |x| g(f(x)))
 }
 
 /// Composes two boxed `FnOnce` closures.
@@ -149,31 +72,7 @@ fn compose_fn_once<A: 'static, B: 'static, C: 'static>(
     f: BFnOnce<A, B>,
     g: BFnOnce<B, C>,
 ) -> BFnOnce<A, C> {
-    Box::new(move |x| g(f(x))) // f and g are moved into the closure
-}
-
-/// Implements `f >> g` (forward composition) for `CFn`.
-/// `(self >> rhs)(x)` is equivalent to `rhs(self(x))`.
-/// `CFn<A,B> >> CFn<B,C>` results in `CFn<A,C>`.
-impl<A: 'static, B: 'static, C: 'static> std::ops::Shr<CFn<B, C>> for CFn<A, B> {
-    type Output = CFn<A, C>;
-    fn shr(self, rhs: CFn<B, C>) -> Self::Output {
-        // self is f: A -> B, rhs is g: B -> C
-        // Result is g(f(x))
-        CFn(compose(self.0, rhs.0))
-    }
-}
-
-/// Implements `g << f` (backward composition) for `CFn`.
-/// `(self << rhs)(x)` is equivalent to `self(rhs(x))`.
-/// `CFn<B,C> << CFn<A,B>` results in `CFn<A,C>`.
-impl<A: 'static, B: 'static, C: 'static> std::ops::Shl<CFn<A, B>> for CFn<B, C> {
-    type Output = CFn<A, C>;
-    fn shl(self, rhs: CFn<A, B>) -> Self::Output {
-        // self is g: B -> C, rhs is f: A -> B
-        // Result is g(f(x))
-        CFn(compose(rhs.0, self.0))
-    }
+    Box::new(move |x| g(f(x)))
 }
 
 /// Implements `f >> g` (forward composition) for `CFnOnce`.
@@ -201,16 +100,13 @@ impl<A: 'static, B: 'static, C: 'static> std::ops::Shl<CFnOnce<A, B>> for CFnOnc
 /// A Clone-able, shared-ownership function wrapper backed by
 /// `Rc<dyn Fn(A) -> B + 'static>`.
 ///
-/// `RcFn<A, B>` is the **Clone-able, shared-ownership** sibling of [`CFn`].
-/// While [`CFn`] wraps `Box<dyn Fn(A) -> B + 'static>` and is therefore
-/// **not** `Clone`, `RcFn` wraps `Rc<dyn Fn(A) -> B + 'static>` and
-/// implements `Clone`. Cloning an `RcFn` bumps the `Rc` reference count
-/// in O(1) — the closure body is **not** duplicated.
+/// `RcFn<A, B>` is the **Clone-able, shared-ownership** multi-call function wrapper.
+/// It wraps `Rc<dyn Fn(A) -> B + 'static>` and implements `Clone`. Cloning an `RcFn`
+/// bumps the `Rc` reference count in O(1) — the closure body is **not** duplicated.
 ///
 /// Unlike `#[derive(Clone)]` (which would add bounds `A: Clone, B: Clone`),
 /// the `Clone` impl here only requires `Rc<dyn Fn(A)->B+'static>: Clone`,
-/// which is always satisfied regardless of `A` and `B`. This allows
-/// `RcFn<X, CFn<A,B>>` to be `Clone` even though `CFn<A,B>` is not.
+/// which is always satisfied regardless of `A` and `B`.
 ///
 /// This makes `RcFn` law-equivalent to a deep copy **only for
 /// referentially-transparent `Fn`** closures (no observable interior
@@ -233,7 +129,6 @@ pub struct RcFn<A, B>(pub RFn<A, B>);
 ///
 /// `Rc<dyn Fn(A)->B+'static>` is always `Clone` (it just bumps the reference
 /// count), so we can implement `Clone for RcFn<A,B>` unconditionally.
-/// This means `RcFn<X, CFn<A,B>>` is `Clone` even though `CFn<A,B>` is not.
 impl<A, B> Clone for RcFn<A, B> {
     fn clone(&self) -> Self {
         RcFn(Rc::clone(&self.0))
@@ -265,8 +160,6 @@ impl<A, B> RcFn<A, B> {
     /// # Returns
     /// The result of type `B` from calling the closure.
     pub fn call(&self, arg: A) -> B {
-        // `self.0.as_ref()` coerces `&Rc<dyn Fn(A)->B>` → `&dyn Fn(A)->B`,
-        // which implements `Fn(A)->B` via the blanket `impl<F: Fn+?Sized> Fn for &F`.
         (self.0.as_ref())(arg)
     }
 }
@@ -288,8 +181,6 @@ impl<A: 'static, B: 'static, C: 'static> std::ops::Shr<RcFn<B, C>> for RcFn<A, B
     fn shr(self, rhs: RcFn<B, C>) -> Self::Output {
         let f = self.0;
         let g = rhs.0;
-        // Both `f` and `g` are owned `Rc<dyn Fn>` moved into the closure.
-        // Calling `f(x)` auto-derefs `Rc<dyn Fn(A)->B>` → `dyn Fn(A)->B`.
         RcFn(Rc::new(move |x: A| g(f(x))))
     }
 }

--- a/src/functor.rs
+++ b/src/functor.rs
@@ -16,10 +16,8 @@ pub mod kind {
     //! It relies on the [`Kind1`] trait from `crate::kind_based::kind` to relate the
     //! marker `Self` to its concrete type application `Self::Of<T>`.
 
-    use crate::function::{CFn, CFnOnce, RcFn};
-    use crate::kind_based::kind::{
-        CFnKind, CFnOnceKind, Kind1, OptionKind, RcFnKind, ResultKind, VecKind,
-    };
+    use crate::function::{CFnOnce, RcFn};
+    use crate::kind_based::kind::{CFnOnceKind, Kind1, OptionKind, RcFnKind, ResultKind, VecKind};
     use std::rc::Rc;
 
     /// Represents a type constructor that can be mapped over, using the Kind pattern.
@@ -53,11 +51,11 @@ pub mod kind {
         ///   - `FnMut`: Allows mutation of captured state if needed, and covers `Fn` and `FnOnce`
         ///     that don't consume their captures by value on first call. Standard library `map`
         ///     methods (like `Option::map`, `Result::map`) often take `FnOnce`.
-        ///   - `Clone`: Necessary for some implementations like [`CFnKind`], where the
+        ///   - `Clone`: Necessary for some implementations like [`RcFnKind`], where the
         ///     function might need to be cloned if the resulting structure can be "called"
         ///     multiple times.
         ///   - `'static`: Often required when functions are stored or returned within structures
-        ///     like [`CFn`] or [`CFnOnce`], especially if they don't borrow from the local scope.
+        ///     like [`RcFn`] or [`CFnOnce`], especially if they don't borrow from the local scope.
         ///
         /// # Returns
         /// A new Kind-structured value `Self::Of<B>` containing the result(s) of
@@ -80,23 +78,6 @@ pub mod kind {
     impl<A, B> Functor<A, B> for VecKind {
         fn map(input: Self::Of<A>, func: impl FnMut(A) -> B + Clone + 'static) -> Self::Of<B> {
             input.into_iter().map(func).collect()
-        }
-    }
-
-    // Functor impl for CFnKind (maps over the output type of CFn)
-    // A is the original output type, B is the new output type
-    impl<X, A, B> Functor<A, B> for CFnKind<X>
-    where
-        X: 'static,
-        A: 'static,
-        B: 'static, // B must be 'static for CFn<X,B> which is Self::Of<B>
-    {
-        fn map(input: Self::Of<A>, func: impl FnMut(A) -> B + Clone + 'static) -> Self::Of<B> {
-            // input is CFn<X, A>
-            // func is A -> B
-            // result is CFn<X, B>
-            // To create a new CFn, the captured 'func' needs to be Clone if 'input' is called multiple times.
-            CFn::new(move |x: X| func.clone()(input.call(x))) // func.clone() for new CFn
         }
     }
 
@@ -136,6 +117,6 @@ pub mod kind {
 
 // Directly export Kind-based Functor
 pub use kind::Functor; // Renamed from hkt to kind
-                       // Note: CFnKind and CFnOnceKind are defined in kind_based::kind
+                       // Note: RcFnKind and CFnOnceKind are defined in kind_based::kind
                        // and Functor implementations for them are in the kind module above.
                        // This re-export makes `crate::functor::Functor` point to the Kind-based one.

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -43,7 +43,7 @@ pub mod kind {
 
     use crate::applicative::kind as applicative_kind; // Renamed hkt to kind
     use crate::apply::kind as apply_kind; // Renamed hkt to kind
-    use crate::function::CFn;
+    use crate::function::RcFn;
     use crate::functor::kind as functor_kind; // Renamed hkt to kind
     use crate::kind_based::kind::Kind; // Changed HKT to Kind
     use crate::monad::kind as monad_kind; // Renamed hkt to kind // For Apply's function container
@@ -82,15 +82,14 @@ pub mod kind {
 
     // Kind-based Apply for IdentityKind
     impl<A, B> apply_kind::Apply<A, B> for IdentityKind
-    // Changed IdentityHKTMarker to IdentityKind
     where
         A: 'static, // Required by Apply trait definition
         B: 'static, // Required by Apply trait definition
     {
-        /// Applies a wrapped function `Identity<CFn<A, B>>` to a wrapped value `Identity<A>`.
+        /// Applies a wrapped function `Identity<RcFn<A, B>>` to a wrapped value `Identity<A>`.
         fn apply(
             value_container: Identity<A>,
-            function_container: Identity<CFn<A, B>>,
+            function_container: Identity<RcFn<A, B>>,
         ) -> Identity<B> {
             Identity(function_container.0.call(value_container.0))
         }

--- a/src/kind_based/kind.rs
+++ b/src/kind_based/kind.rs
@@ -16,7 +16,7 @@
 //! the marker's `Of<Arg>` GAT, they can refer to the concrete type
 //! (e.g., `Option<String>`, `Vec<i32>`).
 
-use crate::function::{CFn, CFnOnce, RcFn};
+use crate::function::{CFnOnce, RcFn};
 use std::marker::PhantomData;
 
 /// Represents a type constructor, often referred to as a Kind.
@@ -79,16 +79,6 @@ impl<E> Kind for ResultKind<E> {
     type Of<Arg> = Result<Arg, E>;
 }
 
-/// Kind Marker for `CFn<X, _>`. `X` is the fixed input type of the function.
-///
-/// Implements [`Kind`] such that `CFnKind<X>::Of<Output>` resolves to `CFn<X, Output>`.
-#[derive(Default)] // CFnKind itself doesn't need Debug, Clone etc. unless used directly in ways that require it.
-pub struct CFnKind<X>(PhantomData<X>);
-
-impl<X> Kind for CFnKind<X> {
-    type Of<Output> = CFn<X, Output>;
-}
-
 /// Kind Marker for `CFnOnce<X, _>`. `X` is the fixed input type of the function.
 ///
 /// Implements [`Kind`] such that `CFnOnceKind<X>::Of<Output>` resolves to `CFnOnce<X, Output>`.
@@ -103,7 +93,7 @@ impl<X> Kind for CFnOnceKind<X> {
 ///
 /// Implements [`Kind`] such that `RcFnKind<X>::Of<Output>` resolves to `RcFn<X, Output>`.
 ///
-/// Unlike [`CFnKind<X>`], the resolved type `RcFn<X, Output>` is `Clone` (O(1) `Rc` bump),
+/// The resolved type `RcFn<X, Output>` is `Clone` (O(1) `Rc` bump),
 /// which enables `Applicative` laws over `VecKind` and `mdo!` do-notation blocks.
 #[derive(Default)]
 pub struct RcFnKind<X>(PhantomData<X>);

--- a/src/legacy/apply.rs
+++ b/src/legacy/apply.rs
@@ -1,5 +1,5 @@
 // Content from the original classic module in src/apply.rs
-use crate::function::CFn; // CFn is not part of legacy/hkt split
+use crate::function::RcFn;
 use crate::legacy::functor::Functor; // Point to legacy Functor
 
 /// Legacy version of the `Apply` trait.
@@ -12,12 +12,12 @@ pub trait Apply<A>: Functor<A> {
     /// E.g., if `Self` is `Option<A>`, then `Apply<T>` would be `Option<T>`.
     type Apply<T>;
     /// The type of the (wrapped) function used by `apply`.
-    /// Typically `CFn<T, U>` for function `T -> U`.
+    /// Typically `RcFn<T, U>` for function `T -> U`.
     type Fnn<T, U>;
 
     /// Applies a wrapped function to a wrapped value.
     ///
-    /// Given `self` (e.g., `Option<A>`) and `i` (e.g., `Option<CFn<A,B>>`),
+    /// Given `self` (e.g., `Option<A>`) and `i` (e.g., `Option<RcFn<A,B>>`),
     /// produces a result (e.g., `Option<B>`).
     #[allow(clippy::type_complexity)]
     fn apply<B>(
@@ -32,38 +32,38 @@ pub trait Apply<A>: Functor<A> {
 
 impl<A: 'static> Apply<A> for Option<A> {
     type Apply<T> = Option<T>;
-    type Fnn<T, U> = CFn<T, U>;
+    type Fnn<T, U> = RcFn<T, U>;
 
-    fn apply<B>(self, i: Option<Self::Fnn<A, B>>) -> Option<B>
+    fn apply<B>(self, i: Option<RcFn<A, B>>) -> Option<B>
     where
         Self: Sized,
     {
-        self.and_then(|val_a| i.map(|func_ab| func_ab.call(val_a)))
+        self.and_then(|val_a| i.map(|func_ab: RcFn<A, B>| func_ab.call(val_a)))
     }
 }
 
 impl<A: 'static, E: 'static + Clone> Apply<A> for Result<A, E> {
     type Apply<T> = Result<T, E>;
-    type Fnn<T, U> = CFn<T, U>;
+    type Fnn<T, U> = RcFn<T, U>;
 
-    fn apply<B>(self, i: Result<Self::Fnn<A, B>, E>) -> Result<B, E>
+    fn apply<B>(self, i: Result<RcFn<A, B>, E>) -> Result<B, E>
     where
         Self: Sized,
     {
-        self.and_then(|val_a| i.map(|func_ab| func_ab.call(val_a)))
+        self.and_then(|val_a| i.map(|func_ab: RcFn<A, B>| func_ab.call(val_a)))
     }
 }
 
 impl<A: 'static + Clone> Apply<A> for Vec<A> {
     type Apply<T> = Vec<T>;
-    type Fnn<T, U> = CFn<T, U>;
+    type Fnn<T, U> = RcFn<T, U>;
 
-    fn apply<B>(self, fs: Vec<Self::Fnn<A, B>>) -> Vec<B>
+    fn apply<B>(self, fs: Vec<RcFn<A, B>>) -> Vec<B>
     where
         Self: Sized,
     {
         fs.into_iter()
-            .flat_map(|f_fn| self.iter().map(move |val_a| f_fn.call(val_a.clone())))
+            .flat_map(|f_fn: RcFn<A, B>| self.iter().map(move |val_a| f_fn.call(val_a.clone())))
             .collect()
     }
 }
@@ -74,8 +74,8 @@ impl<A: 'static + Clone> Apply<A> for Vec<A> {
 /// This is a common helper for `Apply` types.
 pub fn lift2<A, B, C: 'static, A2B2C, FB2C: 'static, FA, FB, FC>(func: A2B2C, fa: FA, fb: FB) -> FC
 where
-    A2B2C: Fn(A) -> CFn<B, C> + Clone + 'static,
-    FA: Functor<A, Functor<CFn<B, C>> = FB2C>,
+    A2B2C: Fn(A) -> RcFn<B, C> + Clone + 'static,
+    FA: Functor<A, Functor<RcFn<B, C>> = FB2C>,
     FB: Apply<B, Functor<<FB as Apply<B>>::Fnn<B, C>> = FB2C, Apply<C> = FC>,
 {
     let f_b_to_c_in_fa = <FA as Functor<A>>::map(fa, func);
@@ -105,9 +105,9 @@ pub fn lift3<
     fc: FC,
 ) -> FD
 where
-    A2B2C2D: Fn(A) -> CFn<B, CFn<C, D>> + Clone + 'static,
-    FA: Functor<A, Functor<CFn<B, CFn<C, D>>> = FB2C2D>,
-    FB: Apply<B, Functor<<FB as Apply<B>>::Fnn<B, CFn<C, D>>> = FB2C2D, Apply<CFn<C, D>> = FC2D>,
+    A2B2C2D: Fn(A) -> RcFn<B, RcFn<C, D>> + Clone + 'static,
+    FA: Functor<A, Functor<RcFn<B, RcFn<C, D>>> = FB2C2D>,
+    FB: Apply<B, Functor<<FB as Apply<B>>::Fnn<B, RcFn<C, D>>> = FB2C2D, Apply<RcFn<C, D>> = FC2D>,
     FC: Apply<C, Functor<<FC as Apply<C>>::Fnn<C, D>> = FC2D, Apply<D> = FD>,
 {
     let f_b_to_c_to_d_in_fa = <FA as Functor<A>>::map(fa, func);
@@ -125,10 +125,10 @@ pub fn apply_first<A, B, FA, FB, FB2A: 'static>(fa: FA, fb: FB) -> <FB as Apply<
 where
     A: Copy + 'static,
     B: 'static,
-    FA: Functor<A, Functor<CFn<B, A>> = FB2A>,
+    FA: Functor<A, Functor<RcFn<B, A>> = FB2A>,
     FB: Apply<B, Functor<<FB as Apply<B>>::Fnn<B, A>> = FB2A>,
 {
-    let map_fn = |x: A| CFn::new(move |_y: B| x);
+    let map_fn = |x: A| RcFn::new(move |_y: B| x);
     lift2(map_fn, fa, fb)
 }
 
@@ -142,11 +142,11 @@ pub fn apply_second<A, B, FA, FB, FMapResult, ResultApplyB>(fa: FA, fb: FB) -> R
 where
     A: 'static,
     B: 'static,
-    FA: Functor<A, Functor<CFn<B, B>> = FMapResult>,
+    FA: Functor<A, Functor<RcFn<B, B>> = FMapResult>,
     FB: Apply<B, Functor<<FB as Apply<B>>::Fnn<B, B>> = FMapResult, Apply<B> = ResultApplyB>,
     FMapResult: Functor<<FB as Apply<B>>::Fnn<B, B>> + 'static,
 {
-    let map_fn = |_: A| CFn::new(|y: B| y);
+    let map_fn = |_: A| RcFn::new(|y: B| y);
     let mapped_fa: FMapResult = <FA as Functor<A>>::map(fa, map_fn);
     <FB as Apply<B>>::apply(fb, mapped_fa)
 }

--- a/src/legacy/functor.rs
+++ b/src/legacy/functor.rs
@@ -1,5 +1,6 @@
 // Content from the original classic module in src/functor.rs
-use crate::function::{CFn, CFnOnce};
+use crate::function::{CFnOnce, RcFn};
+use std::rc::Rc;
 
 /// Represents a type constructor that can be mapped over.
 ///
@@ -9,8 +10,8 @@ use crate::function::{CFn, CFnOnce};
 /// for working with "boxed" or "contextual" values.
 ///
 /// Implementors of `Functor` must satisfy two laws:
-/// 1. **Identity**: `map(x, |a| a) == x` (more precisely, `<Type<A> as Functor<A>>::map(x, |a| a) == x`)
-/// 2. **Composition**: `<Type<B> as Functor<B>>::map(<Type<A> as Functor<A>>::map(x, f), g) == <Type<A> as Functor<A>>::map(x, |a| g(f(a)))`
+/// 1. **Identity**: `map(x, |a| a) == x`
+/// 2. **Composition**: `map(map(x, f), g) == map(x, |a| g(f(a)))`
 ///
 /// The associated type `Functor<T>` represents the generic structure of the functor
 /// itself, allowing `map` to transform the inner type while preserving the structure.
@@ -57,14 +58,15 @@ impl<A: 'static> Functor<A> for Vec<A> {
     }
 }
 
-impl<X: 'static, A: 'static> Functor<A> for CFn<X, A> {
-    type Functor<T> = CFnOnce<X, T>;
+impl<X: 'static, A: 'static> Functor<A> for RcFn<X, A> {
+    type Functor<T> = RcFn<X, T>;
 
-    fn map<B, Func>(self, mut f: Func) -> Self::Functor<B>
+    fn map<B, Func>(self, func: Func) -> RcFn<X, B>
     where
-        Func: FnMut(A) -> B + 'static,
+        Func: FnMut(A) -> B + Clone + 'static,
     {
-        CFnOnce::new(move |x: X| f(self.call(x)))
+        let inner = self.0.clone();
+        RcFn(Rc::new(move |x: X| func.clone()(inner(x))))
     }
 }
 
@@ -77,4 +79,4 @@ impl<X: 'static, A: 'static> Functor<A> for CFnOnce<X, A> {
     {
         CFnOnce::new(move |x: X| f(self.call_once(x)))
     }
-} // Closing for impl Functor for CFnOnce
+}

--- a/src/legacy/identity.rs
+++ b/src/legacy/identity.rs
@@ -1,9 +1,9 @@
 // Content from the original classic module in src/identity.rs
-use crate::function::CFn;
+use crate::function::RcFn;
 use crate::legacy::applicative::Applicative;
 use crate::legacy::apply::Apply;
 use crate::legacy::functor::Functor;
-use crate::legacy::monad::{Bind, Monad}; // CFn is not part of legacy/hkt split
+use crate::legacy::monad::{Bind, Monad};
 
 /// Legacy version of the `Identity` monad.
 ///
@@ -28,8 +28,8 @@ impl<A> Functor<A> for Identity<A> {
 
 impl<A: 'static> Apply<A> for Identity<A> {
     type Apply<T> = Identity<T>;
-    type Fnn<T, U> = CFn<T, U>;
-    fn apply<B>(self, i: Identity<Self::Fnn<A, B>>) -> Identity<B>
+    type Fnn<T, U> = RcFn<T, U>;
+    fn apply<B>(self, i: Identity<RcFn<A, B>>) -> Identity<B>
     where
         Self: Sized,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 pub mod applicative;
 /// Provides the Kind-based `Apply` trait (an extension of `Functor`) and its implementations.
 pub mod apply;
-/// Defines `CFn`, `RcFn`, and `CFnOnce` for heap-allocated, callable function wrappers.
+/// Defines `RcFn` and `CFnOnce` for heap-allocated, callable function wrappers.
 pub mod function;
 /// Provides the Kind-based `Functor` trait and its implementations.
 pub mod functor;
@@ -40,7 +40,7 @@ pub use profunctor::{Choice, Profunctor, Strong};
 pub use transformers::reader::MonadReader; // Points to transformers::reader::kind::MonadReader
 
 // Public re-exports of key structs/types (optional, but can be convenient)
-pub use function::{CFn, CFnOnce, RcFn};
+pub use function::{CFnOnce, RcFn};
 pub use identity::Identity; // Points to identity::kind::Identity
 pub use transformers::reader::{Reader, ReaderT}; // Points to transformers::reader::kind::ReaderT etc.
 
@@ -48,7 +48,6 @@ pub use transformers::reader::{Reader, ReaderT}; // Points to transformers::read
 pub use crate::identity::IdentityKind; // Changed from IdentityHKTMarker
 pub use crate::transformers::reader::ReaderTKind;
 pub use kind_based::kind::{
-    CFnKind,
     CFnOnceKind,
     Kind,
     Kind1, // Core Kind traits
@@ -94,12 +93,11 @@ pub mod do_notation;
 ///
 /// # Limitations
 ///
-/// **`CFnKind` and `CFnOnceKind` are not supported** (not `Clone`; they wrap
-/// `Box<dyn Fn(…)>`). The desugaring emits `(expr).clone()` on every monadic
-/// right-hand side, which fails with `E0599` at depth ≥ 1.
-/// **`RcFnKind` is supported** — it is the `Clone`-able, shared-ownership
-/// sibling backed by `Rc<dyn Fn(…)>`. See `tests/kind/do_notation/cfn_unsupported.rs`
-/// for details.
+/// **`CFnOnceKind` is not supported** (not `Clone`; wraps `Box<dyn FnOnce(…)>`).
+/// The desugaring emits `(expr).clone()` on every monadic right-hand side,
+/// which fails with `E0599` at depth ≥ 1.
+/// **`RcFnKind` is supported** — it is `Clone`-able via `Rc<dyn Fn(…)>` (O(1) bump).
+/// See `tests/kind/do_notation/cfn_unsupported.rs` for details.
 ///
 /// At most **one non-`Copy` external value may be captured per `mdo!` nesting
 /// level**. Because the desugaring emits nested `move` closures bound by

--- a/src/monad.rs
+++ b/src/monad.rs
@@ -43,9 +43,9 @@ pub mod kind {
 
     use crate::applicative::kind::Applicative; // Kind-based Applicative
     use crate::apply::kind::Apply; // Kind-based Apply
-    use crate::function::{CFn, CFnOnce, RcFn};
+    use crate::function::{CFnOnce, RcFn};
     use crate::kind_based::kind::{
-        CFnKind, CFnOnceKind, Kind, Kind1, OptionKind, RcFnKind, ResultKind, VecKind,
+        CFnOnceKind, Kind, Kind1, OptionKind, RcFnKind, ResultKind, VecKind,
     };
     use std::rc::Rc;
 
@@ -184,43 +184,6 @@ pub mod kind {
         }
     }
 
-    // Bind for CFnKind<R> (Kleisli composition for R -> _)
-    // input: Self::Of<A> which is CFn<R, A>
-    // func: A -> Self::Of<B> which is A -> CFn<R, B> (a function producing a function)
-    // result: Self::Of<B> which is CFn<R, B> (a new function R -> B)
-    impl<R, A, B: 'static> Bind<A, B> for CFnKind<R>
-    // Changed CFnHKTMarker to CFnKind
-    where
-        R: 'static + Clone, // Clone for `r.clone()`
-        A: 'static,
-        Self: Apply<A, B>,
-        Self: Kind<Of<A> = CFn<R, A>>, // Changed HKT to Kind, Applied to Of
-        Self: Kind<Of<B> = CFn<R, B>>, // Changed HKT to Kind, Applied to Of
-    {
-        /// Implements Kleisli composition for functions `R -> A` and `A -> (R -> B)`.
-        ///
-        /// Given `input_fn: R -> A` and `func: A -> (R -> B)`,
-        /// produces a new function `R -> B`.
-        /// The new function, when called with `r: R`:
-        /// 1. Calls `input_fn(r)` to get `a: A`.
-        /// 2. Calls `func(a)` to get `output_fn: R -> B`.
-        /// 3. Calls `output_fn(r)` to get `b: B`.
-        fn bind(
-            input: Self::Of<A>,
-            func: impl FnMut(A) -> Self::Of<B> + Clone + 'static,
-        ) -> Self::Of<B> {
-            // Changed Applied to Of
-            let concrete_input_fn = input;
-
-            CFn::new(move |r: R| {
-                let a_val = concrete_input_fn.call(r.clone());
-                let mut func_clone = func.clone(); // Clone for this call, as CFn::new needs Fn
-                let cfn_r_b = func_clone(a_val); // cfn_r_b is CFn<R, B>
-                cfn_r_b.call(r.clone())
-            })
-        }
-    }
-
     // Bind for RcFnKind<R> (Kleisli composition for R -> _)
     // input: RcFn<R, A>; func: A -> RcFn<R, B>; result: RcFn<R, B>
     impl<R, A, B: 'static> Bind<A, B> for RcFnKind<R>
@@ -262,7 +225,7 @@ pub mod kind {
     {
         /// Implements Kleisli composition for functions `R -> A` (once) and `A -> (R -> B)` (once).
         ///
-        /// Similar to `CFnKind::bind`, but for `CFnOnce`.
+        /// Implements Kleisli composition for `CFnOnce`: analogous to `RcFnKind::bind` but for single-use closures.
         /// The resulting function `R -> B` can also only be called once.
         fn bind(
             input: Self::Of<A>,
@@ -314,26 +277,6 @@ pub mod kind {
         }
     }
 
-    impl<R, A> Monad<A> for CFnKind<R>
-    // Changed CFnHKTMarker to CFnKind
-    where
-        R: 'static + Clone,
-        A: 'static + Clone, // From Applicative supertrait for CFnKind<R>
-    {
-        /// Flattens `CFn<R, CFn<R, A>>` to `CFn<R, A>`.
-        ///
-        /// This is achieved by using `bind` with the identity function `|ma: CFn<R,A>| ma`.
-        /// Given `mma: R -> (R -> A)`, produces `R -> A`.
-        /// The new function, when called with `r: R`:
-        /// 1. Calls `mma(r)` to get `ma: R -> A`.
-        /// 2. Calls `ma(r)` to get `a: A`.
-        fn join(mma: Self::Of<Self::Of<A>>) -> Self::Of<A> {
-            // mma is CFn<R, CFn<R,A>>. Changed Applied to Of
-            // Bind<Self::Of<A>, A> means Bind<CFn<R,A>, A>
-            <Self as Bind<Self::Of<A>, A>>::bind(mma, |ma: Self::Of<A>| ma) // Changed Applied to Of
-        }
-    }
-
     impl<R, A> Monad<A> for RcFnKind<R>
     where
         R: 'static + Clone,
@@ -343,7 +286,7 @@ pub mod kind {
         ///
         /// Implemented via `bind` with the identity function `|ma: RcFn<R,A>| ma`.
         /// Because `RcFn` is `Clone`, the inner type `A = RcFn<R, A>` satisfies
-        /// the `Clone` constraint that prevented this from working with `CFnKind`.
+        /// the `Clone` constraint (unlike the old `Box`-backed approach which blocked this).
         fn join(mma: Self::Of<Self::Of<A>>) -> Self::Of<A> {
             <Self as Bind<Self::Of<A>, A>>::bind(mma, |ma: Self::Of<A>| ma)
         }
@@ -357,7 +300,7 @@ pub mod kind {
     {
         /// Flattens `CFnOnce<R, CFnOnce<R, A>>` to `CFnOnce<R, A>`.
         ///
-        /// Similar to `CFnKind::join`, but for `CFnOnce`.
+        /// Analogous to `RcFnKind::join`, but for single-use `CFnOnce` closures.
         fn join(mma: Self::Of<Self::Of<A>>) -> Self::Of<A> {
             // mma is CFnOnce<R, CFnOnce<R,A>>. Changed Applied to Of
             <Self as Bind<Self::Of<A>, A>>::bind(mma, |ma: Self::Of<A>| ma) // Changed Applied to Of

--- a/src/profunctor.rs
+++ b/src/profunctor.rs
@@ -1,6 +1,6 @@
 use std::{marker::PhantomData, ops::Deref};
 
-use crate::function::{CFn, CFnOnce};
+use crate::function::{CFnOnce, RcFn};
 
 /// A `Profunctor` is a bifunctor that is contravariant in its first type parameter
 /// and covariant in its second type parameter.
@@ -15,14 +15,9 @@ use crate::function::{CFn, CFnOnce};
 /// Laws:
 /// 1. `dimap(id, id) == id`
 /// 2. `dimap(f . g, h . i) == dimap(g, h) . dimap(f, i)`
-///    (More precisely: `p.dimap(f, g).dimap(h, i) == p.dimap(h . f, g . i)`)
-///    No, it should be: `p.dimap(f, g).dimap(h, i) == p.dimap(f . h, i . g)` if thinking of `p` as `B -> C`.
-///    Let `p: P<B,C>`. `p.dimap(a2b: A->B, c2d: C->D)` gives `P<A,D>`.
-///    If we then `dimap(x2a: X->A, d2y: D->Y)`, we get `P<X,Y>`.
-///    This is `p.dimap(a2b . x2a, d2y . c2d)`.
 pub trait Profunctor<B, C> {
     /// The associated type representing the structure of the Profunctor.
-    /// For example, if `Self` is `CFn<B, C>`, then `Pro<T, U>` would be `CFn<T, U>`.
+    /// For example, if `Self` is `RcFn<B, C>`, then `Pro<T, U>` would be `RcFn<T, U>`.
     type Pro<T, U>;
 
     /// Maps the input and output of the profunctor.
@@ -50,12 +45,12 @@ pub trait Profunctor<B, C> {
         D: 'static;
 }
 
-/// `CFn<B, C>` (a boxed function `B -> C`) as a `Profunctor`.
+/// `RcFn<B, C>` (a shared-ownership function `B -> C`) as a `Profunctor`.
 ///
-/// `dimap` on `h: CFn<B,C>` with `f: A->B` and `g: C->D` results in a new
-/// `CFn<A,D>` that computes `a -> g(h(f(a)))`.
-impl<B, C> Profunctor<B, C> for CFn<B, C> {
-    type Pro<T, U> = CFn<T, U>;
+/// `dimap` on `h: RcFn<B,C>` with `f: A->B` and `g: C->D` results in a new
+/// `RcFn<A,D>` that computes `a -> g(h(f(a)))`.
+impl<B, C> Profunctor<B, C> for RcFn<B, C> {
+    type Pro<T, U> = RcFn<T, U>;
     fn dimap<A, D, A2B, C2D>(self, a2b: A2B, c2d: C2D) -> Self::Pro<A, D>
     where
         A2B: Fn(A) -> B + 'static,
@@ -69,13 +64,13 @@ impl<B, C> Profunctor<B, C> for CFn<B, C> {
         // a2b is f: A -> B
         // c2d is g: C -> D
         // Result is a function A -> D: a |-> g(h(f(a)))
-        CFn::new(move |a: A| c2d(self.call(a2b(a))))
+        RcFn::new(move |a: A| c2d(self.call(a2b(a))))
     }
 }
 
 /// `CFnOnce<B, C>` (a boxed, once-callable function `B -> C`) as a `Profunctor`.
 ///
-/// Similar to `CFn`, `dimap` on `h: CFnOnce<B,C>` with `f: A->B` and `g: C->D`
+/// Similar to `RcFn`, `dimap` on `h: CFnOnce<B,C>` with `f: A->B` and `g: C->D`
 /// results in a new `CFnOnce<A,D>` that computes `a -> g(h(f(a)))`.
 impl<B, C> Profunctor<B, C> for CFnOnce<B, C> {
     type Pro<T, U> = CFnOnce<T, U>;
@@ -111,18 +106,18 @@ pub trait Strong<A, B>: Profunctor<A, B> {
     fn second<C: 'static>(self) -> Self::Pro<(C, A), (C, B)>;
 }
 
-/// `CFn<A, B>` as a `Strong` profunctor.
-impl<A: 'static, B: 'static> Strong<A, B> for CFn<A, B> {
+/// `RcFn<A, B>` as a `Strong` profunctor.
+impl<A: 'static, B: 'static> Strong<A, B> for RcFn<A, B> {
     /// If `self` is `f: A -> B`, `first` returns `((A,C)) -> (B,C)`
     /// where the new function is `(a,c) -> (f(a), c)`.
     fn first<C: 'static>(self) -> Self::Pro<(A, C), (B, C)> {
-        CFn::new(move |(a, c)| (self.call(a), c)) // self.call as self is CFn
+        RcFn::new(move |(a, c)| (self.call(a), c))
     }
 
     /// If `self` is `f: A -> B`, `second` returns `((C,A)) -> (C,B)`
     /// where the new function is `(c,a) -> (c, f(a))`.
     fn second<C: 'static>(self) -> Self::Pro<(C, A), (C, B)> {
-        CFn::new(move |(c, a)| (c, self.call(a))) // self.call as self is CFn
+        RcFn::new(move |(c, a)| (c, self.call(a)))
     }
 }
 
@@ -130,32 +125,30 @@ impl<A: 'static, B: 'static> Strong<A, B> for CFn<A, B> {
 ///
 /// `Choice` extends `Profunctor` with `left` and `right` methods.
 /// - `left`: Given `P<A, B>`, produces `P<Result<C, A>, Result<C, B>>`. It processes
-///   the `Err` part of a `Result`, leaving `Ok` untouched. (Note: standard `Choice` often maps `Left`, here it's `Err`).
+///   the `Err` part of a `Result`, leaving `Ok` untouched.
 /// - `right`: Given `P<A, B>`, produces `P<Result<A, C>, Result<B, C>>`. It processes
-///   the `Ok` part of a `Result`, leaving `Err` untouched. (Note: standard `Choice` often maps `Right`, here it's `Ok`).
+///   the `Ok` part of a `Result`, leaving `Err` untouched.
 ///
 /// This is useful for optics like Prisms.
 pub trait Choice<A, B>: Profunctor<A, B> {
     /// Adapts the profunctor to operate on the `Err` variant of a `Result`.
     /// If `self` is `P<A,B>`, `left` returns `P<Result<C,A>, Result<C,B>>`.
-    /// (Mapping the second type param of Result, typically `Err` if `Result<Good, Bad>`)
     fn left<C>(self) -> Self::Pro<Result<C, A>, Result<C, B>>;
 
     /// Adapts the profunctor to operate on the `Ok` variant of a `Result`.
     /// If `self` is `P<A,B>`, `right` returns `P<Result<A,C>, Result<B,C>>`.
-    /// (Mapping the first type param of Result, typically `Ok` if `Result<Good, Bad>`)
     fn right<C>(self) -> Self::Pro<Result<A, C>, Result<B, C>>;
 }
 
-/// `CFn<A, B>` as a `Choice` profunctor.
-impl<A: 'static, B: 'static> Choice<A, B> for CFn<A, B> {
+/// `RcFn<A, B>` as a `Choice` profunctor.
+impl<A: 'static, B: 'static> Choice<A, B> for RcFn<A, B> {
     /// If `self` is `f: A -> B`, `left` returns `Result<C,A> -> Result<C,B>`.
     /// If input is `Ok(c)`, it remains `Ok(c)`.
     /// If input is `Err(a)`, it becomes `Err(f(a))`.
     fn left<C>(self) -> Self::Pro<Result<C, A>, Result<C, B>> {
-        CFn::new(move |r: Result<C, A>| match r {
+        RcFn::new(move |r: Result<C, A>| match r {
             Ok(c) => Ok(c),
-            Err(a) => Err(self.call(a)), // self.call as self is CFn
+            Err(a) => Err(self.call(a)),
         })
     }
 
@@ -163,8 +156,8 @@ impl<A: 'static, B: 'static> Choice<A, B> for CFn<A, B> {
     /// If input is `Ok(a)`, it becomes `Ok(f(a))`.
     /// If input is `Err(c)`, it remains `Err(c)`.
     fn right<C>(self) -> Self::Pro<Result<A, C>, Result<B, C>> {
-        CFn::new(move |r: Result<A, C>| match r {
-            Ok(a) => Ok(self.call(a)), // self.call as self is CFn
+        RcFn::new(move |r: Result<A, C>| match r {
+            Ok(a) => Ok(self.call(a)),
             Err(c) => Err(c),
         })
     }
@@ -241,27 +234,27 @@ impl<PA: Strong<S, T>, PB: Strong<A, B>, S: 'static, T: 'static, A: 'static, B: 
 /// Extracts a value `A` from a structure `S` using a `AGetter`.
 ///
 /// # Parameters
-/// - `lens`: The `AGetter<S, T, A, B>` used to focus on the part `A`.
+/// - `getter`: The `AGetter<S, T, A, B>` used to focus on the part `A`.
 ///   `T` and `B` are typically phantom.
 /// - `s`: The structure `S` from which to extract the part.
 ///
 /// # Returns
 /// The extracted part `A`.
 pub fn view<S: 'static, T: 'static, A: 'static, B: 'static>(
-    getter: AGetter<S, T, A, B>, // Changed lens to getter for clarity
+    getter: AGetter<S, T, A, B>,
     s: S,
 ) -> A {
     // To view with a getter (which is Optic<Forget<A,S,T>, Forget<A,A,B>>),
     // we provide an "inner" profunctor Forget<A,A,B>.
     // Forget<A,A,B> needs a function A -> A (identity) for its `inner` field.
     let inner_profunctor = Forget {
-        inner: CFn::new(|x: A| x), // Identity function A -> A
-        _forget: PhantomData,      // Phantom for B
+        inner: RcFn::new(|x: A| x), // Identity function A -> A
+        _forget: PhantomData,       // Phantom for B
     };
     // Applying the getter's optic transformation:
     // (getter.optic)(Forget<A,A,B>) results in Forget<A,S,T>.
-    // This Forget<A,S,T> has an `inner` field which is CFn<S,A>.
-    // Calling this CFn<S,A> with `s` gives the result `A`.
+    // This Forget<A,S,T> has an `inner` field which is RcFn<S,A>.
+    // Calling this RcFn<S,A> with `s` gives the result `A`.
     (getter.optic)(inner_profunctor).inner.call(s)
 }
 
@@ -276,7 +269,7 @@ pub fn view<S: 'static, T: 'static, A: 'static, B: 'static>(
 /// This is used in defining `Fold` and `Getter` optics.
 pub struct Forget<R, AInput, BPhantom> {
     /// The function `AInput -> R` that Forget wraps.
-    pub inner: CFn<AInput, R>, // Made public for construction/inspection
+    pub inner: RcFn<AInput, R>,
     _forget: PhantomData<BPhantom>,
 }
 
@@ -296,13 +289,13 @@ impl<R: 'static, ProfB: 'static, ProfC> Profunctor<ProfB, ProfC> for Forget<R, P
     ) -> Self::Pro<ImplA, ImplD>
     where
         A2B: Fn(ImplA) -> ProfB + 'static,
-        C2D: Fn(ProfC) -> ImplD + 'static, // Type D for _c2d is ImplD
+        C2D: Fn(ProfC) -> ImplD + 'static,
     {
         // Original inner: ProfB -> R
         // New inner: ImplA -> R, via ImplA -> ProfB -> R
         Forget {
-            inner: CFn::new(a2b) >> self.inner, // Compose a2b with self.inner
-            _forget: PhantomData,               // Phantom for ImplD
+            inner: RcFn::new(a2b) >> self.inner, // Compose a2b with self.inner
+            _forget: PhantomData,                // Phantom for ImplD
         }
     }
 }
@@ -319,7 +312,7 @@ impl<R: 'static, AStrong: 'static, BStrong: 'static> Strong<AStrong, BStrong>
         // Original inner: AStrong -> R
         // New inner: (AStrong, C) -> R. We only care about AStrong.
         Forget {
-            inner: CFn::new(|(a, _c): (AStrong, C)| a) >> self.inner,
+            inner: RcFn::new(|(a, _c): (AStrong, C)| a) >> self.inner,
             _forget: PhantomData, // Phantom for (BStrong, C)
         }
     }
@@ -330,7 +323,7 @@ impl<R: 'static, AStrong: 'static, BStrong: 'static> Strong<AStrong, BStrong>
         // Original inner: AStrong -> R
         // New inner: (C, AStrong) -> R. We only care about AStrong.
         Forget {
-            inner: CFn::new(|(_c, a): (C, AStrong)| a) >> self.inner,
+            inner: RcFn::new(|(_c, a): (C, AStrong)| a) >> self.inner,
             _forget: PhantomData, // Phantom for (C, BStrong)
         }
     }
@@ -339,39 +332,25 @@ impl<R: 'static, AStrong: 'static, BStrong: 'static> Strong<AStrong, BStrong>
 /// Internal helper to construct a Lens using the "van Laarhoven" representation.
 /// Not typically called directly by users. `lens` function is preferred.
 ///
-/// `to`: A function `S -> (A, B -> T)`.
+/// `to`: A function `S -> (A, RcFn<B, T>)`.
 ///   - Takes the whole structure `S`.
 ///   - Returns a pair:
 ///     - The focused part `A`.
-///     - A function `B -> T` that takes a new part `B` and reconstructs the whole `T`.
-///
-/// This function is highly generic and relies on the compiler to infer complex
-/// profunctor relationships.
+///     - A function `RcFn<B, T>` that takes a new part `B` and reconstructs the whole `T`.
 pub fn lens_<PO, PI, PBC, S: 'static, T: 'static, A: 'static, B: 'static>(
-    to: CFn<S, (A, CFn<B, T>)>,
+    to: RcFn<S, (A, RcFn<B, T>)>,
 ) -> Lens<PO, PBC, S, T, A, B>
 where
-    PO: Strong<S, T>, // Outer profunctor for S -> T
-    // PI is the profunctor that results from dimap on PBC.first.
-    // It needs to be Profunctor<(A, CFn<B,T>), (B, CFn<B,T>)>
-    // and its Pro<S,T> must be PO.
-    PI: Profunctor<(A, CFn<B, T>), (B, CFn<B, T>), Pro<S, T> = PO>,
-    // PBC is the "inner" profunctor for A -> B, which must be Strong.
-    // Its .first operation results in a profunctor of type PI.
-    PBC: Strong<A, B, Pro<(A, CFn<B, T>), (B, CFn<B, T>)> = PI>,
+    PO: Strong<S, T>,
+    PI: Profunctor<(A, RcFn<B, T>), (B, RcFn<B, T>), Pro<S, T> = PO>,
+    PBC: Strong<A, B, Pro<(A, RcFn<B, T>), (B, RcFn<B, T>)> = PI>,
 {
-    // pbc: PBC (Strong<A,B>)
-    // PBC::first(pbc): PI (Profunctor for ((A, CFn<B,T>), (B, CFn<B,T>)))
-    // PI::dimap(PI_instance, map_fn_S_to_InnerInput, map_fn_InnerOutput_to_T)
-    //   map_fn_S_to_InnerInput: S -> (A, CFn<B,T>)  (this is `to`)
-    //   map_fn_InnerOutput_to_T: (B, CFn<B,T>) -> T (this is `|(b, f)| f(b)`)
-    // The result of dimap is PO (Strong<S,T>)
     let optics_fn = |pbc: PBC| {
-        let pi_instance = PBC::first(pbc); // pi_instance is PI
+        let pi_instance = PBC::first(pbc);
         PI::dimap(
             pi_instance,
-            move |s_val| to.call(s_val), // S -> (A, CFn<B,T>)
-            |(b_val, f_b_to_t)| f_b_to_t.call(b_val), // (B, CFn<B,T>) -> T
+            move |s_val| to.call(s_val), // S -> (A, RcFn<B,T>)
+            |(b_val, f_b_to_t)| f_b_to_t.call(b_val), // (B, RcFn<B,T>) -> T
         )
     };
     Lens(Optic {
@@ -386,28 +365,28 @@ where
 /// Constructs a `Lens` from a getter function and a setter function.
 ///
 /// # Parameters
-/// - `s2a`: A "getter" function `S -> A` that extracts the part `A` from the whole `S`.
-/// - `s2b2t`: A "setter" function `S -> (B -> T)`. It takes the original whole `S`,
+/// - `s2a`: A "getter" function `RcFn<S, A>` that extracts the part `A` from the whole `S`.
+/// - `s2b2t`: A "setter" function `RcFn<S, RcFn<B, T>>`. It takes the original whole `S`,
 ///   returns a new function that takes the new part `B` and produces the new whole `T`.
 ///   `S` must be `Copy` because it's used by both the getter and to capture in the setter closure.
 ///
 /// # Returns
 /// A `Lens<PO, PI, S, T, A, B>`. The profunctor types `PO` and `PI` are usually inferred.
 pub fn lens<PO, PI, S: Copy + 'static, T: 'static, A: 'static, B: 'static>(
-    s2a: CFn<S, A>,
-    s2b2t: CFn<S, CFn<B, T>>,
+    s2a: RcFn<S, A>,
+    s2b2t: RcFn<S, RcFn<B, T>>,
 ) -> Lens<PO, PI, S, T, A, B>
 where
     PO: Strong<S, T>,
     PI: Strong<A, B>,
     // This constraint links the result of PI.first.dimap to PO.
-    <PI as Profunctor<A, B>>::Pro<(A, CFn<B, T>), (B, CFn<B, T>)>:
-        Profunctor<(A, CFn<B, T>), (B, CFn<B, T>), Pro<S, T> = PO>,
+    <PI as Profunctor<A, B>>::Pro<(A, RcFn<B, T>), (B, RcFn<B, T>)>:
+        Profunctor<(A, RcFn<B, T>), (B, RcFn<B, T>), Pro<S, T> = PO>,
 {
-    // Combine getter and setter into the S -> (A, B -> T) form required by lens_
-    let combined_fn = CFn::new(move |s: S| {
+    // Combine getter and setter into the S -> (A, RcFn<B, T>) form required by lens_
+    let combined_fn = RcFn::new(move |s: S| {
         let part_a = s2a.call(s);
-        let setter_fn_for_s = s2b2t.call(s); // This is CFn<B,T>
+        let setter_fn_for_s = s2b2t.call(s); // This is RcFn<B,T>
         (part_a, setter_fn_for_s)
     });
     lens_(combined_fn)
@@ -421,11 +400,11 @@ pub fn _1<
     A: 'static,
     B: 'static,
     C: 'static,
-    PA: Strong<A, B, Pro<(A, C), (B, C)> = PS> + 'static, // PA is PInner for A->B
-    PS: Strong<(A, C), (B, C)>,                           // PS is POuter for (A,C)->(B,C)
+    PA: Strong<A, B, Pro<(A, C), (B, C)> = PS> + 'static,
+    PS: Strong<(A, C), (B, C)>,
 >() -> Lens<PS, PA, (A, C), (B, C), A, B> {
     Lens(Optic {
-        optic: Box::new(Strong::first), // Strong::first transforms PA to PS
+        optic: Box::new(Strong::first),
         _s: PhantomData,
         _t: PhantomData,
         _a: PhantomData,
@@ -441,11 +420,11 @@ pub fn _2<
     A: 'static,
     B: 'static,
     C: 'static,
-    PA: Strong<A, B, Pro<(C, A), (C, B)> = PS> + 'static, // PA is PInner for A->B
-    PS: Strong<(C, A), (C, B)>,                           // PS is POuter for (C,A)->(C,B)
+    PA: Strong<A, B, Pro<(C, A), (C, B)> = PS> + 'static,
+    PS: Strong<(C, A), (C, B)>,
 >() -> Lens<PS, PA, (C, A), (C, B), A, B> {
     Lens(Optic {
-        optic: Box::new(Strong::second), // Strong::second transforms PA to PS
+        optic: Box::new(Strong::second),
         _s: PhantomData,
         _t: PhantomData,
         _a: PhantomData,
@@ -454,48 +433,28 @@ pub fn _2<
 }
 
 /// Example helper function to create a lens for the first element of a pair.
-/// (This seems to be a more concrete version of `_1` or an attempt at it,
-/// possibly with specific profunctor choices in mind that would satisfy the bounds).
-/// Note: This function is not directly used in tests and might be experimental.
-#[allow(dead_code)] // Potentially unused, kept for reference or future use.
+#[allow(dead_code)]
 fn _1_new<A: Copy + 'static, BTuple: Copy + 'static, PO, PI>(
 ) -> Lens<PO, PI, (A, BTuple), (A, BTuple), A, A>
 where
-    PI: Strong<A, A>,                     // Inner profunctor for A -> A
-    PO: Strong<(A, BTuple), (A, BTuple)>, // Outer profunctor for (A,BTuple) -> (A,BTuple)
-    // Constraint linking PI.first.dimap to PO
-    // The inner profunctor PI operates on A -> A.
-    // PI.first takes a C type, which for lens_ construction is CFn<A_NewPartVal, T_Whole>.
-    // Here, A_NewPartVal is A, and T_Whole is (A, BTuple). So C = CFn<A, (A, BTuple)>.
-    // PI.first gives PI::Pro<(A, CFn<A, (A, BTuple)>), (A, CFn<A, (A, BTuple)>)>. Let this be P_intermediate.
-    // This P_intermediate is then dimap'd.
-    // The dimap inputs are:
-    //   Outer S: (A, BTuple)
-    //   Outer T: (A, BTuple)
-    //   Inner A (P_intermediate's input): (A, CFn<A, (A, BTuple)>)
-    //   Inner B (P_intermediate's output): (A, CFn<A, (A, BTuple)>)
-    // So, P_intermediate must be Profunctor where its Pro<(A,BTuple), (A,BTuple)> = PO.
-    <PI as Profunctor<A, A>>::Pro<(A, CFn<A, (A, BTuple)>), (A, CFn<A, (A, BTuple)>)>: Profunctor<
-        (A, CFn<A, (A, BTuple)>),
-        (A, CFn<A, (A, BTuple)>),
+    PI: Strong<A, A>,
+    PO: Strong<(A, BTuple), (A, BTuple)>,
+    <PI as Profunctor<A, A>>::Pro<(A, RcFn<A, (A, BTuple)>), (A, RcFn<A, (A, BTuple)>)>: Profunctor<
+        (A, RcFn<A, (A, BTuple)>),
+        (A, RcFn<A, (A, BTuple)>),
         Pro<(A, BTuple), (A, BTuple)> = PO,
     >,
 {
     lens(
-        CFn::new(|(first_val, _second_val): (A, BTuple)| first_val), // Getter: (A,BTuple) -> A
-        // Setter: S -> (B_NewPartVal -> T)
-        // S = (A, BTuple)
-        // B_NewPartVal = A (type of the new value for the focused part)
-        // T = (A, BTuple) (type of the whole structure after update)
-        // So, setter is: (A, BTuple) -> (A_new_value -> (A_new_value, BTuple_original))
-        CFn::new(|(_original_a, original_b_tuple): (A, BTuple)| {
-            CFn::new(move |new_a: A| (new_a, original_b_tuple))
+        RcFn::new(|(first_val, _second_val): (A, BTuple)| first_val),
+        RcFn::new(|(_original_a, original_b_tuple): (A, BTuple)| {
+            RcFn::new(move |new_a: A| (new_a, original_b_tuple))
         }),
     )
 }
 
 /// A simple struct for demonstrating lenses.
-#[derive(Clone, Copy, Debug, PartialEq)] // Added Debug, PartialEq
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Check {
     /// A field in the Check struct.
     pub key: i8,
@@ -507,17 +466,15 @@ pub struct Check {
 /// Allows getting `check.key` and setting it.
 pub fn _key<PO, PI>() -> Lens<PO, PI, Check, Check, i8, i8>
 where
-    PO: Strong<Check, Check>, // Outer profunctor for Check -> Check
-    PI: Strong<i8, i8>,       // Inner profunctor for i8 -> i8 (identity for key field)
-    // Constraint linking PI.first.dimap to PO
-    <PI as Profunctor<i8, i8>>::Pro<(i8, CFn<i8, Check>), (i8, CFn<i8, Check>)>:
-        Profunctor<(i8, CFn<i8, Check>), (i8, CFn<i8, Check>), Pro<Check, Check> = PO>,
+    PO: Strong<Check, Check>,
+    PI: Strong<i8, i8>,
+    <PI as Profunctor<i8, i8>>::Pro<(i8, RcFn<i8, Check>), (i8, RcFn<i8, Check>)>:
+        Profunctor<(i8, RcFn<i8, Check>), (i8, RcFn<i8, Check>), Pro<Check, Check> = PO>,
 {
     lens(
-        CFn::new(|c: Check| c.key), // Getter: Check -> i8
-        CFn::new(|c: Check| {
-            // Setter: Check -> (i8_new -> Check_new)
-            CFn::new(move |new_key: i8| Check {
+        RcFn::new(|c: Check| c.key),
+        RcFn::new(|c: Check| {
+            RcFn::new(move |new_key: i8| Check {
                 key: new_key,
                 other: c.other,
             })
@@ -542,9 +499,9 @@ where
     B: 'static,
     C: 'static,
     F: Fn(A) -> B + 'static,
-    Pbc: Profunctor<B, C, Pro<A, C> = Pac>, // Pbc is P<B,C>, Pac is P<A,C>
+    Pbc: Profunctor<B, C, Pro<A, C> = Pac>,
 {
-    profunctor.dimap(a2b, |c_val: C| c_val) // Identity function for the covariant part
+    profunctor.dimap(a2b, |c_val: C| c_val)
 }
 
 /// Maps the output of a `Profunctor` (covariant mapping).
@@ -564,7 +521,7 @@ where
     B: 'static,
     C: 'static,
     F: Fn(B) -> C + 'static,
-    Pab: Profunctor<A, B, Pro<A, C> = Pac>, // Pab is P<A,B>, Pac is P<A,C>
+    Pab: Profunctor<A, B, Pro<A, C> = Pac>,
 {
-    profunctor.dimap(|a_val: A| a_val, b2c) // Identity function for the contravariant part
+    profunctor.dimap(|a_val: A| a_val, b2c)
 }

--- a/src/transformers/reader.rs
+++ b/src/transformers/reader.rs
@@ -101,7 +101,7 @@ pub mod kind {
 
     use crate::applicative::kind as applicative_kind; // Renamed hkt to kind
     use crate::apply::kind as apply_kind; // Renamed hkt to kind
-    use crate::function::CFn; // For Apply's function container type
+    use crate::function::RcFn; // For Apply's function container type
     use crate::functor::kind as functor_kind; // Renamed hkt to kind
     use crate::identity::kind::IdentityKind;
     use crate::kind_based::kind::{Kind, Kind1}; // Changed HKT, HKT1 to Kind, Kind1
@@ -206,21 +206,21 @@ pub mod kind {
         MKind: apply_kind::Apply<A, B> + Kind1 + 'static, // Inner MKind must be Apply. HKT1 to Kind1
         A: 'static,
         B: 'static,
-        MKind::Of<A>: 'static,         // M<A>. Applied to Of
-        MKind::Of<B>: 'static,         // M<B>. Applied to Of
-        MKind::Of<CFn<A, B>>: 'static, // M<CFn<A,B>>. Applied to Of
+        MKind::Of<A>: 'static,          // M<A>. Applied to Of
+        MKind::Of<B>: 'static,          // M<B>. Applied to Of
+        MKind::Of<RcFn<A, B>>: 'static, // M<RcFn<A,B>>.
     {
         /// Applies a wrapped function within `ReaderT` to a wrapped value within `ReaderT`.
         /// Both computations share the same environment `R`. The application happens within `MKind`.
         fn apply(
             value_container: ReaderT<R, MKind, A>,
-            function_container: ReaderT<R, MKind, CFn<A, B>>,
+            function_container: ReaderT<R, MKind, RcFn<A, B>>,
         ) -> ReaderT<R, MKind, B> {
             let value_run = value_container.run_reader_t.clone();
             let function_run = function_container.run_reader_t.clone();
             ReaderT::new(move |env: R| {
-                let m_val: MKind::Of<A> = value_run(env.clone()); // Applied to Of
-                let m_func: MKind::Of<CFn<A, B>> = function_run(env); // Applied to Of
+                let m_val: MKind::Of<A> = value_run(env.clone());
+                let m_func: MKind::Of<RcFn<A, B>> = function_run(env);
                 MKind::apply(m_val, m_func) // Delegate to MKind's apply
             })
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,12 +1,12 @@
-/// Creates a `CFn` (boxed `Fn`) from a nullary (0-argument) closure.
+/// Creates an `RcFn` (shared-ownership `Rc<dyn Fn>`) from a nullary (0-argument) closure.
 ///
-/// The resulting `CFn` will take a dummy argument (e.g., `()`) which it ignores,
+/// The resulting `RcFn` will take a dummy argument (e.g., `()`) which it ignores,
 /// then calls the original nullary closure.
 ///
 /// # Examples
 /// ```
-/// use monadify::fn0; // Macro import
-/// use monadify::function::CFn; // For type annotation if needed
+/// use monadify::fn0;
+/// use monadify::function::RcFn;
 ///
 /// let get_number = fn0!(|| 42);
 /// let result: i32 = get_number.call(()); // Call with a dummy unit argument
@@ -18,18 +18,18 @@
 #[macro_export]
 macro_rules! fn0 {
     ($closure:expr) => {
-        $crate::function::CFn::new(|_: ()| $closure()) // Explicitly type dummy arg as unit
+        $crate::function::RcFn::new(|_: ()| $closure())
     };
 }
 
-/// Creates a `CFn` (boxed `Fn`) from a unary (1-argument) closure.
+/// Creates an `RcFn` (shared-ownership `Rc<dyn Fn>`) from a unary (1-argument) closure.
 ///
-/// This is a convenience macro for `CFn::new(closure)`.
+/// This is a convenience macro for `RcFn::new(closure)`.
 ///
 /// # Examples
 /// ```
 /// use monadify::fn1;
-/// use monadify::function::CFn;
+/// use monadify::function::RcFn;
 ///
 /// let add_one = fn1!(|x: i32| x + 1);
 /// assert_eq!(add_one.call(5), 6);
@@ -40,24 +40,24 @@ macro_rules! fn0 {
 #[macro_export]
 macro_rules! fn1 {
     ($closure:expr) => {
-        $crate::function::CFn::new(move |x| $closure(x))
+        $crate::function::RcFn::new(move |x| $closure(x))
     };
 }
 
-/// Creates a curried function of two arguments, wrapped in `CFn`.
+/// Creates a curried function of two arguments, with the inner result wrapped in `RcFn`.
 ///
 /// Given a closure `|x| |y| expr`, `fn2!` transforms it into
-/// `move |x| CFn::new(move |y| closure(x)(y))`.
-/// The outer function takes `x` and returns a `CFn` that takes `y`.
+/// `move |x| RcFn::new(move |y| closure(x)(y))`.
+/// The outer function takes `x` and returns an `RcFn` that takes `y`.
 ///
 /// # Examples
 /// ```
 /// use monadify::fn2;
-/// use monadify::function::CFn;
+/// use monadify::function::RcFn;
 ///
 /// let curried_add = fn2!(|x: i32| move |y: i32| x + y);
 ///
-/// let add_5_fn = curried_add(5); // add_5_fn is CFn<i32, i32>
+/// let add_5_fn = curried_add(5); // add_5_fn is RcFn<i32, i32>
 /// assert_eq!(add_5_fn.call(10), 15); // Calls the inner closure with y = 10
 ///
 /// assert_eq!(curried_add(3).call(7), 10);
@@ -65,23 +65,23 @@ macro_rules! fn1 {
 #[macro_export]
 macro_rules! fn2 {
     ($closure:expr) => {
-        move |x| $crate::function::CFn::new(move |y| $closure(x)(y))
+        move |x| $crate::function::RcFn::new(move |y| $closure(x)(y))
     };
 }
 
-/// Creates a curried function of three arguments, wrapped in nested `CFn`s.
+/// Creates a curried function of three arguments, wrapped in nested `RcFn`s.
 ///
 /// Given a closure `|x| |y| |z| expr`, `fn3!` transforms it into
-/// `move |x| CFn::new(move |y| CFn::new(move |z| closure(x)(y)(z)))`.
+/// `move |x| RcFn::new(move |y| RcFn::new(move |z| closure(x)(y)(z)))`.
 ///
 /// # Examples
 /// ```
 /// use monadify::fn3;
-/// use monadify::function::CFn;
+/// use monadify::function::RcFn;
 ///
 /// let curried_add3 = fn3!(|x: i32| move |y: i32| move |z: i32| x + y + z);
 ///
-/// let add_5_and_10_fn = curried_add3(5).call(10); // add_5_and_10_fn is CFn<i32, i32>
+/// let add_5_and_10_fn = curried_add3(5).call(10); // add_5_and_10_fn is RcFn<i32, i32>
 /// assert_eq!(add_5_and_10_fn.call(20), 35);
 ///
 /// assert_eq!(curried_add3(1)(2).call(3), 6);
@@ -90,8 +90,8 @@ macro_rules! fn2 {
 macro_rules! fn3 {
     ($closure:expr) => {
         move |x| {
-            $crate::function::CFn::new(move |y| {
-                $crate::function::CFn::new(move |z| $closure(x)(y)(z))
+            $crate::function::RcFn::new(move |y| {
+                $crate::function::RcFn::new(move |z| $closure(x)(y)(z))
             })
         }
     };

--- a/tests/kind/applicative.rs
+++ b/tests/kind/applicative.rs
@@ -2,73 +2,64 @@
 use core::convert::identity;
 use monadify::applicative::kind::*; // For Applicative trait and lift_a1. Changed hkt to kind
 use monadify::apply::kind::Apply; // Changed hkt to kind
-use monadify::function::{CFn, CFnOnce};
+use monadify::function::{CFnOnce, RcFn};
 use monadify::functor::kind::Functor; // Changed hkt to kind
 use monadify::identity::{Identity as IdType, IdentityKind}; // Changed IdentityHKTMarker to IdentityKind
-use monadify::kind_based::kind::{CFnKind, CFnOnceKind, OptionKind, ResultKind, VecKind}; // ...HKTMarker to ...Kind
+use monadify::kind_based::kind::{CFnOnceKind, OptionKind, RcFnKind, ResultKind, VecKind};
 use monadify::transformers::reader::{ReaderT, ReaderTKind}; // Changed ReaderTHKTMarker to ReaderTKind
-
-// The kind_laws_tests module itself
-// Copied from src/applicative.rs
 
 // --- OptionKind Applicative Laws ---
 #[test]
 fn option_kind_applicative_law_identity() {
-    // Renamed test and HKT to Kind
-    // apply(v, pure(id_fn)) == v
     let v_some: Option<i32> = Some(10);
     let v_none: Option<i32> = None;
 
-    let id_cfn_creator = || CFn::new(identity::<i32>);
-    let pure_id_cfn_creator = || OptionKind::pure(id_cfn_creator()); // Renamed Marker
+    let id_rcfn_creator = || RcFn::new(identity::<i32>);
+    let pure_id_rcfn_creator = || OptionKind::pure(id_rcfn_creator());
 
-    assert_eq!(OptionKind::apply(v_some, pure_id_cfn_creator()), v_some); // Renamed Marker
-    assert_eq!(OptionKind::apply(v_none, pure_id_cfn_creator()), v_none); // Renamed Marker
+    assert_eq!(OptionKind::apply(v_some, pure_id_rcfn_creator()), v_some);
+    assert_eq!(OptionKind::apply(v_none, pure_id_rcfn_creator()), v_none);
 }
 
 #[test]
 fn option_kind_applicative_law_homomorphism() {
-    // Renamed test and HKT to Kind
-    // apply(pure(x), pure(f_fn)) == pure(f(x))
     let x: i32 = 10;
     let f = |val: i32| val * 2;
 
-    let f_cfn_creator = || CFn::new(f);
-    let pure_f_cfn: Option<CFn<i32, i32>> = OptionKind::pure(f_cfn_creator()); // Renamed Marker
-    let pure_x: Option<i32> = OptionKind::pure(x); // Renamed Marker
+    let f_rcfn_creator = || RcFn::new(f);
+    let pure_f_rcfn: Option<RcFn<i32, i32>> = OptionKind::pure(f_rcfn_creator());
+    let pure_x: Option<i32> = OptionKind::pure(x);
 
     assert_eq!(
-        OptionKind::apply(pure_x, pure_f_cfn), // Renamed Marker
-        OptionKind::pure(f(x))                 // Renamed Marker
+        OptionKind::apply(pure_x, pure_f_rcfn),
+        OptionKind::pure(f(x))
     );
 }
 
 #[test]
 fn option_kind_applicative_law_interchange() {
-    // Renamed test and HKT to Kind
-    // apply(pure(y), u) == apply(u, pure(|f_fn| f_fn(y)))
     type A = i32;
     type B = String;
 
     let y_val: A = 10;
 
-    let concrete_f_creator = || CFn::new(|val: A| format!("val:{}", val));
+    let concrete_f_creator = || RcFn::new(|val: A| format!("val:{}", val));
     let u_some_creator = || Some(concrete_f_creator());
-    let u_none_creator = || None::<CFn<A, B>>;
+    let u_none_creator = || None::<RcFn<A, B>>;
 
-    let pure_y: Option<A> = OptionKind::pure(y_val); // Renamed Marker
+    let pure_y: Option<A> = OptionKind::pure(y_val);
 
     // LHS: apply(pure(y), u)
-    let lhs_some = OptionKind::apply(pure_y, u_some_creator()); // Renamed Marker
-    let lhs_none = OptionKind::apply(pure_y, u_none_creator()); // Renamed Marker
+    let lhs_some = OptionKind::apply(pure_y, u_some_creator());
+    let lhs_none = OptionKind::apply(pure_y, u_none_creator());
 
     let y_val_clone_for_rhs = y_val;
     let interchange_fn_creator =
-        || CFn::new(move |f_map_fn: CFn<A, B>| f_map_fn.call(y_val_clone_for_rhs));
-    let pure_interchange_fn_wrapper_creator = || OptionKind::pure(interchange_fn_creator()); // Renamed Marker
+        || RcFn::new(move |f_map_fn: RcFn<A, B>| f_map_fn.call(y_val_clone_for_rhs));
+    let pure_interchange_fn_wrapper_creator = || OptionKind::pure(interchange_fn_creator());
 
-    let rhs_some = OptionKind::apply(u_some_creator(), pure_interchange_fn_wrapper_creator()); // Renamed Marker
-    let rhs_none = OptionKind::apply(u_none_creator(), pure_interchange_fn_wrapper_creator()); // Renamed Marker
+    let rhs_some = OptionKind::apply(u_some_creator(), pure_interchange_fn_wrapper_creator());
+    let rhs_none = OptionKind::apply(u_none_creator(), pure_interchange_fn_wrapper_creator());
 
     assert_eq!(lhs_some, rhs_some);
     assert_eq!(lhs_none, rhs_none);
@@ -78,7 +69,6 @@ fn option_kind_applicative_law_interchange() {
 // Functor laws for lift_a1 (map defined via pure/apply)
 #[test]
 fn option_kind_lift_a1_functor_identity() {
-    // Renamed test and HKT to Kind
     let fa_some: Option<i32> = Some(10);
     let fa_none: Option<i32> = None;
     let id_fn_static = identity::<i32>;
@@ -86,16 +76,15 @@ fn option_kind_lift_a1_functor_identity() {
     assert_eq!(
         lift_a1::<OptionKind, _, _, _>(id_fn_static, fa_some),
         fa_some
-    ); // Renamed Marker
+    );
     assert_eq!(
         lift_a1::<OptionKind, _, _, _>(id_fn_static, fa_none),
         fa_none
-    ); // Renamed Marker
+    );
 }
 
 #[test]
 fn option_kind_lift_a1_functor_composition() {
-    // Renamed test and HKT to Kind
     let fa_some: Option<i32> = Some(10);
     let fa_none: Option<i32> = None;
 
@@ -103,14 +92,14 @@ fn option_kind_lift_a1_functor_composition() {
     let g = |y: i32| y.to_string();
     let g_compose_f = move |x: i32| g(f(x));
 
-    let lhs_some = lift_a1::<OptionKind, _, _, _>(g_compose_f, fa_some); // Renamed Marker
-    let lhs_none = lift_a1::<OptionKind, _, _, _>(g_compose_f, fa_none); // Renamed Marker
+    let lhs_some = lift_a1::<OptionKind, _, _, _>(g_compose_f, fa_some);
+    let lhs_none = lift_a1::<OptionKind, _, _, _>(g_compose_f, fa_none);
 
-    let map_f_fa_some = lift_a1::<OptionKind, _, _, _>(f, fa_some); // Renamed Marker
-    let rhs_some = lift_a1::<OptionKind, _, _, _>(g, map_f_fa_some); // Renamed Marker
+    let map_f_fa_some = lift_a1::<OptionKind, _, _, _>(f, fa_some);
+    let rhs_some = lift_a1::<OptionKind, _, _, _>(g, map_f_fa_some);
 
-    let map_f_fa_none = lift_a1::<OptionKind, _, _, _>(f, fa_none); // Renamed Marker
-    let rhs_none = lift_a1::<OptionKind, _, _, _>(g, map_f_fa_none); // Renamed Marker
+    let map_f_fa_none = lift_a1::<OptionKind, _, _, _>(f, fa_none);
+    let rhs_none = lift_a1::<OptionKind, _, _, _>(g, map_f_fa_none);
 
     assert_eq!(lhs_some, rhs_some);
     assert_eq!(lhs_none, rhs_none);
@@ -122,66 +111,63 @@ type TestError = String;
 
 #[test]
 fn result_kind_applicative_law_identity() {
-    // Renamed test and HKT to Kind
     let v_ok: Result<i32, TestError> = Ok(10);
     let v_err: Result<i32, TestError> = Err("Error".to_string());
 
-    let id_cfn_creator = || CFn::new(identity::<i32>);
-    let pure_id_cfn_creator = || ResultKind::<TestError>::pure(id_cfn_creator()); // Renamed Marker
+    let id_rcfn_creator = || RcFn::new(identity::<i32>);
+    let pure_id_rcfn_creator = || ResultKind::<TestError>::pure(id_rcfn_creator());
 
     assert_eq!(
-        ResultKind::<TestError>::apply(v_ok.clone(), pure_id_cfn_creator()),
+        ResultKind::<TestError>::apply(v_ok.clone(), pure_id_rcfn_creator()),
         v_ok
-    ); // Renamed Marker
+    );
     assert_eq!(
-        ResultKind::<TestError>::apply(v_err.clone(), pure_id_cfn_creator()),
+        ResultKind::<TestError>::apply(v_err.clone(), pure_id_rcfn_creator()),
         v_err
-    ); // Renamed Marker
+    );
 }
 
 #[test]
 fn result_kind_applicative_law_homomorphism() {
-    // Renamed test and HKT to Kind
     let x: i32 = 10;
     let f = |val: i32| val * 2;
 
-    let f_cfn_creator = || CFn::new(f);
-    let pure_f_cfn = ResultKind::<TestError>::pure(f_cfn_creator()); // Renamed Marker
-    let pure_x = ResultKind::<TestError>::pure(x); // Renamed Marker
+    let f_rcfn_creator = || RcFn::new(f);
+    let pure_f_rcfn = ResultKind::<TestError>::pure(f_rcfn_creator());
+    let pure_x = ResultKind::<TestError>::pure(x);
 
     assert_eq!(
-        ResultKind::<TestError>::apply(pure_x, pure_f_cfn), // Renamed Marker
-        ResultKind::<TestError>::pure(f(x))                 // Renamed Marker
+        ResultKind::<TestError>::apply(pure_x, pure_f_rcfn),
+        ResultKind::<TestError>::pure(f(x))
     );
 }
 
 #[test]
 fn result_kind_applicative_law_interchange() {
-    // Renamed test and HKT to Kind
     type A = i32;
     type B = String;
 
     let y_val: A = 10;
 
-    let concrete_f_creator = || CFn::new(|val: A| format!("val:{}", val));
+    let concrete_f_creator = || RcFn::new(|val: A| format!("val:{}", val));
     let u_ok_creator = || Ok(concrete_f_creator());
-    let u_err_creator = || Err::<CFn<A, B>, TestError>("Error in u".to_string());
+    let u_err_creator = || Err::<RcFn<A, B>, TestError>("Error in u".to_string());
 
-    let pure_y = ResultKind::<TestError>::pure(y_val); // Renamed Marker
+    let pure_y = ResultKind::<TestError>::pure(y_val);
 
-    let lhs_ok = ResultKind::<TestError>::apply(pure_y.clone(), u_ok_creator()); // Renamed Marker
-    let lhs_err = ResultKind::<TestError>::apply(pure_y.clone(), u_err_creator()); // Renamed Marker
+    let lhs_ok = ResultKind::<TestError>::apply(pure_y.clone(), u_ok_creator());
+    let lhs_err = ResultKind::<TestError>::apply(pure_y.clone(), u_err_creator());
 
     let y_val_clone_for_rhs = y_val;
     let interchange_fn_creator =
-        || CFn::new(move |f_map_fn: CFn<A, B>| f_map_fn.call(y_val_clone_for_rhs));
+        || RcFn::new(move |f_map_fn: RcFn<A, B>| f_map_fn.call(y_val_clone_for_rhs));
     let pure_interchange_fn_wrapper_creator =
-        || ResultKind::<TestError>::pure(interchange_fn_creator()); // Renamed Marker
+        || ResultKind::<TestError>::pure(interchange_fn_creator());
 
     let rhs_ok =
-        ResultKind::<TestError>::apply(u_ok_creator(), pure_interchange_fn_wrapper_creator()); // Renamed Marker
+        ResultKind::<TestError>::apply(u_ok_creator(), pure_interchange_fn_wrapper_creator());
     let rhs_err =
-        ResultKind::<TestError>::apply(u_err_creator(), pure_interchange_fn_wrapper_creator()); // Renamed Marker
+        ResultKind::<TestError>::apply(u_err_creator(), pure_interchange_fn_wrapper_creator());
 
     assert_eq!(lhs_ok, rhs_ok);
     assert_eq!(lhs_err, rhs_err);
@@ -191,7 +177,6 @@ fn result_kind_applicative_law_interchange() {
 
 #[test]
 fn result_kind_lift_a1_functor_identity() {
-    // Renamed test and HKT to Kind
     let fa_ok: Result<i32, TestError> = Ok(10);
     let fa_err: Result<i32, TestError> = Err("Error".to_string());
     let id_fn_static = identity::<i32>;
@@ -199,16 +184,15 @@ fn result_kind_lift_a1_functor_identity() {
     assert_eq!(
         lift_a1::<ResultKind<TestError>, _, _, _>(id_fn_static, fa_ok.clone()),
         fa_ok
-    ); // Renamed Marker
+    );
     assert_eq!(
         lift_a1::<ResultKind<TestError>, _, _, _>(id_fn_static, fa_err.clone()),
         fa_err
-    ); // Renamed Marker
+    );
 }
 
 #[test]
 fn result_kind_lift_a1_functor_composition() {
-    // Renamed test and HKT to Kind
     let fa_ok: Result<i32, TestError> = Ok(10);
     let fa_err: Result<i32, TestError> = Err("Error".to_string());
 
@@ -216,14 +200,14 @@ fn result_kind_lift_a1_functor_composition() {
     let g = |y: i32| y.to_string();
     let g_compose_f = move |x: i32| g(f(x));
 
-    let lhs_ok = lift_a1::<ResultKind<TestError>, _, _, _>(g_compose_f, fa_ok.clone()); // Renamed Marker
-    let lhs_err = lift_a1::<ResultKind<TestError>, _, _, _>(g_compose_f, fa_err.clone()); // Renamed Marker
+    let lhs_ok = lift_a1::<ResultKind<TestError>, _, _, _>(g_compose_f, fa_ok.clone());
+    let lhs_err = lift_a1::<ResultKind<TestError>, _, _, _>(g_compose_f, fa_err.clone());
 
-    let map_f_fa_ok = lift_a1::<ResultKind<TestError>, _, _, _>(f, fa_ok.clone()); // Renamed Marker
-    let rhs_ok = lift_a1::<ResultKind<TestError>, _, _, _>(g, map_f_fa_ok); // Renamed Marker
+    let map_f_fa_ok = lift_a1::<ResultKind<TestError>, _, _, _>(f, fa_ok.clone());
+    let rhs_ok = lift_a1::<ResultKind<TestError>, _, _, _>(g, map_f_fa_ok);
 
-    let map_f_fa_err = lift_a1::<ResultKind<TestError>, _, _, _>(f, fa_err.clone()); // Renamed Marker
-    let rhs_err = lift_a1::<ResultKind<TestError>, _, _, _>(g, map_f_fa_err); // Renamed Marker
+    let map_f_fa_err = lift_a1::<ResultKind<TestError>, _, _, _>(f, fa_err.clone());
+    let rhs_err = lift_a1::<ResultKind<TestError>, _, _, _>(g, map_f_fa_err);
 
     assert_eq!(lhs_ok, rhs_ok);
     assert_eq!(lhs_err, rhs_err);
@@ -232,48 +216,52 @@ fn result_kind_lift_a1_functor_composition() {
 }
 
 // --- VecKind Applicative Laws ---
+// NOTE: With RcFn (which is Clone), VecKind applicative laws are now testable!
 #[test]
 fn vec_kind_applicative_law_identity() {
-    // Renamed test and HKT to Kind
-    println!("NOTE: VecKind Applicative Identity law is untestable with CFn due to pure's Clone constraint.");
+    let v_vec: Vec<i32> = vec![1, 2, 3];
+    let id_rcfn = RcFn::new(identity::<i32>);
+    let pure_id: Vec<RcFn<i32, i32>> = VecKind::pure(id_rcfn);
+    let result = VecKind::apply(v_vec.clone(), pure_id);
+    assert_eq!(result, v_vec);
 }
 
 #[test]
 fn vec_kind_applicative_law_homomorphism() {
-    // Renamed test and HKT to Kind
-    println!("NOTE: VecKind Applicative Homomorphism law is untestable with CFn due to pure's Clone constraint.");
+    let x: i32 = 5;
+    let f = |val: i32| val * 3;
+    let pure_x: Vec<i32> = VecKind::pure(x);
+    let pure_f: Vec<RcFn<i32, i32>> = VecKind::pure(RcFn::new(f));
+    assert_eq!(VecKind::apply(pure_x, pure_f), VecKind::pure(f(x)));
 }
 
 #[test]
 fn vec_kind_applicative_law_interchange() {
-    // Renamed test and HKT to Kind
     type A = i32;
     let y_val: A = 10;
 
-    let concrete_f1_creator = || CFn::new(|val: A| format!("f1:{}", val));
-    let concrete_f2_creator = || CFn::new(|val: A| format!("f2:{}", val * 2));
+    let concrete_f1_creator = || RcFn::new(|val: A| format!("f1:{}", val));
+    let concrete_f2_creator = || RcFn::new(|val: A| format!("f2:{}", val * 2));
     let u_vec_creator = || vec![concrete_f1_creator(), concrete_f2_creator()];
 
-    let pure_y_vec: Vec<A> = VecKind::pure(y_val); // Renamed Marker
+    let pure_y_vec: Vec<A> = VecKind::pure(y_val);
 
-    let lhs = VecKind::apply(pure_y_vec.clone(), u_vec_creator()); // Renamed Marker
+    let lhs = VecKind::apply(pure_y_vec.clone(), u_vec_creator());
     assert_eq!(lhs, vec!["f1:10".to_string(), "f2:20".to_string()]);
 }
 
 #[test]
 fn vec_kind_functor_identity_via_map() {
-    // Renamed test and HKT to Kind
     let fa_vec: Vec<i32> = vec![10, 20];
     let fa_empty: Vec<i32> = vec![];
     let id_fn_static = identity::<i32>;
 
-    assert_eq!(VecKind::map(fa_vec.clone(), id_fn_static), fa_vec); // Renamed Marker
-    assert_eq!(VecKind::map(fa_empty.clone(), id_fn_static), fa_empty); // Renamed Marker
+    assert_eq!(VecKind::map(fa_vec.clone(), id_fn_static), fa_vec);
+    assert_eq!(VecKind::map(fa_empty.clone(), id_fn_static), fa_empty);
 }
 
 #[test]
 fn vec_kind_functor_composition_via_map() {
-    // Renamed test and HKT to Kind
     let fa_vec: Vec<i32> = vec![10, 20];
     let fa_empty: Vec<i32> = vec![];
 
@@ -281,14 +269,14 @@ fn vec_kind_functor_composition_via_map() {
     let g = |y: i32| y.to_string();
     let g_compose_f = move |x: i32| g(f(x));
 
-    let lhs_vec = VecKind::map(fa_vec.clone(), g_compose_f); // Renamed Marker
-    let lhs_empty = VecKind::map(fa_empty.clone(), g_compose_f); // Renamed Marker
+    let lhs_vec = VecKind::map(fa_vec.clone(), g_compose_f);
+    let lhs_empty = VecKind::map(fa_empty.clone(), g_compose_f);
 
-    let map_f_fa_vec = VecKind::map(fa_vec.clone(), f); // Renamed Marker
-    let rhs_vec = VecKind::map(map_f_fa_vec, g); // Renamed Marker
+    let map_f_fa_vec = VecKind::map(fa_vec.clone(), f);
+    let rhs_vec = VecKind::map(map_f_fa_vec, g);
 
-    let map_f_fa_empty = VecKind::map(fa_empty.clone(), f); // Renamed Marker
-    let rhs_empty = VecKind::map(map_f_fa_empty, g); // Renamed Marker
+    let map_f_fa_empty = VecKind::map(fa_empty.clone(), f);
+    let rhs_empty = VecKind::map(map_f_fa_empty, g);
 
     assert_eq!(lhs_vec, rhs_vec);
     assert_eq!(lhs_empty, rhs_empty);
@@ -299,52 +287,49 @@ fn vec_kind_functor_composition_via_map() {
 // --- IdentityKind Applicative Laws ---
 #[test]
 fn identity_kind_applicative_law_identity() {
-    // Renamed test and HKT to Kind
     let v: IdType<i32> = IdType(10);
 
-    let id_cfn_creator = || CFn::new(identity::<i32>);
-    let pure_id_cfn: IdType<CFn<i32, i32>> = IdentityKind::pure(id_cfn_creator()); // Renamed Marker
+    let id_rcfn_creator = || RcFn::new(identity::<i32>);
+    let pure_id_rcfn: IdType<RcFn<i32, i32>> = IdentityKind::pure(id_rcfn_creator());
 
-    assert_eq!(IdentityKind::apply(v.clone(), pure_id_cfn), v); // Renamed Marker
+    assert_eq!(IdentityKind::apply(v.clone(), pure_id_rcfn), v);
 }
 
 #[test]
 fn identity_kind_applicative_law_homomorphism() {
-    // Renamed test and HKT to Kind
     let x: i32 = 10;
     let f = |val: i32| val * 2;
 
-    let f_cfn_creator = || CFn::new(f);
-    let pure_f_cfn: IdType<CFn<i32, i32>> = IdentityKind::pure(f_cfn_creator()); // Renamed Marker
-    let pure_x: IdType<i32> = IdentityKind::pure(x); // Renamed Marker
+    let f_rcfn_creator = || RcFn::new(f);
+    let pure_f_rcfn: IdType<RcFn<i32, i32>> = IdentityKind::pure(f_rcfn_creator());
+    let pure_x: IdType<i32> = IdentityKind::pure(x);
 
     assert_eq!(
-        IdentityKind::apply(pure_x, pure_f_cfn), // Renamed Marker
-        IdentityKind::pure(f(x))                 // Renamed Marker
+        IdentityKind::apply(pure_x, pure_f_rcfn),
+        IdentityKind::pure(f(x))
     );
 }
 
 #[test]
 fn identity_kind_applicative_law_interchange() {
-    // Renamed test and HKT to Kind
     type A = i32;
     type B = String;
 
     let y_val: A = 10;
 
-    let concrete_f_creator = || CFn::new(|val: A| format!("val:{}", val));
+    let concrete_f_creator = || RcFn::new(|val: A| format!("val:{}", val));
     let u_identity_creator = || IdType(concrete_f_creator());
 
-    let pure_y: IdType<A> = IdentityKind::pure(y_val); // Renamed Marker
+    let pure_y: IdType<A> = IdentityKind::pure(y_val);
 
-    let lhs = IdentityKind::apply(pure_y.clone(), u_identity_creator()); // Renamed Marker
+    let lhs = IdentityKind::apply(pure_y.clone(), u_identity_creator());
 
     let y_val_clone_for_rhs = y_val;
     let interchange_fn_creator =
-        || CFn::new(move |f_map_fn: CFn<A, B>| f_map_fn.call(y_val_clone_for_rhs));
-    let pure_interchange_fn_wrapper_creator = || IdentityKind::pure(interchange_fn_creator()); // Renamed Marker
+        || RcFn::new(move |f_map_fn: RcFn<A, B>| f_map_fn.call(y_val_clone_for_rhs));
+    let pure_interchange_fn_wrapper_creator = || IdentityKind::pure(interchange_fn_creator());
 
-    let rhs = IdentityKind::apply(u_identity_creator(), pure_interchange_fn_wrapper_creator()); // Renamed Marker
+    let rhs = IdentityKind::apply(u_identity_creator(), pure_interchange_fn_wrapper_creator());
 
     assert_eq!(lhs, rhs);
     assert_eq!(lhs, IdType("val:10".to_string()));
@@ -352,130 +337,157 @@ fn identity_kind_applicative_law_interchange() {
 
 #[test]
 fn identity_kind_lift_a1_functor_identity() {
-    // Renamed test and HKT to Kind
     let fa_id: IdType<i32> = IdType(10);
     let id_fn_static = identity::<i32>;
 
     assert_eq!(
         lift_a1::<IdentityKind, _, _, _>(id_fn_static, fa_id.clone()),
         fa_id
-    ); // Renamed Marker
+    );
 }
 
 #[test]
 fn identity_kind_lift_a1_functor_composition() {
-    // Renamed test and HKT to Kind
     let fa_id: IdType<i32> = IdType(10);
 
     let f = |x: i32| x * 2;
     let g = |y: i32| y.to_string();
     let g_compose_f = move |x: i32| g(f(x));
 
-    let lhs = lift_a1::<IdentityKind, _, _, _>(g_compose_f, fa_id.clone()); // Renamed Marker
-    let map_f_fa = lift_a1::<IdentityKind, _, _, _>(f, fa_id.clone()); // Renamed Marker
-    let rhs = lift_a1::<IdentityKind, _, _, _>(g, map_f_fa); // Renamed Marker
+    let lhs = lift_a1::<IdentityKind, _, _, _>(g_compose_f, fa_id.clone());
+    let map_f_fa = lift_a1::<IdentityKind, _, _, _>(f, fa_id.clone());
+    let rhs = lift_a1::<IdentityKind, _, _, _>(g, map_f_fa);
 
     assert_eq!(lhs, rhs);
     assert_eq!(lhs, IdType("20".to_string()));
 }
 
-// --- CFnKind Applicative Laws ---
+// --- RcFnKind Applicative Laws ---
+// Previously "CFnKind" tests — migrated to RcFnKind since CFnKind is removed.
+// With RcFn (Clone), all applicative laws are now testable.
 type Env = i32;
 
 #[test]
-fn cfn_kind_applicative_law_identity() {
-    // Renamed test and HKT to Kind
-    println!("NOTE: CFnKind Applicative Identity law is untestable with CFn due to pure's Clone constraint.");
+fn rcfn_kind_applicative_law_identity() {
+    let env_val: Env = 5;
+    let fa: RcFn<Env, i32> = RcFn::new(|e: Env| e * 2); // fa(5) = 10
+
+    let id_rcfn = RcFn::new(identity::<i32>);
+    let pure_id: RcFn<Env, RcFn<i32, i32>> = RcFnKind::<Env>::pure(id_rcfn);
+
+    let applied = RcFnKind::<Env>::apply(fa.clone(), pure_id);
+
+    assert_eq!(applied.call(env_val), fa.call(env_val));
+    assert_eq!(applied.call(env_val), 10);
 }
 
 #[test]
-fn cfn_kind_applicative_law_homomorphism() {
-    // Renamed test and HKT to Kind
-    println!(
-        "NOTE: CFnKind Applicative Homomorphism law is untestable due to CFn not being Clone."
+fn rcfn_kind_applicative_law_homomorphism() {
+    let env_val: Env = 0; // pure ignores env
+    let x: i32 = 10;
+    let f = |val: i32| val * 2;
+
+    let lhs = RcFnKind::<Env>::apply(
+        RcFnKind::<Env>::pure(x),
+        RcFnKind::<Env>::pure(RcFn::new(f)),
     );
+    let rhs: RcFn<Env, i32> = RcFnKind::<Env>::pure(f(x));
+
+    assert_eq!(lhs.call(env_val), rhs.call(env_val));
+    assert_eq!(lhs.call(env_val), 20);
 }
 
 #[test]
-fn cfn_kind_applicative_law_interchange() {
-    // Renamed test and HKT to Kind
-    println!("NOTE: CFnKind Applicative Interchange law is untestable due to CFn not being Clone.");
+fn rcfn_kind_applicative_law_interchange() {
+    type A = i32;
+    type B = String;
+    let env_val: Env = 99;
+    let y_val: A = 10;
+
+    let u: RcFn<Env, RcFn<A, B>> =
+        RcFn::new(move |_env: Env| RcFn::new(|val: A| format!("val:{}", val)));
+
+    let pure_y: RcFn<Env, A> = RcFnKind::<Env>::pure(y_val);
+
+    // LHS: apply(pure(y), u)
+    let lhs = RcFnKind::<Env>::apply(pure_y, u.clone());
+
+    // RHS: apply(u, pure(|f_fn| f_fn(y)))
+    let interchange = RcFn::new(move |f_fn: RcFn<A, B>| f_fn.call(y_val));
+    let pure_interchange: RcFn<Env, RcFn<RcFn<A, B>, B>> = RcFnKind::<Env>::pure(interchange);
+    let rhs = RcFnKind::<Env>::apply(u, pure_interchange);
+
+    assert_eq!(lhs.call(env_val), rhs.call(env_val));
+    assert_eq!(lhs.call(env_val), "val:10".to_string());
 }
 
-// --- CFnKind Functor Laws (using map) ---
+// --- RcFnKind Functor Laws (using map) ---
 #[test]
-fn cfn_kind_functor_identity_via_map() {
-    // Renamed test and HKT to Kind
-    let fa_creator = || CFn::new(|_e: Env| 10);
+fn rcfn_kind_functor_identity_via_map() {
+    let env_val: Env = 5;
+    let fa: RcFn<Env, i32> = RcFn::new(|e: Env| e * 2);
     let id_fn_static = identity::<i32>;
 
-    let mapped_val = CFnKind::<Env>::map(fa_creator(), id_fn_static); // Renamed Marker
-
-    assert_eq!(mapped_val.call(100), fa_creator().call(100));
+    let mapped = RcFnKind::<Env>::map(fa.clone(), id_fn_static);
+    assert_eq!(mapped.call(env_val), fa.call(env_val));
 }
 
 #[test]
-fn cfn_kind_functor_composition_via_map() {
-    // Renamed test and HKT to Kind
-    let fa_creator = || CFn::new(|_e: Env| 10);
+fn rcfn_kind_functor_composition_via_map() {
+    let env_val: Env = 3;
+    let fa: RcFn<Env, i32> = RcFn::new(|e: Env| e + 1);
 
     let f = |x: i32| x * 2;
     let g = |y: i32| y.to_string();
     let g_compose_f = move |x: i32| g(f(x));
 
-    let lhs = CFnKind::<Env>::map(fa_creator(), g_compose_f); // Renamed Marker
+    let lhs: RcFn<Env, String> = RcFnKind::<Env>::map(fa.clone(), g_compose_f);
+    let map_f_fa: RcFn<Env, i32> = RcFnKind::<Env>::map(fa.clone(), f);
+    let rhs: RcFn<Env, String> = RcFnKind::<Env>::map(map_f_fa, g);
 
-    let map_f_fa: CFn<Env, i32> = CFnKind::<Env>::map(fa_creator(), f); // Renamed Marker
-    let rhs: CFn<Env, String> = CFnKind::<Env>::map(map_f_fa, g); // Renamed Marker
-
-    assert_eq!(lhs.call(100), rhs.call(100));
-    assert_eq!(lhs.call(100), "20".to_string());
+    assert_eq!(lhs.call(env_val), rhs.call(env_val));
+    assert_eq!(lhs.call(env_val), "8".to_string()); // (3 + 1) * 2 = 8
 }
 
 // --- CFnOnceKind Applicative Laws ---
 #[test]
 fn cfn_once_kind_applicative_law_identity() {
-    // Renamed test and HKT to Kind
     println!("NOTE: CFnOnceKind Applicative Identity law is untestable due to CFnOnce not being Clone and pure's Clone requirement.");
 }
 
 #[test]
 fn cfn_once_kind_applicative_law_homomorphism() {
-    // Renamed test and HKT to Kind
     println!("NOTE: CFnOnceKind Applicative Homomorphism law is untestable due to CFnOnce not being Clone and pure's Clone requirement.");
 }
 
 #[test]
 fn cfn_once_kind_applicative_law_interchange() {
-    // Renamed test and HKT to Kind
     println!("NOTE: CFnOnceKind Applicative Interchange law is untestable due to CFnOnce not being Clone and pure's Clone requirement.");
 }
 
 // --- CFnOnceKind Functor Laws (using map) ---
 #[test]
 fn cfn_once_kind_functor_identity_via_map() {
-    // Renamed test and HKT to Kind
     let fa_creator = || CFnOnce::new(|_e: Env| 10);
     let id_fn_static = identity::<i32>;
 
-    let mapped = CFnOnceKind::<Env>::map(fa_creator(), id_fn_static); // Renamed Marker
+    let mapped = CFnOnceKind::<Env>::map(fa_creator(), id_fn_static);
     assert_eq!(mapped.call_once(100), fa_creator().call_once(100));
 }
 
 #[test]
 fn cfn_once_kind_functor_composition_via_map() {
-    // Renamed test and HKT to Kind
     let fa_creator = || CFnOnce::new(|_e: Env| 10);
 
     let f = |x: i32| x * 2;
     let g = |y: i32| y.to_string();
     let g_compose_f = move |x: i32| g(f(x));
 
-    let lhs = CFnOnceKind::<Env>::map(fa_creator(), g_compose_f); // Renamed Marker
+    let lhs = CFnOnceKind::<Env>::map(fa_creator(), g_compose_f);
     let lhs_result_for_0 = lhs.call_once(0);
 
-    let map_f_fa = CFnOnceKind::<Env>::map(fa_creator(), f); // Renamed Marker
-    let rhs = CFnOnceKind::<Env>::map(map_f_fa, g); // Renamed Marker
+    let map_f_fa = CFnOnceKind::<Env>::map(fa_creator(), f);
+    let rhs = CFnOnceKind::<Env>::map(map_f_fa, g);
 
     assert_eq!(lhs_result_for_0.clone(), rhs.call_once(100));
     assert_eq!(lhs_result_for_0, "20".to_string());
@@ -486,35 +498,26 @@ type ReaderEnv = i32;
 
 #[test]
 fn reader_t_kind_applicative_law_identity() {
-    // Renamed test and HKT to Kind
-    println!("NOTE: ReaderTKind Applicative Identity law is untestable with CFn due to pure's Clone constraint.");
+    println!("NOTE: ReaderTKind Applicative Identity law is untestable with RcFn due to Clone constraints on the inner monad.");
 }
 
 #[test]
 fn reader_t_kind_applicative_law_homomorphism() {
-    // Renamed test and HKT to Kind
-    println!("NOTE: ReaderTKind Applicative Homomorphism law is untestable with CFn due to pure's Clone constraint.");
+    println!("NOTE: ReaderTKind Applicative Homomorphism law is untestable with RcFn due to Clone constraints.");
 }
 
 #[test]
 fn reader_t_kind_applicative_law_interchange() {
-    // Renamed test and HKT to Kind
-    println!("NOTE: ReaderTKind Applicative Interchange law is untestable with CFn due to Clone constraints.");
+    println!("NOTE: ReaderTKind Applicative Interchange law is untestable with RcFn due to Clone constraints.");
 }
 
 // --- ReaderTKind Functor Laws (using map) ---
 #[test]
 fn reader_t_kind_functor_identity_via_map() {
-    // Renamed test and HKT to Kind
-    let fa_creator = || {
-        ReaderT::<ReaderEnv, IdentityKind, i32>::new(
-            // Renamed Marker
-            |_e: ReaderEnv| IdType(10),
-        )
-    };
+    let fa_creator = || ReaderT::<ReaderEnv, IdentityKind, i32>::new(|_e: ReaderEnv| IdType(10));
     let id_fn_static = identity::<i32>;
 
-    let mapped = ReaderTKind::<ReaderEnv, IdentityKind>::map(fa_creator(), id_fn_static); // Renamed Marker
+    let mapped = ReaderTKind::<ReaderEnv, IdentityKind>::map(fa_creator(), id_fn_static);
 
     let env_val = 100;
     assert_eq!(
@@ -525,22 +528,16 @@ fn reader_t_kind_functor_identity_via_map() {
 
 #[test]
 fn reader_t_kind_functor_composition_via_map() {
-    // Renamed test and HKT to Kind
-    let fa_creator = || {
-        ReaderT::<ReaderEnv, IdentityKind, i32>::new(
-            // Renamed Marker
-            |_e: ReaderEnv| IdType(10),
-        )
-    };
+    let fa_creator = || ReaderT::<ReaderEnv, IdentityKind, i32>::new(|_e: ReaderEnv| IdType(10));
 
     let f = |x: i32| x * 2;
     let g = |y: i32| y.to_string();
     let g_compose_f = move |x: i32| g(f(x));
 
-    let lhs = ReaderTKind::<ReaderEnv, IdentityKind>::map(fa_creator(), g_compose_f); // Renamed Marker
+    let lhs = ReaderTKind::<ReaderEnv, IdentityKind>::map(fa_creator(), g_compose_f);
 
-    let map_f_fa = ReaderTKind::<ReaderEnv, IdentityKind>::map(fa_creator(), f); // Renamed Marker
-    let rhs = ReaderTKind::<ReaderEnv, IdentityKind>::map(map_f_fa, g); // Renamed Marker
+    let map_f_fa = ReaderTKind::<ReaderEnv, IdentityKind>::map(fa_creator(), f);
+    let rhs = ReaderTKind::<ReaderEnv, IdentityKind>::map(map_f_fa, g);
 
     let env_val = 100;
     assert_eq!((lhs.run_reader_t)(env_val), (rhs.run_reader_t)(env_val));

--- a/tests/kind/apply.rs
+++ b/tests/kind/apply.rs
@@ -1,7 +1,7 @@
 use monadify::apply::kind::{apply_first, apply_second, lift2, lift3};
 use monadify::fn2;
 use monadify::fn3;
-use monadify::function::CFn;
+use monadify::function::RcFn;
 use monadify::kind_based::kind::{OptionKind, ResultKind, VecKind};
 
 type TestError = String;
@@ -141,8 +141,8 @@ fn apply_second_result_both_ok() {
 fn cfn_forward_compose_shr() {
     // f: i32 -> String, g: String -> usize
     // f >> g  should be  i32 -> usize
-    let f = CFn::new(|x: i32| x.to_string());
-    let g = CFn::new(|s: String| s.len());
+    let f = RcFn::new(|x: i32| x.to_string());
+    let g = RcFn::new(|s: String| s.len());
     let fg = f >> g;
     assert_eq!(fg.call(42), 2); // "42".len() == 2
     assert_eq!(fg.call(100), 3); // "100".len() == 3
@@ -152,8 +152,8 @@ fn cfn_forward_compose_shr() {
 fn cfn_backward_compose_shl() {
     // g: String -> usize, f: i32 -> String
     // g << f  should be  i32 -> usize
-    let f = CFn::new(|x: i32| x.to_string());
-    let g = CFn::new(|s: String| s.len());
+    let f = RcFn::new(|x: i32| x.to_string());
+    let g = RcFn::new(|s: String| s.len());
     let fg = g << f;
     assert_eq!(fg.call(42), 2);
     assert_eq!(fg.call(1000), 4); // "1000".len() == 4
@@ -162,8 +162,8 @@ fn cfn_backward_compose_shl() {
 #[test]
 fn cfn_compose_identity_left() {
     // id >> f == f
-    let f = CFn::new(|x: i32| x * 2);
-    let id = CFn::new(|x: i32| x);
+    let f = RcFn::new(|x: i32| x * 2);
+    let id = RcFn::new(|x: i32| x);
     let composed = id >> f;
     assert_eq!(composed.call(5), 10);
 }
@@ -171,17 +171,17 @@ fn cfn_compose_identity_left() {
 #[test]
 fn cfn_compose_identity_right() {
     // f >> id == f
-    let f = CFn::new(|x: i32| x * 2);
-    let id = CFn::new(|x: i32| x);
+    let f = RcFn::new(|x: i32| x * 2);
+    let id = RcFn::new(|x: i32| x);
     let composed = f >> id;
     assert_eq!(composed.call(5), 10);
 }
 
 #[test]
 fn cfn_compose_three_functions() {
-    let f = CFn::new(|x: i32| x + 1);
-    let g = CFn::new(|x: i32| x * 2);
-    let h = CFn::new(|x: i32| x.to_string());
+    let f = RcFn::new(|x: i32| x + 1);
+    let g = RcFn::new(|x: i32| x * 2);
+    let h = RcFn::new(|x: i32| x.to_string());
     // (f >> g) >> h
     let fgh = (f >> g) >> h;
     // (3 + 1) * 2 = 8 → "8"

--- a/tests/kind/cfn_clonable.rs
+++ b/tests/kind/cfn_clonable.rs
@@ -32,9 +32,9 @@ use core::convert::identity;
 // NOTE: `lift_a1_rc` is the expected export name. The implementer may choose a
 // different sibling name (e.g. a generic `lift_a1` overload taking `RcFn`). The
 // assertion in the test below pins the VALUE, not the name.
-use monadify::applicative::kind::{lift_a1, lift_a1_rc, Applicative};
+use monadify::applicative::kind::{lift_a1, Applicative};
 use monadify::apply::kind::Apply;
-use monadify::function::{CFn, CFnOnce, RcFn};
+use monadify::function::{CFnOnce, RcFn};
 use monadify::functor::kind::Functor;
 use monadify::kind_based::kind::{RcFnKind, VecKind};
 use monadify::monad::kind::{Bind, Monad};
@@ -204,8 +204,8 @@ mod rcfn_kind_applicative_laws {
         let env_val: Env = 11;
         let v: RcFn<Env, i32> = RcFn::new(|env: Env| env + 100); // v(11) == 111
 
-        let id_cfn = CFn::new(identity::<i32>);
-        let pure_id: RcFn<Env, CFn<i32, i32>> = RcFnKind::<Env>::pure(id_cfn);
+        let id_rcfn = RcFn::new(identity::<i32>);
+        let pure_id: RcFn<Env, RcFn<i32, i32>> = RcFnKind::<Env>::pure(id_rcfn);
 
         let applied = RcFnKind::<Env>::apply(v.clone(), pure_id);
 
@@ -222,8 +222,10 @@ mod rcfn_kind_applicative_laws {
         let x: i32 = 10;
         let f = |val: i32| val * 2;
 
-        let lhs =
-            RcFnKind::<Env>::apply(RcFnKind::<Env>::pure(x), RcFnKind::<Env>::pure(CFn::new(f)));
+        let lhs = RcFnKind::<Env>::apply(
+            RcFnKind::<Env>::pure(x),
+            RcFnKind::<Env>::pure(RcFn::new(f)),
+        );
         let rhs: RcFn<Env, i32> = RcFnKind::<Env>::pure(f(x)); // pure(20)
 
         assert_eq!(lhs.call(env_val), rhs.call(env_val));
@@ -241,11 +243,11 @@ mod rcfn_kind_applicative_laws {
     fn cfn_clonable_rcfn_kind_applicative_law_composition() {
         // w: RcFn<Env, i32> — value reader: w(env) = env * 2
         let w: RcFn<Env, i32> = RcFn::new(|env: Env| env * 2);
-        // v: RcFn<Env, CFn<i32, i32>> — first function reader: v(env)(x) = x + env
-        let v: RcFn<Env, CFn<i32, i32>> = RcFn::new(|env: Env| CFn::new(move |x: i32| x + env));
-        // u: RcFn<Env, CFn<i32, String>> — second function reader: u(env)(y) = (y * env).to_string()
-        let u: RcFn<Env, CFn<i32, String>> =
-            RcFn::new(|env: Env| CFn::new(move |y: i32| (y * env).to_string()));
+        // v: RcFn<Env, RcFn<i32, i32>> — first function reader: v(env)(x) = x + env
+        let v: RcFn<Env, RcFn<i32, i32>> = RcFn::new(|env: Env| RcFn::new(move |x: i32| x + env));
+        // u: RcFn<Env, RcFn<i32, String>> — second function reader: u(env)(y) = (y * env).to_string()
+        let u: RcFn<Env, RcFn<i32, String>> =
+            RcFn::new(|env: Env| RcFn::new(move |y: i32| (y * env).to_string()));
 
         // apply(apply(w, v), u) — right-associated: u <*> (v <*> w)
         let inner: RcFn<Env, i32> = RcFnKind::<Env>::apply(w.clone(), v.clone());
@@ -272,19 +274,19 @@ mod rcfn_kind_applicative_laws {
 
         let y_val: A = 10;
 
-        // u: an RcFn<Env, CFn<A,B>> that always returns the same concrete CFn.
+        // u: an RcFn<Env, RcFn<A,B>> that always returns the same concrete RcFn.
         // Because RcFn is Clone, we can share `u` between lhs and rhs.
-        let u: RcFn<Env, CFn<A, B>> =
-            RcFn::new(move |_env: Env| CFn::new(|val: A| format!("val:{}", val)));
+        let u: RcFn<Env, RcFn<A, B>> =
+            RcFn::new(move |_env: Env| RcFn::new(|val: A| format!("val:{}", val)));
 
         let pure_y: RcFn<Env, A> = RcFnKind::<Env>::pure(y_val);
 
         // LHS: apply(pure(y), u)  — Apply<A, B>
         let lhs = RcFnKind::<Env>::apply(pure_y, u.clone());
 
-        // RHS: apply(u, pure(|f_fn| f_fn(y)))  — Apply<CFn<A,B>, B>
-        let interchange = CFn::new(move |f_fn: CFn<A, B>| f_fn.call(y_val));
-        let pure_interchange: RcFn<Env, CFn<CFn<A, B>, B>> = RcFnKind::<Env>::pure(interchange);
+        // RHS: apply(u, pure(|f_fn| f_fn(y)))  — Apply<RcFn<A,B>, B>
+        let interchange = RcFn::new(move |f_fn: RcFn<A, B>| f_fn.call(y_val));
+        let pure_interchange: RcFn<Env, RcFn<RcFn<A, B>, B>> = RcFnKind::<Env>::pure(interchange);
         let rhs = RcFnKind::<Env>::apply(u, pure_interchange);
 
         assert_eq!(lhs.call(env_val), rhs.call(env_val));
@@ -433,7 +435,7 @@ mod rcfn_kind_monad_laws {
 fn cfn_clonable_vec_lift_a1_rc_reenabled() {
     let fa: Vec<i32> = vec![1, 2, 3];
     // 1 % 2 == 1 => false, 2 % 2 == 0 => true, 3 % 2 == 1 => false
-    let result: Vec<bool> = lift_a1_rc::<VecKind, i32, bool, _>(|x: i32| x % 2 == 0, fa);
+    let result: Vec<bool> = lift_a1::<VecKind, i32, bool, _>(|x: i32| x % 2 == 0, fa);
     assert_eq!(result, vec![false, true, false]);
 }
 

--- a/tests/kind/do_notation/cfn_unsupported.rs
+++ b/tests/kind/do_notation/cfn_unsupported.rs
@@ -1,6 +1,6 @@
-//! `CFn` / `CFnOnce` are intentionally unsupported by `mdo!`.
+//! `CFnOnceKind` is intentionally unsupported by `mdo!`; `RcFnKind` IS supported.
 //!
-//! # Why `mdo!` cannot work with `CFnKind` / `CFnOnceKind`
+//! # Why `mdo!` cannot work with `CFnOnceKind`
 //!
 //! The `mdo!` desugaring emits **`(expr).clone()`** for every monadic right-hand
 //! side before passing it to `Bind::bind`. This clone is required because
@@ -14,55 +14,39 @@
 //! the continuation *once per element* (via `flat_map`); the macro must therefore
 //! clone the captured RHS before each invocation.
 //!
-//! `CFn<A, B>` wraps `Box<dyn Fn(A) -> B + 'static>`. `Box<dyn Fn(…)>` is
-//! **not `Clone`** (trait objects cannot be cloned generically), so `CFn` itself
-//! is not `Clone` either. Calling `.clone()` on any `CFn` value — which the
-//! desugaring always does — fails to compile:
+//! `CFnOnce<A, B>` wraps `Box<dyn FnOnce(A) -> B + 'static>`. A `FnOnce` is
+//! move-once by definition and `Box<dyn FnOnce(…)>` is **not `Clone`**, so
+//! `CFnOnce` cannot be `Clone` either — and making it clone-able would be
+//! semantically contradictory (cloning a once-only function would let it run
+//! more than once). Calling `.clone()` on a `CFnOnce` value — which the
+//! desugaring always does — therefore fails to compile at **depth ≥ 1**.
+//! `CFnOnceKind<R>` consequently cannot flow through an `mdo!` block.
+//!
+//! # `RcFnKind` IS supported (the former restriction is lifted)
+//!
+//! The function monad *does* work in `mdo!` — via [`RcFnKind`], the `Rc`-backed,
+//! clone-able function wrapper:
 //!
 //! ```text
-//! error[E0599]: the method `clone` exists for struct `CFn<i32, i32>`,
-//!               but its trait bounds were not satisfied
-//!   = note: the following trait bounds were not satisfied:
-//!           `dyn Fn(i32) -> i32: Sized`  →  `Box<dyn Fn(i32) -> i32>: Clone`
-//!           `dyn Fn(i32) -> i32: Clone`  →  `Box<dyn Fn(i32) -> i32>: Clone`
-//! ```
-//!
-//! This error appears at **depth ≥ 1** — even a single `<-` bind block fails —
-//! because the very first emitted `(cfn_expr).clone()` requires `Clone`.
-//! The situation is identical for `CFnOnce<A, B>` / `CFnOnceKind<R>`.
-//!
-//! The error was empirically confirmed during the Phase 0 spike (scratchpad
-//! `cfn_probe`) and re-confirmed during Phase 3 using a disposable probe crate
-//! that path-depends on the real `monadify` library with `--features do-notation`.
-//!
-//! # Future lift
-//!
-//! Lifting this restriction requires an `Rc`-backed, clone-able function wrapper,
-//! e.g.:
-//!
-//! ```text
-//! pub struct RcFn<A, B>(pub Rc<dyn Fn(A) -> B + 'static>);
+//! pub struct RcFn<A, B>(pub Rc<dyn Fn(A) -> B + 'static>);  // Clone via Rc refcount
 //! ```
 //!
 //! Cloning an `RcFn` bumps the reference count (cheap), exactly as `ReaderT`
-//! does today (`ReaderT` wraps `Rc<dyn Fn(R) -> M::Of<A>>` and is `#[derive(Clone)]`).
-//! Adding an `RcFnKind` marker that implements the full `Functor → Bind` hierarchy
-//! would allow `mdo!` do-blocks of arbitrary depth for that wrapper type. That is
-//! a separate, additive design decision with no impact on the current trait surface.
+//! does. `RcFnKind` implements the full `Functor → Apply → Applicative → Bind →
+//! Monad` hierarchy, so `mdo!` do-blocks of arbitrary depth compile for it (see
+//! the `rcfn_kind_mdo` tests in `tests/kind/cfn_clonable.rs`). `RcFnKind` is the
+//! sole multi-call function marker since `CFnKind`/`CFn` were removed in 0.2.0.
 //!
-//! Until that wrapper exists, `mdo!` blocks over `CFnKind`/`CFnOnceKind` are
-//! **out of scope** by design. Users needing a function monad in a do-block
-//! should use `ReaderTKind<R, IdentityKind>` (already `Clone`) as an alternative.
+//! Users needing a function monad in a do-block should use `RcFnKind` (or
+//! `ReaderTKind<R, IdentityKind>`). `CFnOnceKind` remains out of scope by design.
 
 /// Anchors the module documentation above. No runtime assertions are made here
-/// because no `CFn`/`CFnOnce` `mdo!` block can compile; the exclusion is verified
-/// at the compile-error level and described in this module's doc.
+/// because no `CFnOnce` `mdo!` block can compile; the exclusion is verified at
+/// the compile-error level and described in this module's doc.
 #[test]
-fn cfn_cfnonce_mdo_is_documented_unsupported() {
-    // CFn and CFnOnce are intentionally excluded from mdo! do-blocks.
-    // See module documentation for the full explanation and the empirically
-    // confirmed error (E0599 / Clone bound not satisfied at depth >= 1).
-    //
-    // This placeholder test exists so the module appears in `cargo test --features
-    // do-notation` output, anchoring the documentation.
+fn cfnonce_mdo_is_documented_unsupported() {
+    // CFnOnce is intentionally excluded from mdo! do-blocks (move-once + not
+    // Clone). RcFnKind, by contrast, IS supported — see tests/kind/cfn_clonable.rs.
+    // This placeholder test anchors the documentation in the
+    // `cargo test --features do-notation` output.
 }

--- a/tests/kind/functor.rs
+++ b/tests/kind/functor.rs
@@ -1,7 +1,7 @@
-use monadify::function::{CFn, CFnOnce};
+use monadify::function::{CFnOnce, RcFn};
 use monadify::functor::kind::Functor; // Changed hkt to kind
 use monadify::identity::{Identity, IdentityKind}; // Changed IdentityHKTMarker to IdentityKind
-use monadify::kind_based::kind::{CFnKind, CFnOnceKind, OptionKind, ResultKind, VecKind}; // ...HKTMarker to ...Kind
+use monadify::kind_based::kind::{CFnOnceKind, OptionKind, RcFnKind, ResultKind, VecKind};
 use monadify::transformers::reader::{ReaderT, ReaderTKind}; // Changed ReaderTHKTMarker to ReaderTKind
                                                             // Kind1 import might be needed if supertraits are checked explicitly, but Functor itself implies Kind1.
 
@@ -269,49 +269,46 @@ pub mod vec_kind_functor_laws {
     }
 }
 
-pub mod cfn_kind_functor_laws {
-    // Renamed module
+pub mod rcfn_kind_functor_laws {
     use super::*;
-    type Env = i32; // Common environment type for these tests
+    type Env = i32;
 
-    // Identity law: CFnKind::map(cfn, |x| x) == cfn
+    // Identity law: RcFnKind::map(rcfn, |x| x) == rcfn
     #[test]
-    fn cfn_kind_functor_identity() {
-        // Renamed test
+    fn rcfn_kind_functor_identity() {
         let env_val: Env = 5;
-        let cfn_creator = || CFn::new(move |env: Env| env * 2); // Example CFn: 5 -> 10
+        let rcfn_creator = || RcFn::new(move |env: Env| env * 2);
 
         let identity_fn = clone_fn_map(|x: i32| x);
-        let mapped_cfn: CFn<Env, i32> = CFnKind::<Env>::map(cfn_creator(), identity_fn); // Renamed Marker
+        let mapped_rcfn: RcFn<Env, i32> = RcFnKind::<Env>::map(rcfn_creator(), identity_fn);
 
-        assert_eq!(mapped_cfn.call(env_val), cfn_creator().call(env_val));
-        assert_eq!(mapped_cfn.call(env_val), 10);
+        assert_eq!(mapped_rcfn.call(env_val), rcfn_creator().call(env_val));
+        assert_eq!(mapped_rcfn.call(env_val), 10);
     }
 
-    // Composition law: CFnKind::map(cfn, |x| g(f(x))) == CFnKind::map(CFnKind::map(cfn, f), g)
+    // Composition law: RcFnKind::map(rcfn, |x| g(f(x))) == RcFnKind::map(RcFnKind::map(rcfn, f), g)
     #[test]
-    fn cfn_kind_functor_composition() {
-        // Renamed test
+    fn rcfn_kind_functor_composition() {
         let env_val: Env = 3;
-        let cfn_creator = || CFn::new(move |env: Env| env + 1); // Example CFn: 3 -> 4
+        let rcfn_creator = || RcFn::new(move |env: Env| env + 1);
 
         let f = clone_fn_map(|x: i32| (x * x) as f64);
         let g = clone_fn_map(|y: f64| y.to_string());
 
         let f_clone_for_composed = f.clone();
         let g_clone_for_composed = g.clone();
-        let composed_map_cfn: CFn<Env, String> = CFnKind::<Env>::map(cfn_creator(), move |x| {
+        let composed_map_rcfn: RcFn<Env, String> = RcFnKind::<Env>::map(rcfn_creator(), move |x| {
             g_clone_for_composed.clone()(f_clone_for_composed.clone()(x))
-        }); // Renamed Marker
+        });
 
-        let mapped_f_cfn: CFn<Env, f64> = CFnKind::<Env>::map(cfn_creator(), f); // Renamed Marker
-        let sequential_map_cfn: CFn<Env, String> = CFnKind::<Env>::map(mapped_f_cfn, g); // Renamed Marker
+        let mapped_f_rcfn: RcFn<Env, f64> = RcFnKind::<Env>::map(rcfn_creator(), f);
+        let sequential_map_rcfn: RcFn<Env, String> = RcFnKind::<Env>::map(mapped_f_rcfn, g);
 
         assert_eq!(
-            composed_map_cfn.call(env_val),
-            sequential_map_cfn.call(env_val)
+            composed_map_rcfn.call(env_val),
+            sequential_map_rcfn.call(env_val)
         );
-        assert_eq!(composed_map_cfn.call(env_val), "16".to_string());
+        assert_eq!(composed_map_rcfn.call(env_val), "16".to_string());
     }
 }
 

--- a/tests/kind/identity.rs
+++ b/tests/kind/identity.rs
@@ -1,7 +1,7 @@
 // Original imports from src/identity.rs kind_tests module, adjusted
 use monadify::applicative::kind::Applicative; // Changed hkt to kind
 use monadify::apply::kind::Apply; // Changed hkt to kind
-use monadify::function::CFn;
+use monadify::function::RcFn;
 use monadify::functor::kind::Functor; // Changed hkt to kind
 use monadify::identity::{Identity, IdentityKind}; // Changed HKTMarker to Kind
 use monadify::monad::kind::{Bind, Monad}; // Changed hkt to kind
@@ -23,7 +23,7 @@ fn test_identity_kind_functor_map() {
 fn test_identity_kind_apply() {
     // Renamed test
     let id_val: Identity<i32> = Identity(5);
-    let id_fn: Identity<CFn<i32, i32>> = Identity(CFn::new(|x| x * 2));
+    let id_fn: Identity<RcFn<i32, i32>> = Identity(RcFn::new(|x| x * 2));
     let result: Identity<i32> = IdentityKind::apply(id_val, id_fn); // Renamed Marker
     assert_eq!(result, Identity(10));
 }

--- a/tests/kind/monad.rs
+++ b/tests/kind/monad.rs
@@ -1,7 +1,7 @@
 use monadify::applicative::kind::Applicative; // Changed hkt to kind
-use monadify::function::{CFn, CFnOnce};
+use monadify::function::{CFnOnce, RcFn};
 use monadify::functor::kind::Functor; // Changed hkt to kind
-use monadify::kind_based::kind::{CFnKind, CFnOnceKind, OptionKind, ResultKind, VecKind}; // ...HKTMarker to ...Kind
+use monadify::kind_based::kind::{CFnOnceKind, OptionKind, RcFnKind, ResultKind, VecKind};
 use monadify::monad::kind::{Bind, Monad}; // Changed hkt to kind
 
 // Common error type for Result tests
@@ -471,107 +471,103 @@ mod vec_kind_monad_laws {
     }
 }
 
-mod cfn_kind_monad_laws {
-    // Renamed module
+mod rcfn_kind_monad_laws {
     use super::*;
     type Env = i32;
 
-    // 1. Left Identity: CFnKind::pure(a).bind(f) == f(a)
+    // 1. Left Identity: RcFnKind::pure(a).bind(f) == f(a)
     #[test]
-    fn cfn_kind_monad_left_identity() {
-        // Renamed test
+    fn rcfn_kind_monad_left_identity() {
         let env_val: Env = 5;
         let a: i32 = 10;
 
-        let f = clone_fn(move |x: i32| -> CFn<Env, String> {
-            CFn::new(move |env: Env| (x + env).to_string())
+        let f = clone_fn(move |x: i32| -> RcFn<Env, String> {
+            RcFn::new(move |env: Env| (x + env).to_string())
         });
 
-        let pure_a_cfn: CFn<Env, i32> = CFnKind::<Env>::pure(a); // Renamed Marker
-        let lhs_cfn: CFn<Env, String> = CFnKind::<Env>::bind(pure_a_cfn, f.clone()); // Renamed Marker
+        let pure_a: RcFn<Env, i32> = RcFnKind::<Env>::pure(a);
+        let lhs: RcFn<Env, String> = RcFnKind::<Env>::bind(pure_a, f.clone());
 
-        let rhs_cfn: CFn<Env, String> = f.clone()(a);
+        let rhs: RcFn<Env, String> = f.clone()(a);
 
-        assert_eq!(lhs_cfn.call(env_val), rhs_cfn.call(env_val));
-        assert_eq!(lhs_cfn.call(env_val), "15".to_string());
+        assert_eq!(lhs.call(env_val), rhs.call(env_val));
+        assert_eq!(lhs.call(env_val), "15".to_string());
     }
 
-    // 2. Right Identity: m.bind(CFnKind::pure) == m
+    // 2. Right Identity: m.bind(RcFnKind::pure) == m
     #[test]
-    fn cfn_kind_monad_right_identity() {
-        // Renamed test
+    fn rcfn_kind_monad_right_identity() {
         let env_val: Env = 7;
-        let m_creator = || CFn::new(move |env: Env| env * 2);
+        let m_creator = || RcFn::new(move |env: Env| env * 2);
 
-        let pure_fn = clone_fn(|val: i32| CFnKind::<Env>::pure(val)); // Renamed Marker
+        let pure_fn = clone_fn(|val: i32| RcFnKind::<Env>::pure(val));
 
-        let lhs_cfn: CFn<Env, i32> = CFnKind::<Env>::bind(m_creator(), pure_fn); // Renamed Marker
-        let rhs_cfn: CFn<Env, i32> = m_creator();
+        let lhs: RcFn<Env, i32> = RcFnKind::<Env>::bind(m_creator(), pure_fn);
+        let rhs: RcFn<Env, i32> = m_creator();
 
-        assert_eq!(lhs_cfn.call(env_val), rhs_cfn.call(env_val));
-        assert_eq!(lhs_cfn.call(env_val), 14);
+        assert_eq!(lhs.call(env_val), rhs.call(env_val));
+        assert_eq!(lhs.call(env_val), 14);
     }
 
-    // 3. Associativity: m.bind(f).bind(g) == m.bind(|x| f(x).bind(g))
+    // 3. Associativity
     #[test]
-    fn cfn_kind_monad_associativity() {
-        // Renamed test
+    fn rcfn_kind_monad_associativity() {
         let env_val: Env = 3;
-        let m_creator = || CFn::new(move |env: Env| env + 1);
+        let m_creator = || RcFn::new(move |env: Env| env + 1);
 
-        let f =
-            clone_fn(move |x: i32| -> CFn<Env, f64> { CFn::new(move |env: Env| (x * env) as f64) });
-
-        let g = clone_fn(move |y: f64| -> CFn<Env, String> {
-            CFn::new(move |env: Env| (y + (env as f64)).to_string())
+        let f = clone_fn(move |x: i32| -> RcFn<Env, f64> {
+            RcFn::new(move |env: Env| (x * env) as f64)
         });
 
-        let bound_f: CFn<Env, f64> = CFnKind::<Env>::bind(m_creator(), f.clone()); // Renamed Marker
-        let lhs_cfn: CFn<Env, String> = CFnKind::<Env>::bind(bound_f, g.clone()); // Renamed Marker
+        let g = clone_fn(move |y: f64| -> RcFn<Env, String> {
+            RcFn::new(move |env: Env| (y + (env as f64)).to_string())
+        });
+
+        let bound_f: RcFn<Env, f64> = RcFnKind::<Env>::bind(m_creator(), f.clone());
+        let lhs: RcFn<Env, String> = RcFnKind::<Env>::bind(bound_f, g.clone());
 
         let f_inner = f.clone();
         let g_inner = g.clone();
-        let composed_func = clone_fn(move |x_val: i32| -> CFn<Env, String> {
-            let fx: CFn<Env, f64> = f_inner.clone()(x_val);
-            CFnKind::<Env>::bind(fx, g_inner.clone()) // Renamed Marker
+        let composed_func = clone_fn(move |x_val: i32| -> RcFn<Env, String> {
+            let fx: RcFn<Env, f64> = f_inner.clone()(x_val);
+            RcFnKind::<Env>::bind(fx, g_inner.clone())
         });
-        let rhs_cfn: CFn<Env, String> = CFnKind::<Env>::bind(m_creator(), composed_func); // Renamed Marker
+        let rhs: RcFn<Env, String> = RcFnKind::<Env>::bind(m_creator(), composed_func);
 
-        assert_eq!(lhs_cfn.call(env_val), rhs_cfn.call(env_val));
-        assert_eq!(lhs_cfn.call(env_val), "15".to_string());
+        assert_eq!(lhs.call(env_val), rhs.call(env_val));
+        assert_eq!(lhs.call(env_val), "15".to_string());
     }
 
-    // Monad::join laws for CFnKind
+    // Monad::join laws for RcFnKind
     #[test]
-    fn cfn_kind_monad_join_law1() {
-        // Renamed test
+    fn rcfn_kind_monad_join_law1() {
         let env_val: Env = 5;
         let x: i32 = 10;
 
-        let mma: CFn<Env, CFn<Env, i32>> = CFn::new(move |_env_outer: Env| CFnKind::<Env>::pure(x)); // Renamed Marker
+        let mma: RcFn<Env, RcFn<Env, i32>> =
+            RcFn::new(move |_env_outer: Env| RcFnKind::<Env>::pure(x));
 
-        let lhs_cfn: CFn<Env, i32> = CFnKind::<Env>::join(mma); // Renamed Marker
-        let rhs_cfn: CFn<Env, i32> = CFnKind::<Env>::pure(x); // Renamed Marker
+        let lhs: RcFn<Env, i32> = RcFnKind::<Env>::join(mma);
+        let rhs: RcFn<Env, i32> = RcFnKind::<Env>::pure(x);
 
-        assert_eq!(lhs_cfn.call(env_val), rhs_cfn.call(env_val));
-        assert_eq!(lhs_cfn.call(env_val), 10);
+        assert_eq!(lhs.call(env_val), rhs.call(env_val));
+        assert_eq!(lhs.call(env_val), 10);
     }
 
     #[test]
-    fn cfn_kind_monad_join_law2() {
-        // Renamed test
+    fn rcfn_kind_monad_join_law2() {
         let env_val: Env = 7;
-        let m_creator = || CFn::new(move |env: Env| env * 3);
+        let m_creator = || RcFn::new(move |env: Env| env * 3);
 
-        let pure_fn = clone_fn(|val: i32| CFnKind::<Env>::pure(val)); // Renamed Marker
+        let pure_fn = clone_fn(|val: i32| RcFnKind::<Env>::pure(val));
 
-        let mapped_m_cfn: CFn<Env, CFn<Env, i32>> = CFnKind::<Env>::map(m_creator(), pure_fn); // Renamed Marker
+        let mapped_m: RcFn<Env, RcFn<Env, i32>> = RcFnKind::<Env>::map(m_creator(), pure_fn);
 
-        let lhs_cfn: CFn<Env, i32> = CFnKind::<Env>::join(mapped_m_cfn); // Renamed Marker
-        let rhs_cfn: CFn<Env, i32> = m_creator();
+        let lhs: RcFn<Env, i32> = RcFnKind::<Env>::join(mapped_m);
+        let rhs: RcFn<Env, i32> = m_creator();
 
-        assert_eq!(lhs_cfn.call(env_val), rhs_cfn.call(env_val));
-        assert_eq!(lhs_cfn.call(env_val), 21);
+        assert_eq!(lhs.call(env_val), rhs.call(env_val));
+        assert_eq!(lhs.call(env_val), 21);
     }
 }
 

--- a/tests/kind/proptest_laws/applicative.rs
+++ b/tests/kind/proptest_laws/applicative.rs
@@ -35,7 +35,7 @@
 //!   `pure(compose) <*> u <*> v <*> w` is not constructible, exactly as
 //!   documented in the sibling `apply.rs` — `pure(compose)` would need the
 //!   middle composing closure to *move* a captured `CFn` into its result
-//!   (making it `FnOnce`, but `CFn::new` requires `Fn`), and the usual clone
+//!   (making it `FnOnce`, but `RcFn::new` requires `Fn`), and the usual clone
 //!   escape hatch is unavailable because **`CFn` is not `Clone`**. So we build
 //!   the fully-constructible right-associated side `u <*> (v <*> w)` —
 //!   `apply(apply(w, v), u)` — and assert it equals the ground truth `g(f(x))`
@@ -60,7 +60,7 @@ use super::{
 };
 use monadify::applicative::kind::Applicative;
 use monadify::apply::kind::Apply;
-use monadify::function::CFn;
+use monadify::function::RcFn;
 use monadify::identity::{Identity, IdentityKind};
 use monadify::kind_based::kind::{OptionKind, ResultKind, VecKind};
 use proptest::prelude::*;
@@ -75,7 +75,7 @@ proptest! {
     /// Applicative identity for `Option`: `apply(v, pure(id)) == v`.
     #[test]
     fn option_applicative_identity(v in arb_option_i32()) {
-        let pure_id: Option<CFn<i32, i32>> = OptionKind::pure(CFn::new(|x: i32| x));
+        let pure_id: Option<RcFn<i32, i32>> = OptionKind::pure(RcFn::new(|x: i32| x));
         prop_assert_eq!(OptionKind::apply(v, pure_id), v);
     }
 
@@ -87,7 +87,7 @@ proptest! {
         (a, b) in arb_linear_closure_params(),
     ) {
         let pure_x: Option<i32> = OptionKind::pure(x);
-        let pure_f: Option<CFn<i32, i32>> = OptionKind::pure(linear_cfn(a, b));
+        let pure_f: Option<RcFn<i32, i32>> = OptionKind::pure(linear_cfn(a, b));
         let lhs = OptionKind::apply(pure_x, pure_f);
 
         let mut f = linear_fn(a, b);
@@ -103,7 +103,7 @@ proptest! {
         (a, b) in arb_linear_closure_params(),
         present in any::<bool>(),
     ) {
-        let make_u = || -> Option<CFn<i32, i32>> {
+        let make_u = || -> Option<RcFn<i32, i32>> {
             if present { Some(linear_cfn(a, b)) } else { None }
         };
 
@@ -111,8 +111,8 @@ proptest! {
         let lhs = OptionKind::apply(OptionKind::pure(y), make_u());
 
         // RHS: pure(|f| f(y)) <*> u == apply(u, pure(|f| f(y)))
-        let pure_interchange: Option<CFn<CFn<i32, i32>, i32>> =
-            OptionKind::pure(CFn::new(move |f: CFn<i32, i32>| f.call(y)));
+        let pure_interchange: Option<RcFn<RcFn<i32, i32>, i32>> =
+            OptionKind::pure(RcFn::new(move |f: RcFn<i32, i32>| f.call(y)));
         let rhs = OptionKind::apply(make_u(), pure_interchange);
 
         prop_assert_eq!(lhs, rhs);
@@ -132,8 +132,8 @@ proptest! {
         f_present in any::<bool>(),
         g_present in any::<bool>(),
     ) {
-        let v: Option<CFn<i32, i32>> = if f_present { Some(linear_cfn(fa, fb)) } else { None };
-        let u: Option<CFn<i32, i32>> = if g_present { Some(linear_cfn(ga, gb)) } else { None };
+        let v: Option<RcFn<i32, i32>> = if f_present { Some(linear_cfn(fa, fb)) } else { None };
+        let u: Option<RcFn<i32, i32>> = if g_present { Some(linear_cfn(ga, gb)) } else { None };
 
         let lhs = OptionKind::apply(OptionKind::apply(w, v), u);
 
@@ -154,8 +154,8 @@ proptest! {
     /// Applicative identity for `Result<i32, String>`: `apply(r, pure(id)) == r`.
     #[test]
     fn result_applicative_identity(r in arb_result_i32_string()) {
-        let pure_id: Result<CFn<i32, i32>, TestError> =
-            ResultKind::<TestError>::pure(CFn::new(|x: i32| x));
+        let pure_id: Result<RcFn<i32, i32>, TestError> =
+            ResultKind::<TestError>::pure(RcFn::new(|x: i32| x));
         prop_assert_eq!(ResultKind::<TestError>::apply(r.clone(), pure_id), r);
     }
 
@@ -167,7 +167,7 @@ proptest! {
         (a, b) in arb_linear_closure_params(),
     ) {
         let pure_x: Result<i32, TestError> = ResultKind::<TestError>::pure(x);
-        let pure_f: Result<CFn<i32, i32>, TestError> =
+        let pure_f: Result<RcFn<i32, i32>, TestError> =
             ResultKind::<TestError>::pure(linear_cfn(a, b));
         let lhs = ResultKind::<TestError>::apply(pure_x, pure_f);
 
@@ -185,7 +185,7 @@ proptest! {
         ok in any::<bool>(),
         e in ".*",
     ) {
-        let make_u = || -> Result<CFn<i32, i32>, TestError> {
+        let make_u = || -> Result<RcFn<i32, i32>, TestError> {
             if ok { Ok(linear_cfn(a, b)) } else { Err(e.clone()) }
         };
 
@@ -193,8 +193,8 @@ proptest! {
         let lhs = ResultKind::<TestError>::apply(ResultKind::<TestError>::pure(y), make_u());
 
         // RHS: pure(|f| f(y)) <*> u == apply(u, pure(|f| f(y)))
-        let pure_interchange: Result<CFn<CFn<i32, i32>, i32>, TestError> =
-            ResultKind::<TestError>::pure(CFn::new(move |f: CFn<i32, i32>| f.call(y)));
+        let pure_interchange: Result<RcFn<RcFn<i32, i32>, i32>, TestError> =
+            ResultKind::<TestError>::pure(RcFn::new(move |f: RcFn<i32, i32>| f.call(y)));
         let rhs = ResultKind::<TestError>::apply(make_u(), pure_interchange);
 
         prop_assert_eq!(lhs, rhs);
@@ -216,9 +216,9 @@ proptest! {
         ev in ".*",
         eu in ".*",
     ) {
-        let v: Result<CFn<i32, i32>, TestError> =
+        let v: Result<RcFn<i32, i32>, TestError> =
             if f_ok { Ok(linear_cfn(fa, fb)) } else { Err(ev.clone()) };
-        let u: Result<CFn<i32, i32>, TestError> =
+        let u: Result<RcFn<i32, i32>, TestError> =
             if g_ok { Ok(linear_cfn(ga, gb)) } else { Err(eu.clone()) };
 
         let inner = <ResultKind<TestError> as Apply<i32, i32>>::apply(w.clone(), v);
@@ -247,7 +247,7 @@ proptest! {
     /// Applicative identity for `Identity`: `apply(i, pure(id)) == i`.
     #[test]
     fn identity_applicative_identity(i in arb_identity_i32()) {
-        let pure_id: Identity<CFn<i32, i32>> = IdentityKind::pure(CFn::new(|x: i32| x));
+        let pure_id: Identity<RcFn<i32, i32>> = IdentityKind::pure(RcFn::new(|x: i32| x));
         prop_assert_eq!(IdentityKind::apply(i.clone(), pure_id), i);
     }
 
@@ -259,7 +259,7 @@ proptest! {
         (a, b) in arb_linear_closure_params(),
     ) {
         let pure_x: Identity<i32> = IdentityKind::pure(x);
-        let pure_f: Identity<CFn<i32, i32>> = IdentityKind::pure(linear_cfn(a, b));
+        let pure_f: Identity<RcFn<i32, i32>> = IdentityKind::pure(linear_cfn(a, b));
         let lhs = IdentityKind::apply(pure_x, pure_f);
 
         let mut f = linear_fn(a, b);
@@ -274,14 +274,14 @@ proptest! {
         y in any::<i32>(),
         (a, b) in arb_linear_closure_params(),
     ) {
-        let make_u = || -> Identity<CFn<i32, i32>> { Identity(linear_cfn(a, b)) };
+        let make_u = || -> Identity<RcFn<i32, i32>> { Identity(linear_cfn(a, b)) };
 
         // LHS: u <*> pure(y) == apply(pure(y), u)
         let lhs = IdentityKind::apply(IdentityKind::pure(y), make_u());
 
         // RHS: pure(|f| f(y)) <*> u == apply(u, pure(|f| f(y)))
-        let pure_interchange: Identity<CFn<CFn<i32, i32>, i32>> =
-            IdentityKind::pure(CFn::new(move |f: CFn<i32, i32>| f.call(y)));
+        let pure_interchange: Identity<RcFn<RcFn<i32, i32>, i32>> =
+            IdentityKind::pure(RcFn::new(move |f: RcFn<i32, i32>| f.call(y)));
         let rhs = IdentityKind::apply(make_u(), pure_interchange);
 
         prop_assert_eq!(lhs, rhs);
@@ -324,7 +324,7 @@ proptest! {
         y in any::<i32>(),
         params in prop::collection::vec(arb_linear_closure_params(), 0..=8),
     ) {
-        let u: Vec<CFn<i32, i32>> = params.iter().map(|&(a, b)| linear_cfn(a, b)).collect();
+        let u: Vec<RcFn<i32, i32>> = params.iter().map(|&(a, b)| linear_cfn(a, b)).collect();
 
         // LHS: u <*> pure(y) == apply(pure(y), u)
         let lhs = VecKind::apply(VecKind::pure(y), u);

--- a/tests/kind/proptest_laws/apply.rs
+++ b/tests/kind/proptest_laws/apply.rs
@@ -45,7 +45,7 @@ use super::{
     arb_identity_i32, arb_linear_closure_params, arb_result_i32_string, linear_cfn, linear_fn,
 };
 use monadify::apply::kind::Apply;
-use monadify::function::CFn;
+use monadify::function::RcFn;
 use monadify::identity::{Identity, IdentityKind};
 use monadify::kind_based::kind::{OptionKind, ResultKind};
 use proptest::prelude::*;
@@ -70,8 +70,8 @@ proptest! {
         f_present in any::<bool>(),
         g_present in any::<bool>(),
     ) {
-        let v: Option<CFn<i32, i32>> = if f_present { Some(linear_cfn(fa, fb)) } else { None };
-        let u: Option<CFn<i32, i32>> = if g_present { Some(linear_cfn(ga, gb)) } else { None };
+        let v: Option<RcFn<i32, i32>> = if f_present { Some(linear_cfn(fa, fb)) } else { None };
+        let u: Option<RcFn<i32, i32>> = if g_present { Some(linear_cfn(ga, gb)) } else { None };
 
         // LHS: u <*> (v <*> w) == apply(apply(w, v), u)
         let lhs = OptionKind::apply(OptionKind::apply(w, v), u);
@@ -106,9 +106,9 @@ proptest! {
         ev in ".*",
         eu in ".*",
     ) {
-        let v: Result<CFn<i32, i32>, TestError> =
+        let v: Result<RcFn<i32, i32>, TestError> =
             if f_ok { Ok(linear_cfn(fa, fb)) } else { Err(ev.clone()) };
-        let u: Result<CFn<i32, i32>, TestError> =
+        let u: Result<RcFn<i32, i32>, TestError> =
             if g_ok { Ok(linear_cfn(ga, gb)) } else { Err(eu.clone()) };
 
         // LHS: u <*> (v <*> w) == apply(apply(w, v), u)

--- a/tests/kind/proptest_laws/mod.rs
+++ b/tests/kind/proptest_laws/mod.rs
@@ -10,7 +10,7 @@
 //! Design reference:
 //! `.a5c/runs/01KW2RTB9JS5H05EYB7Z9P1YYY/artifacts/property-testing-design.md`.
 
-use monadify::function::CFn;
+use monadify::function::RcFn;
 use monadify::identity::Identity;
 use proptest::prelude::*;
 
@@ -63,11 +63,12 @@ pub fn linear_fn(a: i32, b: i32) -> impl FnMut(i32) -> i32 + Clone + 'static {
     move |x: i32| x.wrapping_mul(a).wrapping_add(b)
 }
 
-/// Fresh `CFn<i32, i32>` for Applicative `apply` (function-in-container) laws.
+/// Fresh `RcFn<i32, i32>` for Applicative `apply` (function-in-container) laws.
 ///
-/// Rebuilt per use because `CFn` is not `Clone`.
-pub fn linear_cfn(a: i32, b: i32) -> CFn<i32, i32> {
-    CFn::new(move |x: i32| x.wrapping_mul(a).wrapping_add(b))
+/// Rebuilt per use site; `RcFn` is `Clone` (O(1) Rc bump) so it can also be
+/// cloned cheaply when needed by cartesian `Vec` apply.
+pub fn linear_cfn(a: i32, b: i32) -> RcFn<i32, i32> {
+    RcFn::new(move |x: i32| x.wrapping_mul(a).wrapping_add(b))
 }
 
 // --- Smoke test: proves the harness compiles and runs ---

--- a/tests/legacy/applicative.rs
+++ b/tests/legacy/applicative.rs
@@ -51,7 +51,7 @@ mod classic_applicative_tests {
 
 #[cfg(test)]
 mod applicative_laws {
-    use monadify::function::CFn; // Corrected path
+    use monadify::function::RcFn;
     use monadify::legacy::applicative::Applicative;
     use monadify::legacy::apply::Apply;
     #[allow(unused_imports)]
@@ -67,7 +67,7 @@ mod applicative_laws {
         assert_eq!(
             Apply::apply(
                 v,
-                <Option<_> as Applicative<CFn<i32, i32>>>::pure(CFn::new(identity::<i32>))
+                <Option<_> as Applicative<RcFn<i32, i32>>>::pure(RcFn::new(identity::<i32>))
             ),
             v
         );
@@ -79,7 +79,7 @@ mod applicative_laws {
         assert_eq!(
             Apply::apply(
                 v,
-                <Option<_> as Applicative<CFn<i32, i32>>>::pure(CFn::new(identity::<i32>))
+                <Option<_> as Applicative<RcFn<i32, i32>>>::pure(RcFn::new(identity::<i32>))
             ),
             v
         );
@@ -94,14 +94,14 @@ mod applicative_laws {
         assert_eq!(
             Apply::apply(
                 pure_x,
-                <Option<_> as Applicative<CFn<i32, i32>>>::pure(CFn::new(f))
+                <Option<_> as Applicative<RcFn<i32, i32>>>::pure(RcFn::new(f))
             ),
             <Option<_> as Applicative<i32>>::pure(f(x))
         );
         assert_eq!(
             Apply::apply(
                 pure_x,
-                <Option<_> as Applicative<CFn<i32, i32>>>::pure(CFn::new(f))
+                <Option<_> as Applicative<RcFn<i32, i32>>>::pure(RcFn::new(f))
             ),
             Some(20)
         );
@@ -112,10 +112,10 @@ mod applicative_laws {
         let y = 10;
         let f = |x: i32| x + 5;
 
-        let lhs = Apply::apply(<Option<_> as Applicative<i32>>::pure(y), Some(CFn::new(f)));
+        let lhs = Apply::apply(<Option<_> as Applicative<i32>>::pure(y), Some(RcFn::new(f)));
 
-        let u_for_rhs = Some(CFn::new(f));
-        let eval_at_y = move |f_func: CFn<i32, i32>| (f_func).call(y); // .call() not *
+        let u_for_rhs = Some(RcFn::new(f));
+        let eval_at_y = move |f_func: RcFn<i32, i32>| f_func.call(y);
         let rhs_interchange = Functor::map(u_for_rhs, eval_at_y);
 
         assert_eq!(lhs, rhs_interchange);
@@ -125,14 +125,14 @@ mod applicative_laws {
     #[test]
     fn option_applicative_interchange_none_fn() {
         let y = 10;
-        let u: Option<CFn<i32, i32>> = None;
+        let u: Option<RcFn<i32, i32>> = None;
 
         let lhs = Apply::apply(
             <Option<_> as Applicative<i32>>::pure(y),
-            None::<CFn<i32, i32>>,
+            None::<RcFn<i32, i32>>,
         );
 
-        let eval_at_y = move |f_func: CFn<i32, i32>| (f_func).call(y); // .call() not *
+        let eval_at_y = move |f_func: RcFn<i32, i32>| f_func.call(y);
         let rhs_interchange = Functor::map(u, eval_at_y);
 
         assert_eq!(lhs, rhs_interchange);
@@ -143,7 +143,7 @@ mod applicative_laws {
     fn option_applicative_map_some() {
         let v = Some(10);
         let f = |x: i32| x.to_string();
-        let pure_f = <Option<_> as Applicative<CFn<i32, String>>>::pure(CFn::new(f));
+        let pure_f = <Option<_> as Applicative<RcFn<i32, String>>>::pure(RcFn::new(f));
 
         let lhs = Functor::map(v, f); // clone v for map
         let rhs = Apply::apply(v, pure_f);
@@ -156,7 +156,7 @@ mod applicative_laws {
     fn option_applicative_map_none() {
         let v: Option<i32> = None;
         let f = |x: i32| x.to_string();
-        let pure_f = <Option<_> as Applicative<CFn<i32, String>>>::pure(CFn::new(f));
+        let pure_f = <Option<_> as Applicative<RcFn<i32, String>>>::pure(RcFn::new(f));
 
         let lhs = Functor::map(v, f); // clone v for map
         let rhs = Apply::apply(v, pure_f);
@@ -168,10 +168,10 @@ mod applicative_laws {
 
 #[cfg(test)]
 mod result_applicative_laws {
-    use monadify::function::CFn;
+    use monadify::function::RcFn;
     use monadify::legacy::applicative::Applicative;
     use monadify::legacy::apply::Apply;
-    use monadify::legacy::functor::Functor; // Corrected path
+    use monadify::legacy::functor::Functor;
 
     fn identity<T>(x: T) -> T {
         x
@@ -183,7 +183,9 @@ mod result_applicative_laws {
         assert_eq!(
             Apply::apply(
                 v.clone(),
-                <Result<_, String> as Applicative<CFn<i32, i32>>>::pure(CFn::new(identity::<i32>))
+                <Result<_, String> as Applicative<RcFn<i32, i32>>>::pure(RcFn::new(
+                    identity::<i32>
+                ))
             ),
             v
         );
@@ -195,7 +197,9 @@ mod result_applicative_laws {
         assert_eq!(
             Apply::apply(
                 v.clone(),
-                <Result<_, String> as Applicative<CFn<i32, i32>>>::pure(CFn::new(identity::<i32>))
+                <Result<_, String> as Applicative<RcFn<i32, i32>>>::pure(RcFn::new(
+                    identity::<i32>
+                ))
             ),
             v
         );
@@ -204,7 +208,7 @@ mod result_applicative_laws {
     #[test]
     fn result_applicative_identity_ok_apply_err() {
         let v: Result<i32, String> = Ok(10);
-        let f_err: Result<CFn<i32, i32>, String> = Err("function error".to_string());
+        let f_err: Result<RcFn<i32, i32>, String> = Err("function error".to_string());
         assert_eq!(Apply::apply(v, f_err), Err("function error".to_string()));
     }
 
@@ -212,20 +216,20 @@ mod result_applicative_laws {
     fn result_applicative_homomorphism_ok() {
         let x = 10;
         let f = |y: i32| y * 2;
-        let pure_x: Result<i32, String> = <Result<_, String> as Applicative<i32>>::pure(x); // Corrected
+        let pure_x: Result<i32, String> = <Result<_, String> as Applicative<i32>>::pure(x);
 
         assert_eq!(
             Apply::apply(
                 pure_x.clone(),
-                <Result<_, String> as Applicative<CFn<i32, i32>>>::pure(CFn::new(f))
+                <Result<_, String> as Applicative<RcFn<i32, i32>>>::pure(RcFn::new(f))
             ),
             <Result<_, String> as Applicative<i32>>::pure(f(x))
         );
         assert_eq!(
             Apply::apply(
                 <Result<_, String> as Applicative<i32>>::pure(x),
-                <Result<_, String> as Applicative<CFn<i32, i32>>>::pure(CFn::new(f))
-            ), // Corrected
+                <Result<_, String> as Applicative<RcFn<i32, i32>>>::pure(RcFn::new(f))
+            ),
             Ok::<i32, String>(20)
         );
     }
@@ -234,8 +238,8 @@ mod result_applicative_laws {
     fn result_applicative_homomorphism_err_val() {
         let x = 10;
         let _f = |y: i32| y * 2;
-        let pure_f_err: Result<CFn<i32, i32>, String> = Err("function error".to_string());
-        let pure_x: Result<i32, String> = <Result<_, String> as Applicative<i32>>::pure(x); // Corrected
+        let pure_f_err: Result<RcFn<i32, i32>, String> = Err("function error".to_string());
+        let pure_x: Result<i32, String> = <Result<_, String> as Applicative<i32>>::pure(x);
         assert_eq!(
             Apply::apply(pure_x, pure_f_err),
             Err("function error".to_string())
@@ -249,14 +253,13 @@ mod result_applicative_laws {
 
         let lhs = Apply::apply(
             <Result<_, String> as Applicative<i32>>::pure(y),
-            Ok(CFn::new(f)),
+            Ok(RcFn::new(f)),
         );
 
-        let u_for_rhs: Result<CFn<i32, i32>, String> = Ok(CFn::new(f));
-        // The closure for map needs to capture y.
+        let u_for_rhs: Result<RcFn<i32, i32>, String> = Ok(RcFn::new(f));
         let y_clone_for_map = y;
-        let rhs = Functor::map(u_for_rhs, move |f_func: CFn<i32, i32>| {
-            (f_func).call(y_clone_for_map)
+        let rhs = Functor::map(u_for_rhs, move |f_func: RcFn<i32, i32>| {
+            f_func.call(y_clone_for_map)
         });
 
         assert_eq!(lhs, rhs);
@@ -266,15 +269,15 @@ mod result_applicative_laws {
     #[test]
     fn result_applicative_interchange_err_fn() {
         let y = 10;
-        let u: Result<CFn<i32, i32>, String> = Err("function error".to_string());
+        let u: Result<RcFn<i32, i32>, String> = Err("function error".to_string());
 
         let lhs = Apply::apply(
             <Result<_, String> as Applicative<i32>>::pure(y),
             Err("function error".to_string()),
         );
         let y_clone_for_map = y;
-        let rhs = Functor::map(u, move |f_func: CFn<i32, i32>| {
-            (f_func).call(y_clone_for_map)
+        let rhs = Functor::map(u, move |f_func: RcFn<i32, i32>| {
+            f_func.call(y_clone_for_map)
         });
 
         assert_eq!(lhs, rhs);
@@ -289,7 +292,7 @@ mod result_applicative_laws {
         let lhs = Functor::map(v.clone(), f);
         let rhs = Apply::apply(
             v,
-            <Result<_, String> as Applicative<CFn<i32, String>>>::pure(CFn::new(f)),
+            <Result<_, String> as Applicative<RcFn<i32, String>>>::pure(RcFn::new(f)),
         );
 
         assert_eq!(lhs, rhs);
@@ -304,7 +307,7 @@ mod result_applicative_laws {
         let lhs = Functor::map(v.clone(), f);
         let rhs = Apply::apply(
             v,
-            <Result<_, String> as Applicative<CFn<i32, String>>>::pure(CFn::new(f)),
+            <Result<_, String> as Applicative<RcFn<i32, String>>>::pure(RcFn::new(f)),
         );
 
         assert_eq!(lhs, rhs);
@@ -314,7 +317,7 @@ mod result_applicative_laws {
 
 #[cfg(test)]
 mod vec_applicative_laws {
-    use monadify::function::CFn; // Corrected path
+    use monadify::function::RcFn;
     use monadify::legacy::applicative::Applicative;
     use monadify::legacy::apply::Apply;
     use monadify::legacy::functor::Functor;
@@ -326,14 +329,14 @@ mod vec_applicative_laws {
     #[test]
     fn vec_applicative_identity_non_empty() {
         let v = vec![10, 20];
-        let pure_identity_fn_vec = vec![CFn::new(identity::<i32>)];
+        let pure_identity_fn_vec = vec![RcFn::new(identity::<i32>)];
         assert_eq!(Apply::apply(v.clone(), pure_identity_fn_vec), v);
     }
 
     #[test]
     fn vec_applicative_identity_empty() {
         let v: Vec<i32> = vec![];
-        let pure_identity_fn_vec = vec![CFn::new(identity::<i32>)];
+        let pure_identity_fn_vec = vec![RcFn::new(identity::<i32>)];
         assert_eq!(Apply::apply(v.clone(), pure_identity_fn_vec), v);
     }
 
@@ -343,7 +346,7 @@ mod vec_applicative_laws {
         let f = |y: i32| y * 2;
         let pure_x_vec = <Vec<_> as Applicative<i32>>::pure(x);
 
-        let pure_f_vec = vec![CFn::new(f)];
+        let pure_f_vec = vec![RcFn::new(f)];
         let lhs = Apply::apply(pure_x_vec, pure_f_vec);
         let rhs = <Vec<_> as Applicative<i32>>::pure(f(x));
         assert_eq!(lhs, rhs);
@@ -356,12 +359,12 @@ mod vec_applicative_laws {
         let add_5 = |x: i32| x + 5;
         let mul_2 = |x: i32| x * 2;
 
-        let u_lhs: Vec<CFn<i32, i32>> = vec![CFn::new(add_5), CFn::new(mul_2)];
+        let u_lhs: Vec<RcFn<i32, i32>> = vec![RcFn::new(add_5), RcFn::new(mul_2)];
         let lhs = Apply::apply(<Vec<_> as Applicative<i32>>::pure(y), u_lhs);
 
         let y_cloned = y;
-        let u_rhs: Vec<CFn<i32, i32>> = vec![CFn::new(add_5), CFn::new(mul_2)];
-        let rhs = Functor::map(u_rhs, move |f_val: CFn<i32, i32>| (f_val).call(y_cloned));
+        let u_rhs: Vec<RcFn<i32, i32>> = vec![RcFn::new(add_5), RcFn::new(mul_2)];
+        let rhs = Functor::map(u_rhs, move |f_val: RcFn<i32, i32>| f_val.call(y_cloned));
 
         assert_eq!(lhs, rhs);
         assert_eq!(lhs, vec![15, 20]);
@@ -370,13 +373,13 @@ mod vec_applicative_laws {
     #[test]
     fn vec_applicative_interchange_empty_u() {
         let y = 10;
-        let u_lhs: Vec<CFn<i32, i32>> = vec![];
-        let u_rhs: Vec<CFn<i32, i32>> = vec![];
+        let u_lhs: Vec<RcFn<i32, i32>> = vec![];
+        let u_rhs: Vec<RcFn<i32, i32>> = vec![];
 
         let lhs = Apply::apply(<Vec<_> as Applicative<i32>>::pure(y), u_lhs);
 
         let y_cloned = y;
-        let rhs = Functor::map(u_rhs, move |f_val: CFn<i32, i32>| (f_val).call(y_cloned));
+        let rhs = Functor::map(u_rhs, move |f_val: RcFn<i32, i32>| f_val.call(y_cloned));
 
         assert_eq!(lhs, rhs);
         assert_eq!(lhs, Vec::<i32>::new());
@@ -389,7 +392,7 @@ mod vec_applicative_laws {
 
         let lhs = Functor::map(v.clone(), f);
 
-        let pure_f_vec = vec![CFn::new(f)];
+        let pure_f_vec = vec![RcFn::new(f)];
         let rhs = Apply::apply(v, pure_f_vec);
 
         assert_eq!(lhs, rhs);
@@ -402,7 +405,7 @@ mod vec_applicative_laws {
         let f = |x: i32| x.to_string();
 
         let lhs = Functor::map(v.clone(), f);
-        let pure_f_vec = vec![CFn::new(f)];
+        let pure_f_vec = vec![RcFn::new(f)];
         let rhs = Apply::apply(v, pure_f_vec);
 
         assert_eq!(lhs, rhs);

--- a/tests/legacy/identity.rs
+++ b/tests/legacy/identity.rs
@@ -1,7 +1,7 @@
 #![cfg(all(test, feature = "legacy"))] // Ensure these run only when 'legacy' is active
 
 // These imports will need to point to legacy versions.
-use monadify::function::CFn;
+use monadify::function::RcFn;
 use monadify::legacy::applicative::Applicative;
 use monadify::legacy::apply::Apply;
 use monadify::legacy::functor::Functor;
@@ -22,12 +22,12 @@ fn test_identity_functor_map() {
 #[test]
 fn test_identity_apply() {
     let id_val = Identity(5);
-    let id_fn: Identity<CFn<i32, i32>> = Identity(CFn::new(|x| x * 2));
+    let id_fn: Identity<RcFn<i32, i32>> = Identity(RcFn::new(|x| x * 2));
     let result = <Identity<i32> as Apply<i32>>::apply(id_val, id_fn);
     assert_eq!(result, Identity(10));
 
     let id_str_val = Identity(String::from("test"));
-    let id_str_fn: Identity<CFn<String, usize>> = Identity(CFn::new(|s: String| s.len()));
+    let id_str_fn: Identity<RcFn<String, usize>> = Identity(RcFn::new(|s: String| s.len()));
     let result_str = <Identity<String> as Apply<String>>::apply(id_str_val, id_str_fn);
     assert_eq!(result_str, Identity(4));
 }

--- a/tests/legacy/transformers/reader_test.rs
+++ b/tests/legacy/transformers/reader_test.rs
@@ -1,14 +1,14 @@
 #![cfg(all(test, feature = "legacy"))] // Ensure these run only when 'legacy' is active
 
 // Import necessary items from the monadify crate, pointing to legacy versions
-use monadify::function::CFn;
+use monadify::function::RcFn;
 use monadify::legacy::applicative::Applicative;
 use monadify::legacy::apply::Apply; // For apply
 use monadify::legacy::functor::Functor; // For map
 use monadify::legacy::identity::Identity;
 use monadify::legacy::monad::Bind; // For laws
 use monadify::legacy::transformers::reader::MonadReader;
-use monadify::legacy::transformers::reader::{Reader, ReaderT}; // CFn is not part of legacy/hkt split
+use monadify::legacy::transformers::reader::{Reader, ReaderT}; // RcFn is not part of legacy/hkt split
 
 #[test]
 fn test_reader_t_new_and_run() {
@@ -69,14 +69,14 @@ fn test_reader_t_apply() {
     };
     let reader_val: ReaderT<i32, Option<i32>, i32> = ReaderT::new(reader_val_fn);
 
-    let reader_func_fn = |env: i32| -> Option<CFn<i32, String>> {
+    let reader_func_fn = |env: i32| -> Option<RcFn<i32, String>> {
         if env > 0 {
-            Some(CFn::new(move |x: i32| format!("Env: {}, Val: {}", env, x)))
+            Some(RcFn::new(move |x: i32| format!("Env: {}, Val: {}", env, x)))
         } else {
             None
         }
     };
-    let reader_func: ReaderT<i32, Option<CFn<i32, String>>, CFn<i32, String>> =
+    let reader_func: ReaderT<i32, Option<RcFn<i32, String>>, RcFn<i32, String>> =
         ReaderT::new(reader_func_fn);
 
     let result_reader =
@@ -91,14 +91,14 @@ fn test_reader_t_apply() {
     let reader_val_always_some: ReaderT<i32, Option<i32>, i32> =
         ReaderT::new(reader_val_always_some_fn);
 
-    let reader_func_fn_env_neg = |env: i32| -> Option<CFn<i32, String>> {
+    let reader_func_fn_env_neg = |env: i32| -> Option<RcFn<i32, String>> {
         if env > 0 {
-            Some(CFn::new(move |x: i32| format!("Env: {}, Val: {}", env, x)))
+            Some(RcFn::new(move |x: i32| format!("Env: {}, Val: {}", env, x)))
         } else {
             None
         }
     };
-    let reader_func_env_neg: ReaderT<i32, Option<CFn<i32, String>>, CFn<i32, String>> =
+    let reader_func_env_neg: ReaderT<i32, Option<RcFn<i32, String>>, RcFn<i32, String>> =
         ReaderT::new(reader_func_fn_env_neg);
 
     let result_reader_2 = <ReaderT<i32, Option<i32>, i32> as Apply<i32>>::apply(

--- a/tests/profunctor.rs
+++ b/tests/profunctor.rs
@@ -18,47 +18,38 @@ mod tests {
     #[test]
     fn test_fn_dimap() {
         let closure = fn1!(|x: i32| format!("{x}"));
-        // Assuming Profunctor is in scope via `use monadify::Profunctor;` at the top of this test file
-        // or `use super::Profunctor;` if it were defined in this file's parent.
-        // Since Profunctor is a trait, `closure.dimap` should work if `closure` (a CFn) implements Profunctor.
         let proclosure = closure.dimap(|x: i8| (x + 1).into(), |s| vec![s]);
-        let result = proclosure(1);
+        let result = proclosure.call(1i8);
         assert_eq!(result, vec!["2"])
     }
 
     #[test]
     fn test_fn_lcmap() {
-        let profunctor_val = fn1!(|x: i32| format!("{x}")); // Renamed from profunctor to avoid conflict
+        let profunctor_val = fn1!(|x: i32| format!("{x}"));
         let proclosure = lcmap(|x: i8| x as i32 + 1, profunctor_val);
-        let result = proclosure(1);
+        let result = proclosure.call(1i8);
         assert_eq!(result, "2")
     }
 
     #[test]
     fn test_fn_rmap() {
-        let profunctor_val = fn1!(|x: i32| format!("{x}")); // Renamed
+        let profunctor_val = fn1!(|x: i32| format!("{x}"));
         let proclosure = rmap(|s| vec![s], profunctor_val);
-        let result = proclosure(1);
+        let result = proclosure.call(1i32);
         assert_eq!(result, vec!["1"])
     }
 
     #[test]
     fn test_fn_rmap_with_identity() {
-        let profunctor_val = fn1!(|x: i32| x); // Renamed
+        let profunctor_val = fn1!(|x: i32| x);
         let proclosure = rmap(|s| vec![s], profunctor_val);
-        let result = proclosure(1);
+        let result = proclosure.call(1i32);
         assert_eq!(result, vec![1])
     }
 
     #[test]
     fn test_1() {
         let tuple = (1, 3);
-        // The AGetter type alias might need to be defined or imported if it's not automatically resolved.
-        // For now, assuming view can infer types or AGetter is accessible.
-        // AGetter is `Fold<A, S, T, A, B>`, Fold is `Optic<Forget<R,S,T>, Forget<R,A,B>, S,T,A,B>`
-        // These are complex types defined in profunctor.rs.
-        // The `_1()` function returns a `Lens`. `into()` converts it to `Optic`.
-        // This should work if `Lens`, `Optic`, `Forget`, `view`, `_1`, `_2` are in scope.
         let r = view::<_, _, _, ()>(_1().into(), tuple);
         assert_eq!(r, 1);
         let r = view::<_, _, _, ()>(_2().into(), tuple);
@@ -67,15 +58,15 @@ mod tests {
 
     #[test]
     fn test_key() {
-        let rec = Check { key: 1, other: 1 }; // Check struct needs to be in scope
-        let r = view(_key().0, rec); // _key() returns Lens, .0 accesses the Optic inside
+        let rec = Check { key: 1, other: 1 };
+        let r = view(_key().0, rec);
         assert_eq!(r, 1);
     }
 }
 
 #[cfg(test)]
 mod profunctor_laws {
-    use monadify::function::CFn;
+    use monadify::function::RcFn;
     use monadify::Profunctor;
 
     // Helper identity function
@@ -84,88 +75,60 @@ mod profunctor_laws {
     }
 
     // Law 1: p.dimap(id, id) == p
-    // We need a way to compare Profunctors (CFn in this case).
-    // Since CFn wraps Box<dyn Fn>, direct comparison is not possible.
     // We test by applying the same input and checking for equal output.
     #[test]
     fn profunctor_identity_law() {
-        // Add type annotation for x
-        let p: CFn<i32, String> = CFn::new(|x: i32| x.to_string());
+        let p: RcFn<i32, String> = RcFn::new(|x: i32| x.to_string());
         let input = 123;
 
         // p.dimap(id, id)
-        // Recreate p for lhs instead of cloning
-        let p_lhs: CFn<i32, String> = CFn::new(|x: i32| x.to_string());
+        let p_lhs: RcFn<i32, String> = RcFn::new(|x: i32| x.to_string());
         let lhs_p = p_lhs.dimap(identity::<i32>, identity::<String>);
 
-        // Apply input
-        let lhs_result = lhs_p(input);
-        let rhs_result = p(input); // Apply to original p
+        let lhs_result = lhs_p.call(input);
+        let rhs_result = p.call(input);
 
         assert_eq!(lhs_result, rhs_result);
         assert_eq!(lhs_result, "123".to_string());
     }
 
-    // Law 2: p.dimap(f, g).dimap(h, i) == p.dimap(f . h, i . g)
-    // Law 2 rewritten: p.dimap(h, i).dimap(f, g) == p.dimap(f . h, g . i)
-    // Let p: CFn<B, C>
-    // f: A -> B
-    // g: C -> D
-    // h: X -> A
-    // i: D -> Y
-    // p.dimap(h, i) -> CFn<X, Y>
-    // p.dimap(h, i).dimap(f, g) -> This doesn't match the types easily.
-    // The law is: p.dimap(h, i).dimap(f, g) == p.dimap(f . h, g . i)
-    // Let p: B -> C
-    // h: A -> B
-    // i: C -> D
-    // f: X -> A
-    // g: D -> Y
+    // Law 2: p.dimap(h, i).dimap(f, g) == p.dimap(f . h, g . i)
     #[test]
     fn profunctor_composition_law() {
         // p: B -> C  (i32 -> String)
-        let _p: CFn<i32, String> = CFn::new(|x| format!("Value: {x}")); // Prefixed with _
-                                                                        // h: A -> B  (u16 -> i32)
+        let _p: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
+        // h: A -> B  (u16 -> i32)
         let h = |x: u16| x as i32 + 10;
-        // i: C -> D  (String -> usize) - Simplified
+        // i: C -> D  (String -> usize)
         let i = |s: String| s.len();
         // f: X -> A  (u8 -> u16)
         let f = |x: u8| x as u16 * 2;
-        // g: D -> Y  (usize -> usize) - Simplified
+        // g: D -> Y  (usize -> usize)
         let g = |x: usize| x + 1;
 
-        let input: u8 = 5; // Input type X
+        let input: u8 = 5;
 
         // LHS: p.dimap(h, i).dimap(f, g)
-        let p_lhs1: CFn<i32, String> = CFn::new(|x| format!("Value: {x}")); // Recreate p
-        let p_hi = p_lhs1.dimap(h, i); // CFn<u16, usize> (A -> D)
-        let lhs_p = p_hi.dimap(f, g); // CFn<u8, usize> (X -> Y)
-        let lhs_result = lhs_p(input); // Y
+        let p_lhs1: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
+        let p_hi = p_lhs1.dimap(h, i); // RcFn<u16, usize>
+        let lhs_p = p_hi.dimap(f, g); // RcFn<u8, usize>
+        let lhs_result = lhs_p.call(input);
 
         // RHS: p.dimap(f . h, g . i)
-        // f . h : X -> B (u8 -> i32)
         let f_dot_h = move |x: u8| h(f(x));
-        // g . i : C -> Y (String -> usize)
         let g_dot_i = move |s: String| g(i(s));
-        let p_rhs: CFn<i32, String> = CFn::new(|x| format!("Value: {x}")); // Recreate p
-        let rhs_p = p_rhs.dimap(f_dot_h, g_dot_i); // CFn<u8, usize> (X -> Y)
-        let rhs_result = rhs_p(input); // Y
+        let p_rhs: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
+        let rhs_p = p_rhs.dimap(f_dot_h, g_dot_i);
+        let rhs_result = rhs_p.call(input);
 
-        assert_eq!(lhs_result, rhs_result); // Check the law holds
-
-        // Manual check (simplified): g(i(p(h(f(input)))))
-        // f(5) = 10 (u16)
-        // h(10) = 20 (i32)
-        // p(20) = "Value: 20" (String)
-        // i("Value: 20") = 10 (usize)
-        // g(10) = 11 (usize) -> Incorrect trace, g(9) was called, result is 10
-        assert_eq!(lhs_result, 10); // Verify the actual value (corrected)
+        assert_eq!(lhs_result, rhs_result);
+        assert_eq!(lhs_result, 10);
     }
 }
 
 #[cfg(test)]
 mod strong_laws {
-    use monadify::function::CFn;
+    use monadify::function::RcFn;
     use monadify::{Profunctor, Strong};
 
     // Helper identity function
@@ -182,135 +145,103 @@ mod strong_laws {
     }
 
     // Law: p.first().dimap(split(f, id), split(g, id)) == p.dimap(f, g).first()
-    // Let p: B -> C
-    // f: A -> B
-    // g: C -> D
-    // id: X -> X (for some type X)
     #[test]
     fn strong_first_dimap_law() {
         // p: i32 -> String
-        let _p: CFn<i32, String> = CFn::new(|x| format!("Value: {x}")); // Prefixed with _
-                                                                        // f: u16 -> i32
+        let _p: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
+        // f: u16 -> i32
         let f = |x: u16| x as i32 + 10;
         // g: String -> usize
         let g = |s: String| s.len();
         // X will be u8
         type X = u8;
 
-        let input: (u16, X) = (5, 99); // Input type (A, X)
+        let input: (u16, X) = (5, 99);
 
         // LHS: p.first().dimap(split(f, id), split(g, id))
-        let p_lhs: CFn<i32, String> = CFn::new(|x| format!("Value: {x}"));
-        let p_first = p_lhs.first::<X>(); // CFn<(i32, X), (String, X)>
-        let lhs_p = p_first.dimap(split(f, identity::<X>), split(g, identity::<X>)); // CFn<(u16, X), (usize, X)>
-        let lhs_result = lhs_p(input);
+        let p_lhs: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
+        let p_first = p_lhs.first::<X>();
+        let lhs_p = p_first.dimap(split(f, identity::<X>), split(g, identity::<X>));
+        let lhs_result = lhs_p.call(input);
 
         // RHS: p.dimap(f, g).first()
-        let p_rhs: CFn<i32, String> = CFn::new(|x| format!("Value: {x}"));
-        let p_fg = p_rhs.dimap(f, g); // CFn<u16, usize>
-        let rhs_p = p_fg.first::<X>(); // CFn<(u16, X), (usize, X)>
-        let rhs_result = rhs_p(input);
+        let p_rhs: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
+        let p_fg = p_rhs.dimap(f, g);
+        let rhs_p = p_fg.first::<X>();
+        let rhs_result = rhs_p.call(input);
 
         assert_eq!(lhs_result, rhs_result);
-
-        // Manual check:
-        // input = (5, 99)
-        // f(5) = 15
-        // p(15) = "Value: 15"
-        // g("Value: 15") = 9 (length of "Value: 15")
-        // Expected output: (9, 99)
+        // input = (5, 99), f(5) = 15, p(15) = "Value: 15", g("Value: 15") = 9
         assert_eq!(lhs_result, (9, 99));
     }
 
-    // Similar law for second: p.second().dimap(split(id, f), split(id, g)) == p.dimap(f, g).second()
+    // Similar law for second
     #[test]
     fn strong_second_dimap_law() {
         // p: i32 -> String
-        let _p: CFn<i32, String> = CFn::new(|x| format!("Value: {x}")); // Prefixed with _
-                                                                        // f: u16 -> i32
+        let _p: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
+        // f: u16 -> i32
         let f = |x: u16| x as i32 + 10;
         // g: String -> usize
         let g = |s: String| s.len();
         // X will be u8
         type X = u8;
 
-        let input: (X, u16) = (99, 5); // Input type (X, A)
+        let input: (X, u16) = (99, 5);
 
         // LHS: p.second().dimap(split(id, f), split(id, g))
-        let p_lhs: CFn<i32, String> = CFn::new(|x| format!("Value: {x}"));
-        let p_second = p_lhs.second::<X>(); // CFn<(X, i32), (X, String)>
-        let lhs_p = p_second.dimap(split(identity::<X>, f), split(identity::<X>, g)); // CFn<(X, u16), (X, usize)>
-        let lhs_result = lhs_p(input);
+        let p_lhs: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
+        let p_second = p_lhs.second::<X>();
+        let lhs_p = p_second.dimap(split(identity::<X>, f), split(identity::<X>, g));
+        let lhs_result = lhs_p.call(input);
 
         // RHS: p.dimap(f, g).second()
-        let p_rhs: CFn<i32, String> = CFn::new(|x| format!("Value: {x}"));
-        let p_fg = p_rhs.dimap(f, g); // CFn<u16, usize>
-        let rhs_p = p_fg.second::<X>(); // CFn<(X, u16), (X, usize)>
-        let rhs_result = rhs_p(input);
+        let p_rhs: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
+        let p_fg = p_rhs.dimap(f, g);
+        let rhs_p = p_fg.second::<X>();
+        let rhs_result = rhs_p.call(input);
 
         assert_eq!(lhs_result, rhs_result);
-
-        // Manual check:
-        // input = (99, 5)
-        // f(5) = 15
-        // p(15) = "Value: 15"
-        // g("Value: 15") = 9 (length of "Value: 15")
-        // Expected output: (99, 9)
+        // input = (99, 5), f(5) = 15, p(15) = "Value: 15", g("Value: 15") = 9
         assert_eq!(lhs_result, (99, 9));
     }
 
-    // Other laws exist relating first/second composition, etc.
-    // e.g., p.first().second() == p.dimap(swap, swap).second().first()
-    // For now, testing the interaction with dimap is a good start.
-
     // Law: p.first().first() == p.first().dimap(assoc, inv_assoc)
-    // where assoc(((a,b),c)) = (a,(b,c))
-    // and inv_assoc((a,(b,c))) = ((a,b),c)
     #[test]
     fn strong_associativity_law() {
         // p: A -> B (i32 -> String)
-        let _p_orig: CFn<i32, String> = CFn::new(|x| format!("Value: {x}")); // Prefixed with _
+        let _p_orig: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
 
-        // Types for the tuple elements
         type X = u8;
         type Y = bool;
 
         let input: ((i32, X), Y) = ((10, 20u8), true);
 
         // LHS: p.first().first()
-        let p_lhs: CFn<i32, String> = CFn::new(|x| format!("Value: {x}")); // Recreate p
+        let p_lhs: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
         let lhs = p_lhs.first::<X>().first::<Y>();
-        let lhs_result = lhs(input);
+        let lhs_result = lhs.call(input);
 
         // RHS: p.first().dimap(assoc, inv_assoc)
-        let p_rhs: CFn<i32, String> = CFn::new(|x| format!("Value: {x}")); // Recreate p
-        let p_first_intermediate = p_rhs.first::<(X, Y)>(); // p.first() for type (A, (X,Y)) -> (B, (X,Y))
+        let p_rhs: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
+        let p_first_intermediate = p_rhs.first::<(X, Y)>();
 
         let assoc = |((a, x), y): ((i32, X), Y)| (a, (x, y));
         let inv_assoc = |(b, (x, y)): (String, (X, Y))| ((b, x), y);
 
         let rhs = p_first_intermediate.dimap(assoc, inv_assoc);
-        let rhs_result = rhs(input);
+        let rhs_result = rhs.call(input);
 
         assert_eq!(lhs_result, rhs_result);
-
-        // Manual check:
-        // input = ((10, 20), true)
-        // p(10) = "Value: 10"
-        // Expected output: (("Value: 10", 20), true)
+        // input = ((10, 20), true), p(10) = "Value: 10"
         assert_eq!(lhs_result, (("Value: 10".to_string(), 20u8), true));
     }
 }
 
 #[cfg(test)]
 mod choice_laws {
-    use monadify::function::CFn;
+    use monadify::function::RcFn;
     use monadify::{Choice, Profunctor};
-
-    // Helper identity function (Removed as unused in this module)
-    // fn identity<T>(x: T) -> T {
-    //     x
-    // }
 
     // Helper function for Choice laws
     fn map_result<A, B, C, F: Fn(A) -> B>(f: F, r: Result<C, A>) -> Result<C, B> {
@@ -321,65 +252,54 @@ mod choice_laws {
     }
 
     // Law: p.left().dimap(map_result(f, id), map_result(g, id)) == p.dimap(f, g).left()
-    // Let p: B -> C
-    // f: A -> B
-    // g: C -> D
-    // id: X -> X (for some type X)
     #[test]
     fn choice_left_dimap_law() {
         // p: i32 -> String
-        let _p: CFn<i32, String> = CFn::new(|x| format!("Value: {x}")); // Prefixed with _
-                                                                        // f: u16 -> i32
+        let _p: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
+        // f: u16 -> i32
         let f = |x: u16| x as i32 + 10;
         // g: String -> usize
         let g = |s: String| s.len();
         // X will be u8
         type X = u8;
 
-        let input_err: Result<X, u16> = Err(5); // Input type Result<X, A>
+        let input_err: Result<X, u16> = Err(5);
         let input_ok: Result<X, u16> = Ok(99);
 
-        // --- LHS ---
-        // Calculate LHS for Err input
-        let p_lhs_err: CFn<i32, String> = CFn::new(|x| format!("Value: {x}"));
+        // --- LHS (Err) ---
+        let p_lhs_err: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
         let lhs_p_err = p_lhs_err.left::<X>().dimap(
-            move |r: Result<X, u16>| map_result(f, r),    // Added move
-            move |r: Result<X, String>| map_result(g, r), // Added move
+            move |r: Result<X, u16>| map_result(f, r),
+            move |r: Result<X, String>| map_result(g, r),
         );
-        let lhs_result_err = lhs_p_err(input_err);
+        let lhs_result_err = lhs_p_err.call(input_err);
 
-        // --- RHS ---
-        // Calculate RHS for Err input
-        let p_rhs_err: CFn<i32, String> = CFn::new(|x| format!("Value: {x}"));
+        // --- RHS (Err) ---
+        let p_rhs_err: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
         let rhs_p_err = p_rhs_err.dimap(f, g).left::<X>();
-        let rhs_result_err = rhs_p_err(input_err);
+        let rhs_result_err = rhs_p_err.call(input_err);
 
-        // --- Assertions for Err ---
         assert_eq!(lhs_result_err, rhs_result_err);
         // f(5) = 15, p(15) = "Value: 15", g("Value: 15") = 9
         assert_eq!(lhs_result_err, Err(9));
 
-        // Test with Ok input
-        // Calculate LHS for Ok input
-        let p_lhs_ok: CFn<i32, String> = CFn::new(|x| format!("Value: {x}"));
+        // --- LHS (Ok) ---
+        let p_lhs_ok: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
         let lhs_p_ok = p_lhs_ok.left::<X>().dimap(
-            move |r: Result<X, u16>| map_result(f, r),    // Added move
-            move |r: Result<X, String>| map_result(g, r), // Added move
+            move |r: Result<X, u16>| map_result(f, r),
+            move |r: Result<X, String>| map_result(g, r),
         );
-        let lhs_result_ok = lhs_p_ok(input_ok);
+        let lhs_result_ok = lhs_p_ok.call(input_ok);
 
-        // Calculate RHS for Ok input
-        let p_rhs_ok: CFn<i32, String> = CFn::new(|x| format!("Value: {x}"));
+        // --- RHS (Ok) ---
+        let p_rhs_ok: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
         let rhs_p_ok = p_rhs_ok.dimap(f, g).left::<X>();
-        let rhs_result_ok = rhs_p_ok(input_ok);
+        let rhs_result_ok = rhs_p_ok.call(input_ok);
 
-        // --- Assertions for Ok ---
         assert_eq!(lhs_result_ok, rhs_result_ok);
-        // Manual check: Ok(99) -> Ok(99) -> Ok(99) -> Ok(99)
         assert_eq!(lhs_result_ok, Ok(99));
     }
 
-    // Similar law for right: p.right().dimap(map_result(id, f), map_result(id, g)) == p.dimap(f, g).right()
     // Helper function for right
     fn map_result_right<A, B, C, F: Fn(A) -> B>(f: F, r: Result<A, C>) -> Result<B, C> {
         match r {
@@ -391,54 +311,48 @@ mod choice_laws {
     #[test]
     fn choice_right_dimap_law() {
         // p: i32 -> String
-        let _p: CFn<i32, String> = CFn::new(|x| format!("Value: {x}")); // Prefixed with _
-                                                                        // f: u16 -> i32
+        let _p: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
+        // f: u16 -> i32
         let f = |x: u16| x as i32 + 10;
         // g: String -> usize
         let g = |s: String| s.len();
         // X will be u8
         type X = u8;
 
-        let input_ok: Result<u16, X> = Ok(5); // Input type Result<A, X>
+        let input_ok: Result<u16, X> = Ok(5);
         let input_err: Result<u16, X> = Err(99);
 
-        // --- LHS ---
-        // Calculate LHS for Ok input
-        let p_lhs_ok: CFn<i32, String> = CFn::new(|x| format!("Value: {x}"));
+        // --- LHS (Ok) ---
+        let p_lhs_ok: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
         let lhs_p_ok = p_lhs_ok.right::<X>().dimap(
-            move |r: Result<u16, X>| map_result_right(f, r), // Added move
-            move |r: Result<String, X>| map_result_right(g, r), // Added move
+            move |r: Result<u16, X>| map_result_right(f, r),
+            move |r: Result<String, X>| map_result_right(g, r),
         );
-        let lhs_result_ok = lhs_p_ok(input_ok);
+        let lhs_result_ok = lhs_p_ok.call(input_ok);
 
-        // --- RHS ---
-        // Calculate RHS for Ok input
-        let p_rhs_ok: CFn<i32, String> = CFn::new(|x| format!("Value: {x}"));
+        // --- RHS (Ok) ---
+        let p_rhs_ok: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
         let rhs_p_ok = p_rhs_ok.dimap(f, g).right::<X>();
-        let rhs_result_ok = rhs_p_ok(input_ok);
+        let rhs_result_ok = rhs_p_ok.call(input_ok);
 
-        // --- Assertions for Ok ---
         assert_eq!(lhs_result_ok, rhs_result_ok);
         // f(5) = 15, p(15) = "Value: 15", g("Value: 15") = 9
         assert_eq!(lhs_result_ok, Ok(9));
 
-        // Test with Err input
-        // Calculate LHS for Err input
-        let p_lhs_err: CFn<i32, String> = CFn::new(|x| format!("Value: {x}"));
+        // --- LHS (Err) ---
+        let p_lhs_err: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
         let lhs_p_err = p_lhs_err.right::<X>().dimap(
-            move |r: Result<u16, X>| map_result_right(f, r), // Added move
-            move |r: Result<String, X>| map_result_right(g, r), // Added move
+            move |r: Result<u16, X>| map_result_right(f, r),
+            move |r: Result<String, X>| map_result_right(g, r),
         );
-        let lhs_result_err = lhs_p_err(input_err);
+        let lhs_result_err = lhs_p_err.call(input_err);
 
-        // Calculate RHS for Err input
-        let p_rhs_err: CFn<i32, String> = CFn::new(|x| format!("Value: {x}"));
+        // --- RHS (Err) ---
+        let p_rhs_err: RcFn<i32, String> = RcFn::new(|x| format!("Value: {x}"));
         let rhs_p_err = p_rhs_err.dimap(f, g).right::<X>();
-        let rhs_result_err = rhs_p_err(input_err);
+        let rhs_result_err = rhs_p_err.call(input_err);
 
-        // --- Assertions for Err ---
         assert_eq!(lhs_result_err, rhs_result_err);
-        // Manual check: Err(99) -> Err(99) -> Err(99) -> Err(99)
         assert_eq!(lhs_result_err, Err(99));
     }
 }


### PR DESCRIPTION
## Summary

**BREAKING (0.2.0).** Removes `CFn` (the `Box<dyn Fn>` wrapper) and `CFnKind`; promotes `RcFn` (`Rc<dyn Fn>`, `Clone`) to the **single multi-call function wrapper**. `CFnOnce`/`CFnOnceKind` are **kept** (move-once, genuinely not subsumed by `RcFn`).

Having both wrappers was dead weight: `RcFn` is a *capability superset* of `CFn` (everything `CFn` did, plus O(1) `Clone`). This was verified, not assumed — an adversarial necessity check (six attack angles) returned **`capabilityRequired: false`, `realGaps: []`**:

- **Box-uniqueness is never exploited** — the only move-out-of-box (`Rc::from(value.0)`) was itself a `CFn`-not-`Clone` *workaround*.
- Both `Box<dyn Fn>` and `Rc<dyn Fn>` are `!Send`/`!Sync`, so `CFn` held **no thread-boundary advantage**.
- `Profunctor for RcFn` ports verbatim; no coherence/law/Rc-cycle obstacle.

Stacked on #4 (the `RcFn` introduction), now merged.

## Changes

- `Apply` carrier `Self::Of<CFn<A,B>>` → `Self::Of<RcFn<A,B>>`; the now-redundant **`ApplyRc` trait deleted**.
- `lift_a1` → `RcFn`; duplicate **`lift_a1_rc` deleted**; `lift2`/`lift3`/`apply_first`/`apply_second` → `RcFn`.
- **Profunctor/Strong/Choice/Forget + optics** (`Lens`/`lens_`/`lens`/`_1`/`_2`/`_key`/`view`) migrated `CFn` → `RcFn` (identical law shapes). `Profunctor for CFnOnce` retained.
- **`CFnKind` marker + its `Functor..Monad` stack deleted**, along with the `Applicative<CFn<A,B>> for RcFnKind` bridge (RcFnKind covers them).
- `fn0!..fn3!` emit `RcFn::new`; `legacy/*` migrated; `CFn` struct + re-export removed.
- Direct-call `cfn(arg)` → `rcfn.call(arg)` throughout (`Rc<dyn Fn>` has **no blanket `Fn` impl** in std, unlike `Box<dyn Fn>`).
- `cfn_unsupported` doc rewritten: `RcFnKind` is now supported in `mdo!`; `CFnOnceKind` remains the intentionally-unsupported case.

## Tests & gates

The removed `CFnKind` applicative-law tests were vacuous `println!` **stubs** — replaced by real `RcFnKind`/`VecKind` law assertions, so **coverage improved**. No test was weakened or deleted to pass.

All gates green: `fmt`; `clippy --all-targets --all-features -D warnings`; `default`+`legacy`+`do-notation`+`--all-features` (330+84+13+21, 1 ignored = the CFnOnce-non-Clone guard); doc-tests; **MSRV 1.66 on a fresh lock**; zero-dep guard. `grep CFn[^O]` in `src/` is empty (CFn gone, CFnOnce intact).

## Migration (for downstream)

`CFn` → `RcFn` (constructors `CFn::new` → `RcFn::new`); call wrapped functions with `.call(x)` rather than `f(x)`; `CFnKind` → `RcFnKind`. `CFnOnce` is unchanged.

**Net −593 lines.** Version `0.1.1` → `0.2.0`.