### PR TITLE
feat(transformers): add StateT monad transformer + MonadState

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ plus profunctor-encoded optics. v0.1.1, MIT, edition 2021, MSRV 1.66.
 The defining design simulates **Higher-Kinded Types (HKTs)** using Generic
 Associated Types: a `Kind` trait with `type Of<Arg>` plus lightweight marker
 structs (`OptionKind`, `VecKind`, `ResultKind<E>`, `CFnKind<X>`, `CFnOnceKind<X>`,
-`RcFnKind<X>`, `IdentityKind`, `ReaderTKind`). Traits are generic over the *marker*, and
+`RcFnKind<X>`, `IdentityKind`, `ReaderTKind`, `StateTKind`). Traits are generic over the *marker*, and
 `Self::Of<A>` resolves to the concrete type (e.g. `OptionKind::Of<i32> == Option<i32>`).
 Core infrastructure lives in `src/kind_based/kind.rs`.
 
@@ -24,14 +24,20 @@ Core infrastructure lives in `src/kind_based/kind.rs`.
   (`Lens`/`Getter`/`Fold`, `_1`/`_2`/`_key`, `view`, `lcmap`/`rmap`, `Forget`).
 - `src/function.rs` — `CFn`, `RcFn`, `CFnOnce` function wrappers + composition (`>>`/`<<`).
 - `src/identity.rs` — `Identity` monad. `src/transformers/reader.rs` — `ReaderT` +
-  `MonadReader` (`ask`/`local`). `src/utils.rs` — `fn0!`..`fn3!` macros.
+  `MonadReader` (`ask`/`local`). `src/transformers/state.rs` — `StateT` +
+  `MonadState` (`state`/`get`/`put`/`modify`/`gets`) + runners
+  `run`/`eval`/`exec_state_t`. `src/utils.rs` — `fn0!`..`fn3!` macros.
 - `src/legacy/` — the older associated-type implementation, behind the `legacy`
   feature flag (kept for comparison/benchmarking; not the default).
 - `tests/{kind,legacy}/` — law-verifying test suites. `benches/compare.rs` —
   criterion benchmarks comparing kind-based vs native vs legacy.
 
 Concrete instances implementing the full hierarchy (where lawful): `Option`,
-`Result`, `Vec`, `Identity`, `CFn`, `RcFn`, `CFnOnce`, `ReaderT`.
+`Result`, `Vec`, `Identity`, `RcFn`, `CFnOnce`, `ReaderT`, `StateT`. `StateT`'s
+`Apply`/`Bind`/`Monad` require the **inner** monad to be `Bind`/`Monad` (state is
+threaded — a sequential dependency), unlike `ReaderT` whose `Apply` needs only an
+inner `Apply`; its four `MonadState` laws (get-get, get-put, put-get, put-put) are
+first-class and law-tested.
 
 ## Conventions
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,15 +38,18 @@ pub use functor::Functor; // Points to functor::kind::Functor
 pub use monad::{Bind, Monad}; // Points to monad::kind::Bind and monad::kind::Monad
 pub use profunctor::{Choice, Profunctor, Strong};
 pub use transformers::reader::MonadReader; // Points to transformers::reader::kind::MonadReader
+pub use transformers::state::MonadState; // Points to transformers::state::kind::MonadState
 
 // Public re-exports of key structs/types (optional, but can be convenient)
 pub use function::{CFnOnce, RcFn};
 pub use identity::Identity; // Points to identity::kind::Identity
 pub use transformers::reader::{Reader, ReaderT}; // Points to transformers::reader::kind::ReaderT etc.
+pub use transformers::state::{State, StateT}; // Points to transformers::state::kind::StateT etc.
 
 // Re-export Kind markers and core Kind traits by default
 pub use crate::identity::IdentityKind; // Changed from IdentityHKTMarker
 pub use crate::transformers::reader::ReaderTKind;
+pub use crate::transformers::state::StateTKind;
 pub use kind_based::kind::{
     CFnOnceKind,
     Kind,

--- a/src/transformers/mod.rs
+++ b/src/transformers/mod.rs
@@ -1,3 +1,4 @@
 //! Monad transformers.
 
 pub mod reader;
+pub mod state;

--- a/src/transformers/state.rs
+++ b/src/transformers/state.rs
@@ -1,0 +1,459 @@
+//! # StateT Monad Transformer for the `monadify` library
+// Kind-based version is the default (mirrors `reader.rs`).
+
+pub mod kind {
+    //! # Kind-based StateT Monad Transformer
+    //!
+    //! This module provides the Kind-based implementation of the `StateT` monad
+    //! transformer. `StateT` (State Transformer) threads a **mutable state** of
+    //! type `S` through an underlying monad (`MKind`, a Kind marker).
+    //!
+    //! A computation `StateT<S, MKind, A>` is a function
+    //! `S -> MKind::Of<(A, S)>`: given a starting state it produces, inside the
+    //! inner monad, a pair `(value, new_state)`.
+    //!
+    //! ## Relationship to [`ReaderT`](crate::transformers::reader)
+    //!
+    //! `StateT` mirrors `ReaderT`'s structure, but **threads** state rather than
+    //! broadcasting a read-only environment. This causes four deliberate
+    //! divergences from `ReaderT`:
+    //!
+    //! 1. **Inner `Bind`/`Monad`, not just `Apply`.** [`apply`](apply_kind::Apply::apply),
+    //!    [`bind`](monad_kind::Bind::bind), and [`join`](monad_kind::Monad::join)
+    //!    require the **inner** `MKind` to be `Bind`/`Monad`, because step *n+1*
+    //!    depends on the state produced by step *n* — a genuine sequential data
+    //!    dependency. `ReaderT::apply` needs only an inner `Apply` (the
+    //!    environment is broadcast read-only).
+    //! 2. **Every inner bound is over the pair `(A, S)`**, never bare `A`.
+    //! 3. [`apply`](apply_kind::Apply::apply) additionally requires `A: Clone`
+    //!    (the argument value is produced inside the inner monad and must be
+    //!    duplicated to feed the function).
+    //! 4. **Three runners** — [`run_state_t`](StateT::run_state_t) (the raw
+    //!    field), [`eval_state_t`](StateT::eval_state_t) (value only), and
+    //!    [`exec_state_t`](StateT::exec_state_t) (final state only).
+    //!
+    //! The tuple order is `(A, S) = (value, new_state)`; it is fixed and never
+    //! reordered (transposing silently breaks the monad and `MonadState` laws).
+    //!
+    //! ## Key Components
+    //! - [`StateT<S, MKind, A>`]: the computation `S -> MKind::Of<(A, S)>`.
+    //! - [`StateTKind<S, MKind>`]: the Kind marker for `StateT`.
+    //! - [`MonadState<S, A, MKind>`]: a trait providing `state`, `get`, `put`,
+    //!   `modify`, and `gets`.
+    //! - [`State<S, A>`]: alias for `StateT<S, IdentityKind, A>` (the plain State monad).
+    //!
+    //! ## Example
+    //! ```
+    //! use monadify::transformers::state::{State, StateT, StateTKind, MonadState};
+    //! use monadify::IdentityKind;
+    //! use monadify::Identity;
+    //! use monadify::applicative::kind::Applicative;
+    //! use monadify::monad::kind::Bind;
+    //!
+    //! type Counter<A> = State<i32, A>;            // StateT<i32, IdentityKind, A>
+    //! type CounterKind = StateTKind<i32, IdentityKind>;
+    //!
+    //! // `state`: a pure state transition. Return the old value, increment the state.
+    //! let tick: Counter<i32> =
+    //!     <CounterKind as MonadState<i32, i32, IdentityKind>>::state(|s| (s, s + 1));
+    //! let Identity((v, s)) = (tick.run_state_t)(10);
+    //! assert_eq!((v, s), (10, 11));
+    //!
+    //! // `get` then `put`: read the state, store `x + 5`, return the original `x`.
+    //! let prog: Counter<i32> = CounterKind::bind(
+    //!     <CounterKind as MonadState<i32, i32, IdentityKind>>::get(),
+    //!     |x| {
+    //!         CounterKind::bind(
+    //!             <CounterKind as MonadState<i32, (), IdentityKind>>::put(x + 5),
+    //!             move |_| CounterKind::pure(x),
+    //!         )
+    //!     },
+    //! );
+    //! let Identity((v, s)) = (prog.run_state_t)(1);
+    //! assert_eq!((v, s), (1, 6));
+    //!
+    //! // Runners: project just the value or just the final state.
+    //! let again: Counter<i32> =
+    //!     <CounterKind as MonadState<i32, i32, IdentityKind>>::state(|s| (s * 2, s + 100));
+    //! assert_eq!(again.clone().eval_state_t(3), Identity(6));
+    //! assert_eq!(again.exec_state_t(3), Identity(103));
+    //! ```
+
+    use crate::applicative::kind as applicative_kind;
+    use crate::apply::kind as apply_kind;
+    use crate::function::RcFn; // Apply's function container (CFn removed in 0.2.0).
+    use crate::functor::kind as functor_kind;
+    use crate::identity::kind::IdentityKind;
+    use crate::kind_based::kind::{Kind, Kind1};
+    use crate::monad::kind as monad_kind;
+    use std::marker::PhantomData;
+    use std::rc::Rc;
+
+    /// The `StateT` monad transformer for Kind-encoded types.
+    ///
+    /// `StateT<S, MKind, A>` is a computation that takes a state `S` and yields,
+    /// inside the inner monad `MKind`, a pair `(A, S)` — the produced value and
+    /// the new state. The computation is stored in [`run_state_t`](Self::run_state_t),
+    /// a function `S -> MKind::Of<(A, S)>`.
+    ///
+    /// # Type Parameters
+    /// - `S`: the threaded state type.
+    /// - `MKind`: the Kind marker for the inner monad (must implement [`Kind1`]).
+    /// - `A`: the value produced alongside the new state.
+    #[derive(Clone)]
+    pub struct StateT<S, MKind: Kind1, A> {
+        /// The core computation: `S -> MKind::Of<(A, S)>` (value-then-new-state).
+        // The boxed-`Fn` carrier is inherent to the encoding (mirrors ReaderT).
+        #[allow(clippy::type_complexity)]
+        pub run_state_t: Rc<dyn Fn(S) -> MKind::Of<(A, S)> + 'static>,
+        _phantom_s: PhantomData<S>,
+        _phantom_m_kind: PhantomData<MKind>,
+        _phantom_a: PhantomData<A>,
+    }
+
+    impl<S, MKind: Kind1, A> StateT<S, MKind, A> {
+        /// Creates a new `StateT` from a function `S -> MKind::Of<(A, S)>`.
+        pub fn new<F>(f: F) -> Self
+        where
+            F: Fn(S) -> MKind::Of<(A, S)> + 'static,
+        {
+            StateT {
+                run_state_t: Rc::new(f),
+                _phantom_s: PhantomData,
+                _phantom_m_kind: PhantomData,
+                _phantom_a: PhantomData,
+            }
+        }
+    }
+
+    /// The Kind marker for `StateT<S, MKind, _>`.
+    ///
+    /// Used to implement [`Functor`](functor_kind::Functor),
+    /// [`Apply`](apply_kind::Apply), [`Applicative`](applicative_kind::Applicative),
+    /// [`Bind`](monad_kind::Bind), and [`Monad`](monad_kind::Monad) for the
+    /// `StateT` type constructor.
+    ///
+    /// # Type Parameters
+    /// - `S`: the state type.
+    /// - `MKind`: the Kind marker for the inner monad.
+    #[derive(Default)]
+    pub struct StateTKind<S, MKind: Kind1>(PhantomData<(S, MKind)>);
+
+    impl<S, MKind: Kind1> Kind for StateTKind<S, MKind> {
+        type Of<A> = StateT<S, MKind, A>;
+    }
+    // Kind1 is provided by the blanket impl in kind_based/kind.rs.
+
+    /// A type alias for `StateT` with [`IdentityKind`] as the inner monad.
+    /// This is the plain State monad: `State<S, A>` is a computation
+    /// `S -> Identity<(A, S)>`.
+    pub type State<S, A> = StateT<S, IdentityKind, A>;
+
+    // --- Kind Trait Implementations for StateTKind ---
+
+    impl<S, MKind, A, B> functor_kind::Functor<A, B> for StateTKind<S, MKind>
+    where
+        S: Clone + 'static,
+        MKind: functor_kind::Functor<(A, S), (B, S)> + Kind1 + 'static,
+        A: 'static,
+        B: 'static,
+        MKind::Of<(A, S)>: 'static,
+        MKind::Of<(B, S)>: 'static,
+    {
+        /// Maps `A -> B` over the produced value, threading the state unchanged.
+        /// The mapping happens within the inner monad `MKind`.
+        fn map(
+            input: StateT<S, MKind, A>,
+            func: impl FnMut(A) -> B + Clone + 'static,
+        ) -> StateT<S, MKind, B> {
+            let run = input.run_state_t.clone();
+            StateT::new(move |s: S| {
+                let m_pair = run(s); // MKind::Of<(A, S)>
+                let mut f = func.clone();
+                MKind::map(m_pair, move |(a, s2)| (f(a), s2))
+            })
+        }
+    }
+
+    impl<S, MKind, T> applicative_kind::Applicative<T> for StateTKind<S, MKind>
+    where
+        S: Clone + 'static,
+        T: Clone + 'static,
+        // `Applicative<T>: Apply<T, T>`, so the full `Apply<T, T>` bound set is
+        // dragged in here (auto-satisfied for every concrete inner monad).
+        MKind: functor_kind::Functor<(T, S), (T, S)>
+            + monad_kind::Bind<(T, S), (T, S)>
+            + monad_kind::Bind<(RcFn<T, T>, S), (T, S)>
+            + applicative_kind::Applicative<(T, S)>
+            + Kind1
+            + 'static,
+        MKind::Of<(T, S)>: 'static,
+        MKind::Of<(RcFn<T, T>, S)>: 'static,
+    {
+        /// Lifts a value `T` into `StateT`, threading the incoming state
+        /// unchanged: `s -> MKind::pure((value, s))`.
+        fn pure(value: T) -> StateT<S, MKind, T> {
+            StateT::new(move |s: S| MKind::pure((value.clone(), s)))
+        }
+    }
+
+    impl<S, MKind, A, B> apply_kind::Apply<A, B> for StateTKind<S, MKind>
+    where
+        S: Clone + 'static,
+        A: Clone + 'static, // DIVERGENCE 3: value is duplicated to feed the function.
+        B: 'static,
+        // `Apply<A, B>: Functor<A, B>` (the Functor bound), plus the inner-`Bind`
+        // bounds the state-threaded `apply` body needs.
+        MKind: functor_kind::Functor<(A, S), (B, S)>
+            + monad_kind::Bind<(A, S), (B, S)>
+            + monad_kind::Bind<(RcFn<A, B>, S), (B, S)>
+            + applicative_kind::Applicative<(B, S)>
+            + Kind1
+            + 'static,
+        MKind::Of<(A, S)>: 'static,
+        MKind::Of<(B, S)>: 'static,
+        MKind::Of<(RcFn<A, B>, S)>: 'static,
+    {
+        /// Applies a wrapped function to a wrapped value, threading state
+        /// sequentially: run the value computation (`s -> s1`), then the
+        /// function computation (`s1 -> s2`), then `pure` the applied result.
+        ///
+        /// Because state must be threaded, `apply` is derived from the inner
+        /// monad's `bind`/`pure` (not its `apply`) — hence the inner `Bind`
+        /// bounds. The function container is [`RcFn`].
+        fn apply(
+            value_container: StateT<S, MKind, A>,
+            function_container: StateT<S, MKind, RcFn<A, B>>,
+        ) -> StateT<S, MKind, B> {
+            let value_run = value_container.run_state_t.clone();
+            let func_run = function_container.run_state_t.clone();
+            StateT::new(move |s: S| {
+                let func_run = func_run.clone();
+                // 1. run the value computation: s -> (a, s1)
+                <MKind as monad_kind::Bind<(A, S), (B, S)>>::bind(value_run(s), move |(a, s1)| {
+                    let func_run = func_run.clone();
+                    // 2. run the function computation from s1: s1 -> (g, s2)
+                    <MKind as monad_kind::Bind<(RcFn<A, B>, S), (B, S)>>::bind(
+                        func_run(s1),
+                        move |(g, s2)| MKind::pure((g.call(a.clone()), s2)), // 3. apply, thread s2
+                    )
+                })
+            })
+        }
+    }
+
+    impl<S, MKind, A, B> monad_kind::Bind<A, B> for StateTKind<S, MKind>
+    where
+        S: Clone + 'static,
+        A: Clone + 'static, // inherited via the `Bind<A, B>: Apply<A, B>` supertrait.
+        B: 'static,
+        // `Bind<A, B>: Apply<A, B>`, so the full `Apply<A, B>` bound set is dragged
+        // in here on top of the `Bind<(A, S), (B, S)>` the `bind` body uses.
+        MKind: functor_kind::Functor<(A, S), (B, S)>
+            + monad_kind::Bind<(A, S), (B, S)>
+            + monad_kind::Bind<(RcFn<A, B>, S), (B, S)>
+            + applicative_kind::Applicative<(B, S)>
+            + Kind1
+            + 'static,
+        MKind::Of<(A, S)>: 'static,
+        MKind::Of<(B, S)>: 'static,
+        MKind::Of<(RcFn<A, B>, S)>: 'static,
+    {
+        /// Sequentially composes a `StateT` with a function producing the next
+        /// `StateT`, **threading the state**: the first computation's output
+        /// state `s1` is fed to the computation produced by `func`.
+        fn bind(
+            input: StateT<S, MKind, A>,
+            func: impl FnMut(A) -> StateT<S, MKind, B> + Clone + 'static,
+        ) -> StateT<S, MKind, B> {
+            let run = input.run_state_t.clone();
+            StateT::new(move |s: S| {
+                let mut f = func.clone();
+                MKind::bind(run(s), move |(a, s1)| {
+                    let next: StateT<S, MKind, B> = f(a);
+                    (next.run_state_t)(s1)
+                })
+            })
+        }
+    }
+
+    impl<S, MKind, A> monad_kind::Monad<A> for StateTKind<S, MKind>
+    where
+        S: Clone + 'static,
+        A: Clone + 'static,
+        // `Monad<A>: Applicative<A>: Apply<A, A>`, so the full `Apply<A, A>` bound
+        // set is dragged in, plus the `Bind<(StateT<…>, S), (A, S)>` `join` uses.
+        MKind: functor_kind::Functor<(A, S), (A, S)>
+            + monad_kind::Bind<(A, S), (A, S)>
+            + monad_kind::Bind<(RcFn<A, A>, S), (A, S)>
+            + applicative_kind::Applicative<(A, S)>
+            + monad_kind::Bind<(StateT<S, MKind, A>, S), (A, S)>
+            + Kind1
+            + 'static,
+        MKind::Of<(A, S)>: 'static,
+        MKind::Of<(RcFn<A, A>, S)>: 'static,
+        MKind::Of<(StateT<S, MKind, A>, S)>: 'static,
+    {
+        /// Flattens a nested `StateT<S, MKind, StateT<S, MKind, A>>`: run the
+        /// outer computation to obtain the inner one and the threaded state
+        /// `s1`, then run the inner computation from `s1`.
+        fn join(mma: StateT<S, MKind, StateT<S, MKind, A>>) -> StateT<S, MKind, A> {
+            StateT::new(move |s: S| {
+                <MKind as monad_kind::Bind<(StateT<S, MKind, A>, S), (A, S)>>::bind(
+                    (mma.run_state_t)(s),
+                    move |(inner, s1)| (inner.run_state_t)(s1),
+                )
+            })
+        }
+    }
+
+    // --- Runners (value / state projections) ---
+
+    impl<S, MKind: Kind1, A> StateT<S, MKind, A> {
+        /// Runs the computation and keeps only the produced value, discarding
+        /// the final state: `MKind::Of<A>` (inner `Functor`, projecting `fst`).
+        pub fn eval_state_t(self, s: S) -> MKind::Of<A>
+        where
+            S: Clone + 'static,
+            A: 'static,
+            MKind: functor_kind::Functor<(A, S), A> + 'static,
+            MKind::Of<(A, S)>: 'static,
+        {
+            MKind::map((self.run_state_t)(s), |(a, _s)| a)
+        }
+
+        /// Runs the computation and keeps only the final state, discarding the
+        /// value: `MKind::Of<S>` (inner `Functor`, projecting `snd`).
+        pub fn exec_state_t(self, s: S) -> MKind::Of<S>
+        where
+            S: Clone + 'static,
+            A: 'static,
+            MKind: functor_kind::Functor<(A, S), S> + 'static,
+            MKind::Of<(A, S)>: 'static,
+        {
+            MKind::map((self.run_state_t)(s), |(_a, s2)| s2)
+        }
+    }
+
+    /// Trait for monads that thread a mutable state `S`.
+    ///
+    /// The analog of [`MonadReader`](crate::transformers::reader::MonadReader)
+    /// for state. The primitive is [`state`](Self::state); the rest derive from
+    /// it. Every operation ends in a single `MKind::pure(...)`, so each needs
+    /// only the inner [`Applicative`](applicative_kind::Applicative) bound — no
+    /// inner `Bind`/`Monad` is required for the `MonadState` surface itself.
+    ///
+    /// # Type Parameters
+    /// - `S`: the state type.
+    /// - `A`: the value type produced by [`state`](Self::state)/[`gets`](Self::gets).
+    /// - `MKind`: the Kind marker for the inner monad.
+    pub trait MonadState<S, A, MKind: Kind1>
+    where
+        Self: Sized,
+    {
+        /// Embeds a pure state transition `S -> (A, S)`. The primitive from which
+        /// `get`/`put`/`modify`/`gets` derive.
+        fn state<F>(f: F) -> StateT<S, MKind, A>
+        where
+            S: Clone + 'static,
+            A: 'static,
+            MKind: applicative_kind::Applicative<(A, S)> + 'static,
+            MKind::Of<(A, S)>: 'static,
+            F: Fn(S) -> (A, S) + 'static;
+
+        /// Reads the whole state as the value, leaving it unchanged: `s -> (s, s)`.
+        fn get() -> StateT<S, MKind, S>
+        where
+            S: Clone + 'static,
+            MKind: applicative_kind::Applicative<(S, S)> + 'static,
+            MKind::Of<(S, S)>: 'static;
+
+        /// Replaces the state, returning unit: `_ -> ((), new_state)`.
+        fn put(new_state: S) -> StateT<S, MKind, ()>
+        where
+            S: Clone + 'static,
+            MKind: applicative_kind::Applicative<((), S)> + 'static,
+            MKind::Of<((), S)>: 'static;
+
+        /// Applies `f` to the state, returning unit: `s -> ((), f(s))`.
+        fn modify<F>(f: F) -> StateT<S, MKind, ()>
+        where
+            S: Clone + 'static,
+            MKind: applicative_kind::Applicative<((), S)> + 'static,
+            MKind::Of<((), S)>: 'static,
+            F: Fn(S) -> S + 'static;
+
+        /// Projects the state through `f` as the value, leaving the state
+        /// unchanged: `s -> (f(s), s)`.
+        fn gets<F, B>(f: F) -> StateT<S, MKind, B>
+        where
+            S: Clone + 'static,
+            B: 'static,
+            MKind: applicative_kind::Applicative<(B, S)> + 'static,
+            MKind::Of<(B, S)>: 'static,
+            F: Fn(S) -> B + 'static;
+    }
+
+    impl<S, MKindImpl, A> MonadState<S, A, MKindImpl> for StateTKind<S, MKindImpl>
+    where
+        S: 'static,
+        A: 'static,
+        MKindImpl: Kind1 + 'static,
+    {
+        fn state<F>(f: F) -> StateT<S, MKindImpl, A>
+        where
+            S: Clone + 'static,
+            A: 'static,
+            MKindImpl: applicative_kind::Applicative<(A, S)> + 'static,
+            MKindImpl::Of<(A, S)>: 'static,
+            F: Fn(S) -> (A, S) + 'static,
+        {
+            StateT::new(move |s: S| {
+                let (a, s2) = f(s);
+                MKindImpl::pure((a, s2))
+            })
+        }
+
+        fn get() -> StateT<S, MKindImpl, S>
+        where
+            S: Clone + 'static,
+            MKindImpl: applicative_kind::Applicative<(S, S)> + 'static,
+            MKindImpl::Of<(S, S)>: 'static,
+        {
+            StateT::new(move |s: S| MKindImpl::pure((s.clone(), s)))
+        }
+
+        fn put(new_state: S) -> StateT<S, MKindImpl, ()>
+        where
+            S: Clone + 'static,
+            MKindImpl: applicative_kind::Applicative<((), S)> + 'static,
+            MKindImpl::Of<((), S)>: 'static,
+        {
+            StateT::new(move |_s: S| MKindImpl::pure(((), new_state.clone())))
+        }
+
+        fn modify<F>(f: F) -> StateT<S, MKindImpl, ()>
+        where
+            S: Clone + 'static,
+            MKindImpl: applicative_kind::Applicative<((), S)> + 'static,
+            MKindImpl::Of<((), S)>: 'static,
+            F: Fn(S) -> S + 'static,
+        {
+            StateT::new(move |s: S| MKindImpl::pure(((), f(s))))
+        }
+
+        fn gets<F, B>(f: F) -> StateT<S, MKindImpl, B>
+        where
+            S: Clone + 'static,
+            B: 'static,
+            MKindImpl: applicative_kind::Applicative<(B, S)> + 'static,
+            MKindImpl::Of<(B, S)>: 'static,
+            F: Fn(S) -> B + 'static,
+        {
+            StateT::new(move |s: S| MKindImpl::pure((f(s.clone()), s)))
+        }
+    }
+}
+
+// Directly export Kind-based versions
+pub use kind::{MonadState, State, StateT, StateTKind};

--- a/tests/kind/do_notation/mod.rs
+++ b/tests/kind/do_notation/mod.rs
@@ -22,4 +22,5 @@ pub mod laws;
 pub mod option;
 pub mod reader;
 pub mod result;
+pub mod state;
 pub mod vec;

--- a/tests/kind/do_notation/state.rs
+++ b/tests/kind/do_notation/state.rs
@@ -1,0 +1,136 @@
+//! `mdo!` do-block tests for `StateTKind` (the State monad: threading a mutable state).
+//!
+//! Gated by the parent `do_notation` module's `#![cfg(feature = "do-notation")]`.
+//!
+//! ## What we test
+//!
+//! The "real power" of State is that a single state value is silently threaded —
+//! and updated — through every step. These tests use `State<i32, A>`
+//! (`StateT<i32, IdentityKind, A>`) so each run value is `Identity<(A, i32)>` and
+//! the focus is purely on state threading.
+//!
+//! 1. **State threading** — `get`/`put` steps in a do-block thread the updated
+//!    state forward; the final `(value, state)` reflects every write.
+//! 2. **Equivalence** — the `mdo!` block produces identical `(value, state)` to a
+//!    hand-written nested `bind` chain (closures can't be compared, so we compare
+//!    by *running* both against the same `s0`).
+//! 3. **Deeper chains** — depth > 2 confirms the desugaring.
+//! 4. **proptest** — `mdo!` vs hand-written `bind`, run-and-compared across
+//!    generated initial states.
+//!
+//! `guard` is intentionally absent: `StateT` has no lawful zero, so a `guard`
+//! inside a State do-block is a deliberate compile error (same as Reader).
+//! `StateT` is `Rc<dyn Fn> + #[derive(Clone)]`; the `.clone()` the macro emits is
+//! a cheap reference-count bump.
+
+use monadify::applicative::kind::Applicative;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::monad::kind::Bind;
+use monadify::transformers::state::{MonadState, State, StateTKind};
+use proptest::prelude::*;
+
+type StKind = StateTKind<i32, IdentityKind>;
+type Counter<A> = State<i32, A>;
+
+fn get() -> Counter<i32> {
+    <StKind as MonadState<i32, i32, IdentityKind>>::get()
+}
+fn put(s: i32) -> Counter<()> {
+    <StKind as MonadState<i32, (), IdentityKind>>::put(s)
+}
+fn run_id<A>(st: Counter<A>, s0: i32) -> (A, i32) {
+    let Identity(pair) = (st.run_state_t)(s0);
+    pair
+}
+
+// ── 1. State threading in a do-block ─────────────────────────────────────────
+
+#[test]
+fn state_mdo_threads_and_updates() {
+    let comp: Counter<i32> = mdo! {
+        StKind;
+        x <- get();
+        _ <- put(x + 1);
+        y <- get();
+        StKind::pure(x + y)
+    };
+    // s0 = 10: x = 10, state -> 11, y = 11, result = 21, final state = 11.
+    assert_eq!(run_id(comp, 10), (21, 11));
+}
+
+#[test]
+fn state_mdo_uses_modify() {
+    let comp: Counter<i32> = mdo! {
+        StKind;
+        _ <- <StKind as MonadState<i32, (), IdentityKind>>::modify(|s| s * 2);
+        x <- get();
+        StKind::pure(x + 1)
+    };
+    // s0 = 5: state -> 10, x = 10, result = 11, final state = 10.
+    assert_eq!(run_id(comp, 5), (11, 10));
+}
+
+// ── 2. Equivalence with a hand-written bind chain ────────────────────────────
+
+#[test]
+fn state_mdo_equivalent_to_manual_bind() {
+    let via_mdo: Counter<i32> = mdo! {
+        StKind;
+        x <- get();
+        _ <- put(x + 1);
+        y <- get();
+        StKind::pure(x + y)
+    };
+
+    let via_bind: Counter<i32> = StKind::bind(get(), |x| {
+        StKind::bind(put(x + 1), move |_| {
+            StKind::bind(get(), move |y| StKind::pure(x + y))
+        })
+    });
+
+    for s0 in [-5, 0, 3, 10, 100] {
+        assert_eq!(run_id(via_mdo.clone(), s0), run_id(via_bind.clone(), s0));
+    }
+}
+
+// ── 3. Deeper chain (depth > 2) ──────────────────────────────────────────────
+
+#[test]
+fn state_mdo_four_binding_chain() {
+    let comp: Counter<i32> = mdo! {
+        StKind;
+        a <- get();
+        _ <- put(a + 1);
+        b <- get();
+        _ <- put(b + 1);
+        c <- get();
+        StKind::pure(a + b + c)
+    };
+    // s0 = 0: a=0 -> s1; put1 -> s=1; b=1 -> ; put2 -> s=2; c=2; result=0+1+2=3, state=2.
+    assert_eq!(run_id(comp, 0), (3, 2));
+}
+
+// ── 4. proptest: mdo! == manual bind, run-and-compared ───────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    #[test]
+    fn state_mdo_matches_manual_over_generated_states(s0 in any::<i32>(), d in any::<i32>()) {
+        let via_mdo: Counter<i32> = mdo! {
+            StKind;
+            x <- get();
+            _ <- <StKind as MonadState<i32, (), IdentityKind>>::modify(move |s| s.wrapping_add(d));
+            y <- get();
+            StKind::pure(x.wrapping_add(y))
+        };
+        let via_bind: Counter<i32> = StKind::bind(get(), move |x| {
+            StKind::bind(
+                <StKind as MonadState<i32, (), IdentityKind>>::modify(move |s| s.wrapping_add(d)),
+                move |_| StKind::bind(get(), move |y| StKind::pure(x.wrapping_add(y))),
+            )
+        });
+        prop_assert_eq!(run_id(via_mdo, s0), run_id(via_bind, s0));
+    }
+}

--- a/tests/kind/proptest_laws/mod.rs
+++ b/tests/kind/proptest_laws/mod.rs
@@ -19,6 +19,7 @@ pub mod apply;
 pub mod functor;
 pub mod monad;
 pub mod rcfn;
+pub mod state;
 
 // --- Arbitrary strategies (reusable across the law-family modules) ---
 

--- a/tests/kind/proptest_laws/state.rs
+++ b/tests/kind/proptest_laws/state.rs
@@ -1,0 +1,143 @@
+//! Property-based (`proptest`) law tests for `StateTKind` (the State transformer).
+//!
+//! Companion to the example-based tests in
+//! `tests/kind/transformers/state.rs`. `StateT` is function-typed and has no
+//! structural `Eq`, so — like `ReaderT` — laws are verified **observationally**:
+//! run the two sides against the same generated initial state `s0` and compare
+//! the produced `(value, final_state)` pair.
+//!
+//! Covers the three Monad laws and the four `MonadState` laws over
+//! `StateTKind<i32, IdentityKind>`, with the threaded Kleisli arrows
+//! materialized from generated `linear_fn` slope/intercept parameters (rebuilt
+//! fresh per use; `wrapping_*` arithmetic avoids overflow panics).
+
+use super::linear_fn;
+use monadify::applicative::kind::Applicative;
+use monadify::functor::kind::Functor;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::monad::kind::Bind;
+use monadify::transformers::state::{MonadState, State, StateTKind};
+use proptest::prelude::*;
+
+type S<A> = State<i32, A>;
+type SKind = StateTKind<i32, IdentityKind>;
+
+fn run(st: S<i32>, s0: i32) -> (i32, i32) {
+    let Identity(pair) = (st.run_state_t)(s0);
+    pair
+}
+fn run_unit(st: S<()>, s0: i32) -> ((), i32) {
+    let Identity(pair) = (st.run_state_t)(s0);
+    pair
+}
+fn get() -> S<i32> {
+    <SKind as MonadState<i32, i32, IdentityKind>>::get()
+}
+fn put(s: i32) -> S<()> {
+    <SKind as MonadState<i32, (), IdentityKind>>::put(s)
+}
+/// A threaded Kleisli arrow: maps the value by a linear fn and bumps the state.
+fn arrow(slope: i32, intercept: i32, ds: i32) -> impl Fn(i32) -> S<i32> + Clone {
+    move |x: i32| {
+        let mut lf = linear_fn(slope, intercept);
+        let v = lf(x);
+        <SKind as MonadState<i32, i32, IdentityKind>>::state(move |s: i32| (v, s.wrapping_add(ds)))
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    // --- Monad laws (threaded) ---
+
+    /// Left identity: `bind(pure(a), f) == f(a)`.
+    #[test]
+    fn state_monad_left_identity(a in any::<i32>(), s0 in any::<i32>(),
+                                 (sl, ic) in (any::<i32>(), any::<i32>()), ds in any::<i32>()) {
+        let f = arrow(sl, ic, ds);
+        let lhs = SKind::bind(SKind::pure(a), f.clone());
+        let rhs = f(a);
+        prop_assert_eq!(run(lhs, s0), run(rhs, s0));
+    }
+
+    /// Right identity: `bind(m, pure) == m`.
+    #[test]
+    fn state_monad_right_identity(s0 in any::<i32>(), ds in any::<i32>()) {
+        let lhs = SKind::bind(
+            <SKind as MonadState<i32, i32, IdentityKind>>::state(move |s: i32| (s, s.wrapping_add(ds))),
+            SKind::pure,
+        );
+        let rhs = <SKind as MonadState<i32, i32, IdentityKind>>::state(move |s: i32| (s, s.wrapping_add(ds)));
+        prop_assert_eq!(run(lhs, s0), run(rhs, s0));
+    }
+
+    /// Associativity: `bind(bind(m, f), g) == bind(m, |x| bind(f(x), g))`.
+    #[test]
+    fn state_monad_associativity(s0 in any::<i32>(),
+                                 (sl1, ic1, ds1) in (any::<i32>(), any::<i32>(), any::<i32>()),
+                                 (sl2, ic2, ds2) in (any::<i32>(), any::<i32>(), any::<i32>())) {
+        let f = arrow(sl1, ic1, ds1);
+        let g = arrow(sl2, ic2, ds2);
+        let m = || <SKind as MonadState<i32, i32, IdentityKind>>::state(move |s: i32| (s, s.wrapping_add(1)));
+
+        let lhs = SKind::bind(SKind::bind(m(), f.clone()), g.clone());
+        let rhs = SKind::bind(m(), move |x| SKind::bind(f(x), g.clone()));
+        prop_assert_eq!(run(lhs, s0), run(rhs, s0));
+    }
+
+    // --- MonadState laws ---
+
+    /// get-get: `get >>= \_ -> get == get`.
+    #[test]
+    fn state_get_get(s0 in any::<i32>()) {
+        let lhs = SKind::bind(get(), |_| get());
+        prop_assert_eq!(run(lhs, s0), run(get(), s0));
+    }
+
+    /// get-put: `get >>= put == pure(())`.
+    #[test]
+    fn state_get_put(s0 in any::<i32>()) {
+        let lhs = SKind::bind(get(), put);
+        let rhs: S<()> = SKind::pure(());
+        prop_assert_eq!(run_unit(lhs, s0), run_unit(rhs, s0));
+    }
+
+    /// put-get: `put(s) >> get == put(s) >> pure(s)`.
+    #[test]
+    fn state_put_get(s0 in any::<i32>(), w in any::<i32>()) {
+        let lhs = SKind::bind(put(w), move |_| get());
+        let rhs = SKind::bind(put(w), move |_| SKind::pure(w));
+        prop_assert_eq!(run(lhs, s0), run(rhs, s0));
+    }
+
+    /// put-put: `put(s1) >> put(s2) == put(s2)` (last write wins).
+    #[test]
+    fn state_put_put(s0 in any::<i32>(), w1 in any::<i32>(), w2 in any::<i32>()) {
+        let lhs = SKind::bind(put(w1), move |_| put(w2));
+        prop_assert_eq!(run_unit(lhs, s0), run_unit(put(w2), s0));
+    }
+
+    /// `gets(f) == get.map(f)` and `modify(f) == get >>= (put . f)`.
+    #[test]
+    fn state_gets_and_modify_derivations(s0 in any::<i32>(), (sl, ic) in (any::<i32>(), any::<i32>())) {
+        let gets = <SKind as MonadState<i32, i32, IdentityKind>>::gets(move |s| {
+            let mut lf = linear_fn(sl, ic);
+            lf(s)
+        });
+        let derived_gets = SKind::map(get(), move |s| {
+            let mut lf = linear_fn(sl, ic);
+            lf(s)
+        });
+        prop_assert_eq!(run(gets, s0), run(derived_gets, s0));
+
+        let modify = <SKind as MonadState<i32, (), IdentityKind>>::modify(move |s| {
+            let mut lf = linear_fn(sl, ic);
+            lf(s)
+        });
+        let derived_modify = SKind::bind(get(), move |s| {
+            let mut lf = linear_fn(sl, ic);
+            put(lf(s))
+        });
+        prop_assert_eq!(run_unit(modify, s0), run_unit(derived_modify, s0));
+    }
+}

--- a/tests/kind/transformers/mod.rs
+++ b/tests/kind/transformers/mod.rs
@@ -1,2 +1,4 @@
 #[cfg(not(feature = "legacy"))]
 pub mod reader;
+#[cfg(not(feature = "legacy"))]
+pub mod state;

--- a/tests/kind/transformers/state.rs
+++ b/tests/kind/transformers/state.rs
@@ -1,0 +1,220 @@
+//! Example-based law tests for `StateTKind` (the State monad transformer).
+//!
+//! `StateT<S, M, A> ≅ S -> M::Of<(A, S)>` has no structural `Eq` (it wraps a
+//! boxed `Fn`), so every law is verified **observationally**: run the left- and
+//! right-hand sides against the same initial state `s0` and compare the produced
+//! `(value, final_state)` pair.
+//!
+//! Coverage: Functor/Applicative/Apply/Bind/Monad smoke tests, the three Monad
+//! laws, and the four `MonadState` laws (get-get, get-put, put-get, put-put),
+//! over both `IdentityKind` (pure threading) and `OptionKind` (effectful
+//! threading + `None` short-circuit).
+
+use monadify::applicative::kind::Applicative;
+use monadify::apply::kind::Apply;
+use monadify::function::RcFn;
+use monadify::functor::kind::Functor;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::monad::kind::{Bind, Monad};
+use monadify::transformers::state::{MonadState, State, StateT, StateTKind};
+use monadify::OptionKind;
+
+// ── Identity-inner helpers (the plain State monad) ──────────────────────────
+
+type TestState<A> = State<i32, A>; // StateT<i32, IdentityKind, A>
+type TestStateKind = StateTKind<i32, IdentityKind>;
+
+/// Run a `State<i32, A>` against `s0` and unwrap the `Identity` to `(A, i32)`.
+fn run_id<A>(st: TestState<A>, s0: i32) -> (A, i32) {
+    let Identity(pair) = (st.run_state_t)(s0);
+    pair
+}
+
+/// Assert two `State<i32, A>` computations are observationally equal at `s0`.
+fn assert_eq_at<A: PartialEq + std::fmt::Debug>(l: TestState<A>, r: TestState<A>, s0: i32) {
+    assert_eq!(run_id(l, s0), run_id(r, s0));
+}
+
+fn st_state<A: 'static, F: Fn(i32) -> (A, i32) + 'static>(f: F) -> TestState<A> {
+    <TestStateKind as MonadState<i32, A, IdentityKind>>::state(f)
+}
+fn st_get() -> TestState<i32> {
+    <TestStateKind as MonadState<i32, i32, IdentityKind>>::get()
+}
+fn st_put(s: i32) -> TestState<()> {
+    <TestStateKind as MonadState<i32, (), IdentityKind>>::put(s)
+}
+
+// ── Functor / Applicative / Apply / Bind / Monad smoke tests ────────────────
+
+#[test]
+fn functor_map_threads_state_and_maps_value() {
+    // (value, state) starts (10, 5); map doubles the value, leaves state.
+    let st: TestState<i32> = st_state(|s| (10, s));
+    let mapped = TestStateKind::map(st, |v| v * 2);
+    assert_eq!(run_id(mapped, 5), (20, 5));
+}
+
+#[test]
+fn applicative_pure_ignores_then_threads_state() {
+    let st: TestState<i32> = TestStateKind::pure(42);
+    assert_eq!(run_id(st, 7), (42, 7));
+}
+
+#[test]
+fn apply_threads_state_sequentially() {
+    // value: s -> (s, s+1); function: s -> (\a. a*10, s+100)
+    let value: TestState<i32> = st_state(|s| (s, s + 1));
+    let func: TestState<RcFn<i32, i32>> = st_state(|s| (RcFn::new(|a: i32| a * 10), s + 100));
+    let applied = <TestStateKind as Apply<i32, i32>>::apply(value, func);
+    // run at 1: value -> (1, 2); func from 2 -> (\a.a*10, 102); apply -> (10, 102)
+    assert_eq!(run_id(applied, 1), (10, 102));
+}
+
+#[test]
+fn bind_threads_output_state_into_next_step() {
+    let m: TestState<i32> = st_state(|s| (s, s + 1));
+    let bound = TestStateKind::bind(m, |x| st_state(move |s| (x + s, s + 1)));
+    // run at 10: first -> (10, 11); second sees s=11 -> (10+11, 12) = (21, 12)
+    assert_eq!(run_id(bound, 10), (21, 12));
+}
+
+#[test]
+fn join_flattens_threading_state() {
+    let nested: TestState<TestState<i32>> =
+        st_state(|s| (st_state(|s2| (s2 * 2, s2 + 1)), s + 100));
+    let flat = TestStateKind::join(nested);
+    // outer at 1 -> (inner, 101); inner from 101 -> (202, 102)
+    assert_eq!(run_id(flat, 1), (202, 102));
+}
+
+// ── Monad laws (threaded f/g that both read and modify state) ────────────────
+
+#[test]
+fn monad_left_identity() {
+    // pure(a).bind(f) == f(a)
+    let f = |x: i32| st_state(move |s| (x + s, s + 1));
+    for s0 in [-3, 0, 5, 42] {
+        let lhs = TestStateKind::bind(TestStateKind::pure(9), f);
+        let rhs = f(9);
+        assert_eq_at(lhs, rhs, s0);
+    }
+}
+
+#[test]
+fn monad_right_identity() {
+    // m.bind(pure) == m
+    for s0 in [-3, 0, 5, 42] {
+        let m: TestState<i32> = st_state(|s| (s * 7, s + 2));
+        let m2: TestState<i32> = st_state(|s| (s * 7, s + 2));
+        let lhs = TestStateKind::bind(m, TestStateKind::pure);
+        assert_eq_at(lhs, m2, s0);
+    }
+}
+
+#[test]
+fn monad_associativity() {
+    // m.bind(f).bind(g) == m.bind(|x| f(x).bind(g))
+    let f = |x: i32| st_state(move |s| (x + s, s + 1));
+    let g = |y: i32| st_state(move |s| (y * 2, s + 10));
+    for s0 in [-3, 0, 5, 42] {
+        let m: TestState<i32> = st_state(|s| (s, s + 1));
+        let lhs = TestStateKind::bind(TestStateKind::bind(m, f), g);
+
+        let m2: TestState<i32> = st_state(|s| (s, s + 1));
+        let rhs = TestStateKind::bind(m2, move |x| TestStateKind::bind(f(x), g));
+        assert_eq_at(lhs, rhs, s0);
+    }
+}
+
+// ── The four MonadState laws (over IdentityKind) ─────────────────────────────
+
+#[test]
+fn monadstate_get_get() {
+    // get >>= \_ -> get  ==  get   (reading twice is reading once)
+    for s0 in [-1, 0, 13, 99] {
+        let lhs = TestStateKind::bind(st_get(), |_s| st_get());
+        assert_eq_at(lhs, st_get(), s0);
+    }
+}
+
+#[test]
+fn monadstate_get_put() {
+    // get >>= put  ==  pure(())   (writing back what you read is a no-op)
+    for s0 in [-1, 0, 13, 99] {
+        let lhs = TestStateKind::bind(st_get(), st_put);
+        let rhs: TestState<()> = TestStateKind::pure(());
+        assert_eq_at(lhs, rhs, s0);
+    }
+}
+
+#[test]
+fn monadstate_put_get() {
+    // put(s) >> get  ==  put(s) >> pure(s)   (you read back what you wrote)
+    for s0 in [-1, 0, 13, 99] {
+        let written = 7;
+        let lhs = TestStateKind::bind(st_put(written), move |_| st_get());
+        let rhs = TestStateKind::bind(st_put(written), move |_| TestStateKind::pure(written));
+        assert_eq_at(lhs, rhs, s0);
+    }
+}
+
+#[test]
+fn monadstate_put_put() {
+    // put(s1) >> put(s2)  ==  put(s2)   (last write wins)
+    for s0 in [-1, 0, 13, 99] {
+        let lhs = TestStateKind::bind(st_put(3), move |_| st_put(8));
+        assert_eq_at(lhs, st_put(8), s0);
+    }
+}
+
+#[test]
+fn modify_and_gets_derive_correctly() {
+    let modify = <TestStateKind as MonadState<i32, (), IdentityKind>>::modify(|s| s + 100);
+    // modify(f) == get.bind(|s| put(f(s)))
+    let derived_modify = TestStateKind::bind(st_get(), |s| st_put(s + 100));
+    assert_eq_at(modify, derived_modify, 5);
+
+    let gets = <TestStateKind as MonadState<i32, i32, IdentityKind>>::gets(|s| s * 3);
+    // gets(f) == get.map(f)
+    let derived_gets = TestStateKind::map(st_get(), |s| s * 3);
+    assert_eq_at(gets, derived_gets, 5);
+}
+
+// ── Effectful inner monad: OptionKind threading + None short-circuit ──────────
+
+type OptState<A> = StateT<i32, OptionKind, A>;
+type OptStateKind = StateTKind<i32, OptionKind>;
+
+fn run_opt<A>(st: OptState<A>, s0: i32) -> Option<(A, i32)> {
+    (st.run_state_t)(s0)
+}
+
+#[test]
+fn option_inner_threads_state_when_all_some() {
+    let m: OptState<i32> = <OptStateKind as MonadState<i32, i32, OptionKind>>::get();
+    let bound = OptStateKind::bind(m, |x| {
+        <OptStateKind as MonadState<i32, i32, OptionKind>>::state(move |s| (x + s, s + 1))
+    });
+    // get at 4 -> Some((4,4)); state from 4 -> Some((4+4, 5)) = Some((8,5))
+    assert_eq!(run_opt(bound, 4), Some((8, 5)));
+}
+
+#[test]
+fn option_inner_none_short_circuits() {
+    // A computation that fails inside the inner Option.
+    let failing: OptState<i32> = StateT::new(|_s: i32| None);
+    let bound = OptStateKind::bind(failing, |x| {
+        <OptStateKind as MonadState<i32, i32, OptionKind>>::state(move |s| (x, s))
+    });
+    assert_eq!(run_opt(bound, 10), None);
+}
+
+#[test]
+fn option_inner_monadstate_laws_hold() {
+    // put-put last-write-wins over OptionKind.
+    let put = |s: i32| <OptStateKind as MonadState<i32, (), OptionKind>>::put(s);
+    let lhs = OptStateKind::bind(put(3), move |_| put(8));
+    assert_eq!(run_opt(lhs.clone(), 0), run_opt(put(8), 0));
+    assert_eq!(run_opt(lhs, 0), Some(((), 8)));
+}


### PR DESCRIPTION
## Summary

Adds **`StateT<S, M, A>`** — the State monad transformer (`S -> M::Of<(A, S)>`) — as the second monad transformer in the crate, mirroring the existing `ReaderT`. It threads a mutable state `S` through an inner monad `M`, exposing a `MonadState` surface (`state`/`get`/`put`/`modify`/`gets`) analogous to `MonadReader`'s `ask`/`local`, plus runners `eval_state_t`/`exec_state_t` (`run_state_t` is the raw field).

This was produced by a research run (blueprint + ADR + compile-verified feasibility proof) and then implemented from that blueprint.

## The defining divergence from `ReaderT`

Because state is **threaded** — step *n+1*'s input state is step *n*'s output state, a genuine sequential data dependency — `StateT`'s `Apply`/`Bind`/`Monad` require the **inner** monad to be a `Bind`/`Monad`, *not* merely `Apply`/`Applicative` like `ReaderT` (which broadcasts a read-only environment). Additionally, monadify's `Functor ← Apply ← Applicative` and `Apply ← Bind` supertrait chain forces every impl from `Apply` upward to spell out the full inner-bound set (`Functor<(A,S),(B,S)> + Bind<(A,S),(B,S)> + Bind<(RcFn<A,B>,S),(B,S)> + Applicative<(B,S)>`, plus `A: Clone`). These are auto-satisfied for concrete inner monads (Option/Vec/Result/Identity), so user and test code stays clean.

## Changes

- **`src/transformers/state.rs`** (new) — `StateT`, `StateTKind`, `State<S,A>` alias, the full `Functor → Apply → Applicative → Bind → Monad` hierarchy, the `MonadState` trait + impl, and the runners. Strict-only; `S: Clone + 'static`; `RcFn` carrier (not `CFn`, removed in 0.2.0).
- **`src/lib.rs` / `src/transformers/mod.rs`** — re-exports (`State`, `StateT`, `StateTKind`, `MonadState`).
- **`CLAUDE.md`** — marker list, layout, and instances updated (also drops the stale `CFn` from the instances line).

## Tests

- `tests/kind/transformers/state.rs` — **16** example law tests: Functor/Applicative/Apply/Bind/Monad smoke tests, the 3 Monad laws, and the **4 MonadState laws** (get-get, get-put, put-get, put-put), over both `IdentityKind` (pure threading) and `OptionKind` (effectful threading + `None` short-circuit).
- `tests/kind/do_notation/state.rs` — **5** `mdo!` tests (state threading, manual-bind equivalence, depth-4 chain, run-and-compare proptest).
- `tests/kind/proptest_laws/state.rs` — **8** property-based laws (3 Monad + 4 MonadState + derivations) over `IdentityKind`.

`StateT` is `Clone` via `Rc`, so it flows through `mdo!` exactly as `ReaderT` does; `guard` is intentionally absent (no lawful zero).

## Notes

- **Additive / non-breaking** — a brand-new module; nothing existing changes behaviour.
- `lift` / a general `MonadTrans` trait are **intentionally deferred** (no consumer yet; the `MonadState` ops need only inner `Applicative`) — tracked as a follow-up for when a second transformer (`WriterT`/`ExceptT`) also wants `lift`.

## Test plan

All gates green locally:
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (default), `--features legacy`, `--features do-notation`, `--all-features`
- `cargo test --all-features --doc`
- MSRV 1.66 fresh-lock: `rm -f Cargo.lock && cargo +1.66.0 check --workspace --all-features`
- zero-dependency guard (no proc-macro deps in default features)