### PR TITLE
docs(examples): add real-world StateT examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,19 @@ required-features = ["do-notation"]
 [[example]]
 name = "list_comprehension"
 required-features = ["do-notation"]
+
+[[example]]
+name = "state_stack_machine"
+required-features = ["do-notation"]
+
+[[example]]
+name = "state_unique_id"
+required-features = ["do-notation"]
+
+[[example]]
+name = "state_rng_lcg"
+required-features = ["do-notation"]
+
+[[example]]
+name = "state_bank_account"
+required-features = ["do-notation"]

--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ assert_eq!(result, Some(5));
 
 Run with: `cargo run --example validation --features do-notation`
 
+### State monad examples
+
+These demonstrate the `StateT` State monad threading state through a computation
+via `mdo!` do-notation — each `<-` bind both reads and updates the implicit state:
+
+- `state_stack_machine.rs` — RPN / stack calculator (state = the operand stack)
+- `state_unique_id.rs` — fresh-id / gensym generator (state = a counter)
+- `state_rng_lcg.rs` — deterministic LCG pseudo-random generator (state = the seed)
+- `state_bank_account.rs` — running-balance ledger (state = the balance)
+
+Run any of them with (each requires the `do-notation` feature):
+```bash
+cargo run --example state_stack_machine --features do-notation
+cargo run --example state_unique_id    --features do-notation
+cargo run --example state_rng_lcg      --features do-notation
+cargo run --example state_bank_account --features do-notation
+```
+
 **Limitations and notes**:
 - `pure` is a reserved free-call head inside `mdo!` blocks (rewritten to `Marker::pure`); use `::pure`-qualified or `.pure()` method syntax to bypass
 - `CFn` / `CFnOnce` unsupported (not `Clone`); use `RcFn` instead for a `Clone`-able, shared-ownership function monad

--- a/examples/state_bank_account.rs
+++ b/examples/state_bank_account.rs
@@ -1,0 +1,124 @@
+//! Do-notation with State monad: running-balance ledger example.
+//!
+//! Demonstrates the State monad (`StateT<S, IdentityKind, A>`) as a
+//! running-balance bank account. The state `i64` is a balance in cents;
+//! `deposit` and `withdraw` update it via `modify`, while `balance` reads it
+//! via `get`. The `mdo!` block threads the state implicitly — no explicit
+//! passing required.
+//!
+//! Run with: `cargo run --example state_bank_account --features do-notation`
+
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::transformers::state::{MonadState, State, StateTKind};
+
+/// Type alias: a computation that threads an `i64` balance (in cents) and
+/// returns an `Identity<A>`. `State<S, A> = StateT<S, IdentityKind, A>`.
+type Account<A> = State<i64, A>;
+
+/// Kind marker alias for the `mdo!` macro: `StateTKind<i64, IdentityKind>`.
+type SKind = StateTKind<i64, IdentityKind>;
+
+// ── Ledger primitives ────────────────────────────────────────────────────────
+
+/// Deposits `cents` into the account (increases the balance).
+fn deposit(cents: i64) -> Account<()> {
+    <SKind as MonadState<i64, (), IdentityKind>>::modify(move |b| b + cents)
+}
+
+/// Withdraws `cents` from the account (decreases the balance).
+fn withdraw(cents: i64) -> Account<()> {
+    <SKind as MonadState<i64, (), IdentityKind>>::modify(move |b| b - cents)
+}
+
+/// Reads the current balance without modifying it.
+fn balance() -> Account<i64> {
+    <SKind as MonadState<i64, i64, IdentityKind>>::get()
+}
+
+// ── The ledger computation ───────────────────────────────────────────────────
+
+/// A multi-step ledger session that returns `(mid, fin)`:
+/// - `mid`: balance after the two deposits (before the withdrawal)
+/// - `fin`: balance after the withdrawal
+fn run_ledger() -> Account<(i64, i64)> {
+    mdo! {
+        SKind;
+        _ <- deposit(10000);
+        _ <- deposit(2550);
+        mid <- balance();
+        _ <- withdraw(4000);
+        fin <- balance();
+        pure((mid, fin))
+    }
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+fn main() {
+    println!("=== Do-notation with State monad: Bank Account Ledger ===\n");
+
+    let comp = run_ledger();
+
+    // eval_state_t: run and keep only the produced value, discard final state.
+    let Identity((mid, fin)) = comp.clone().eval_state_t(0);
+
+    // exec_state_t: run and keep only the final threaded state.
+    let Identity(final_state) = comp.clone().exec_state_t(0);
+
+    // run_state_t: run and keep both value and final state.
+    let Identity((pair_val, pair_state)) = (comp.run_state_t)(0);
+
+    println!("Initial balance:              $0.00");
+    println!("After deposit  $100.00:       ${:.2}", 10000_f64 / 100.0);
+    println!(
+        "After deposit  $25.50:        ${:.2}",
+        (10000 + 2550) as f64 / 100.0
+    );
+    println!(
+        "Intermediate balance (mid):   ${:.2}  ({} cents)",
+        mid as f64 / 100.0,
+        mid
+    );
+    println!(
+        "After withdraw $40.00:        ${:.2}",
+        (mid - 4000) as f64 / 100.0
+    );
+    println!(
+        "Final balance (fin):          ${:.2}  ({} cents)",
+        fin as f64 / 100.0,
+        fin
+    );
+    println!(
+        "exec_state_t final state:     ${:.2}  ({} cents)",
+        final_state as f64 / 100.0,
+        final_state
+    );
+    println!();
+
+    // ── Assertions ───────────────────────────────────────────────────────────
+
+    assert_eq!(
+        mid, 12550,
+        "intermediate balance after two deposits must be 12550 cents ($125.50)"
+    );
+    assert_eq!(
+        fin, 8550,
+        "final balance after withdrawal must be 8550 cents ($85.50)"
+    );
+    assert_eq!(
+        final_state, 8550,
+        "exec_state_t final state must match the read balance value"
+    );
+
+    // run_state_t returns the same value and state together.
+    assert_eq!(pair_val, (mid, fin));
+    assert_eq!(pair_state, fin);
+
+    println!("All assertions passed.");
+    println!();
+    println!("Key insight: `mdo!` with `StateT` demonstrates implicit state threading:");
+    println!("  deposit/withdraw call `modify` — each step's output state feeds the next.");
+    println!("  balance calls `get` — reads without modifying the threaded state.");
+    println!("  No explicit state parameter is passed; the monad wires it automatically.");
+}

--- a/examples/state_rng_lcg.rs
+++ b/examples/state_rng_lcg.rs
@@ -1,0 +1,98 @@
+//! Do-notation with StateT: deterministic LCG pseudo-random generator.
+//!
+//! Demonstrates the State monad threading a mutable `u64` seed through a
+//! sequence of die rolls without any explicit seed-passing between steps.
+//!
+//! Run with: `cargo run --example state_rng_lcg --features do-notation`
+
+use monadify::applicative::kind::Applicative;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::monad::kind::Bind;
+use monadify::transformers::state::{MonadState, State, StateTKind};
+
+/// Type alias: a stateful computation that threads a `u64` LCG seed.
+/// `State<S, A> = StateT<S, IdentityKind, A>`.
+type Rng<A> = State<u64, A>;
+
+/// Kind marker for the `mdo!` block header.
+type SKind = StateTKind<u64, IdentityKind>;
+
+// LCG constants (Numerical Recipes).
+const MUL: u64 = 6364136223846793005;
+const ADD: u64 = 1442695040888963407;
+
+/// Advance the LCG seed and return the new seed as the produced value.
+fn next_u64() -> Rng<u64> {
+    <SKind as MonadState<u64, u64, IdentityKind>>::state(|seed| {
+        let s2 = seed.wrapping_mul(MUL).wrapping_add(ADD);
+        (s2, s2)
+    })
+}
+
+/// Roll a six-sided die by mapping a raw `u64` output to `1..=6`.
+fn roll_d6() -> Rng<u64> {
+    SKind::bind(next_u64(), |raw| SKind::pure((raw % 6) + 1))
+}
+
+fn main() {
+    println!("=== Do-notation with StateT: LCG Pseudo-Random Generator ===\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Build the computation: roll 5 dice using mdo! do-notation.
+    // The seed threads implicitly through each roll — no explicit passing needed.
+    // ─────────────────────────────────────────────────────────────────────────────
+    let comp = mdo! {
+        SKind;
+        d1 <- roll_d6();
+        d2 <- roll_d6();
+        d3 <- roll_d6();
+        d4 <- roll_d6();
+        d5 <- roll_d6();
+        pure(vec![d1, d2, d3, d4, d5])
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Run 1: eval_state_t — keep only the produced value, discard the final seed.
+    // ─────────────────────────────────────────────────────────────────────────────
+    let Identity(rolls) = comp.clone().eval_state_t(42);
+    println!("Rolls from seed 42 (eval_state_t): {:?}", rolls);
+
+    // Every face must be a valid die result.
+    for &r in &rolls {
+        assert!((1..=6).contains(&r), "die face out of range: {}", r);
+    }
+    println!("  All faces in 1..=6 PASSED");
+
+    // Pin the deterministic sequence (pre-computed from the LCG formula at seed 42).
+    // Each value is in 1..=6 and is fully determined by seed=42.
+    assert_eq!(rolls, vec![6, 3, 6, 5, 6]);
+    println!("  Pinned sequence PASSED");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Run 2: determinism check — same seed must yield identical rolls.
+    // ─────────────────────────────────────────────────────────────────────────────
+    let Identity(rolls2) = comp.clone().eval_state_t(42);
+    assert_eq!(rolls, rolls2, "LCG must be deterministic");
+    println!("  Determinism check PASSED");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Run 3: run_state_t — keep both value and final seed.
+    // ─────────────────────────────────────────────────────────────────────────────
+    let Identity((rolls3, final_seed)) = (comp.run_state_t)(42);
+    println!("\nFull run (run_state_t):");
+    println!("  Rolls        : {:?}", rolls3);
+    println!("  Final seed   : {}", final_seed);
+    assert_eq!(
+        rolls3, rolls,
+        "run_state_t value matches eval_state_t value"
+    );
+    println!("  run_state_t PASSED");
+
+    println!("\n=== All tests passed! ===");
+    println!("\nKey insight: `mdo!` with `StateTKind` threads the LCG seed");
+    println!("  through each `roll_d6()` step automatically.  No seed argument");
+    println!("  is ever passed explicitly — the State monad handles it.");
+    println!("  Running the same computation from the same seed always produces");
+    println!("  the same sequence, demonstrating referential transparency.");
+}

--- a/examples/state_stack_machine.rs
+++ b/examples/state_stack_machine.rs
@@ -1,0 +1,147 @@
+//! Do-notation with StateT: RPN / postfix stack calculator example.
+//!
+//! Demonstrates threading a mutable operand stack through an RPN (Reverse Polish
+//! Notation) calculator using `mdo!` do-blocks and `State<Vec<i64>, A>`.
+//! Each stack operation is a pure state transition; no explicit stack is ever
+//! passed through function arguments.
+//!
+//! Run with: `cargo run --example state_stack_machine --features do-notation`
+
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::transformers::state::{MonadState, State, StateTKind};
+
+/// Type alias: a computation that threads a `Vec<i64>` operand stack and produces `A`.
+/// `State<S, A> = StateT<S, IdentityKind, A>`.
+type Stack<A> = State<Vec<i64>, A>;
+
+/// Kind marker alias for the `mdo!` macro: `StateTKind<Vec<i64>, IdentityKind>`.
+type SKind = StateTKind<Vec<i64>, IdentityKind>;
+
+// ── Helper wrappers (mirror the style of reader_config.rs) ───────────────────
+
+/// Push an operand onto the stack (returns unit; modifies state).
+fn push(n: i64) -> Stack<()> {
+    <SKind as MonadState<Vec<i64>, (), IdentityKind>>::modify(move |mut st| {
+        st.push(n);
+        st
+    })
+}
+
+/// Apply a binary operator: pop two operands (right then left), push one result.
+fn binary_op(op: impl Fn(i64, i64) -> i64 + 'static) -> Stack<()> {
+    <SKind as MonadState<Vec<i64>, (), IdentityKind>>::state(move |mut st| {
+        let b = st.pop().expect("stack underflow: missing right operand");
+        let a = st.pop().expect("stack underflow: missing left operand");
+        st.push(op(a, b));
+        ((), st)
+    })
+}
+
+/// Addition: pop two operands, push their sum.
+fn add_op() -> Stack<()> {
+    binary_op(|a, b| a + b)
+}
+
+/// Multiplication: pop two operands, push their product.
+fn mul_op() -> Stack<()> {
+    binary_op(|a, b| a * b)
+}
+
+/// Read the top of the stack without consuming it (state is left unchanged).
+fn peek_top() -> Stack<i64> {
+    <SKind as MonadState<Vec<i64>, i64, IdentityKind>>::gets(|st| {
+        *st.last().expect("peek_top: empty stack")
+    })
+}
+
+// ── Programs ─────────────────────────────────────────────────────────────────
+
+/// Evaluate the sub-expression `3 4 +` (used for the intermediate check).
+fn prog_add() -> Stack<()> {
+    mdo! {
+        SKind;
+        _ <- push(3);
+        _ <- push(4);
+        _ <- add_op();
+        pure(())
+    }
+}
+
+/// Evaluate the full postfix program `3 4 + 5 *`.
+///
+/// Returns `(intermediate_sum, final_product)` so both can be asserted in
+/// `main` from a single execution. Both values are `i64` (Copy), so they cross
+/// `mdo!` nesting levels without triggering the non-Copy capture restriction.
+fn prog_full() -> Stack<(i64, i64)> {
+    mdo! {
+        SKind;
+        _ <- push(3);
+        _ <- push(4);
+        _ <- add_op();
+        mid    <- peek_top();   // mid   : i64 (Copy) — safe across bind levels
+        _ <- push(5);
+        _ <- mul_op();
+        result <- peek_top();   // result: i64 (Copy)
+        pure((mid, result))
+    }
+}
+
+fn main() {
+    println!("=== Do-notation with StateT: RPN Stack Calculator ===\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: Intermediate check — `3 4 +` leaves stack top = 7
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("Test 1: Intermediate check — `3 4 +`");
+    let Identity(stack_after_add) = prog_add().exec_state_t(vec![]);
+    let top_after_add = *stack_after_add.last().expect("stack must be non-empty");
+    assert_eq!(top_after_add, 7, "stack top after `3 4 +` must be 7");
+    println!("  Stack after `3 4 +`: {:?}", stack_after_add);
+    println!("  Stack top = {} (expected 7)", top_after_add);
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: Full program `3 4 + 5 *` — value = 35, final stack = [35]
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("Test 2: Full program `3 4 + 5 *` (expected 35)");
+    let Identity(((mid, result), final_stack)) = (prog_full().run_state_t)(vec![]);
+    assert_eq!(mid, 7, "intermediate value after `3 4 +` must be 7");
+    assert_eq!(result, 35, "`3 4 + 5 *` must evaluate to 35");
+    assert_eq!(final_stack, vec![35i64], "final stack must be exactly [35]");
+    println!("  Intermediate sum (3+4) captured mid-program: {}", mid);
+    println!("  Final product (7*5): {}", result);
+    println!("  Final stack: {:?}", final_stack);
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 3: Runners — eval_state_t (value only) and exec_state_t (state only)
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("Test 3: Runners — eval_state_t and exec_state_t");
+    let Identity(value_only) = prog_full().eval_state_t(vec![]);
+    let Identity(state_only) = prog_full().exec_state_t(vec![]);
+    assert_eq!(
+        value_only,
+        (7, 35),
+        "eval_state_t must return (mid=7, result=35)"
+    );
+    assert_eq!(
+        state_only,
+        vec![35i64],
+        "exec_state_t must return final stack [35]"
+    );
+    println!("  eval_state_t -> {:?}", value_only);
+    println!("  exec_state_t -> {:?}", state_only);
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Summary
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("=== All tests passed! ===");
+    println!("\nKey insight: `mdo!` with `StateT` threads the operand stack implicitly:");
+    println!("  * `modify` handles push: transforms the state without yielding a value.");
+    println!("  * `state`  handles binary ops: pops two operands, pushes one result.");
+    println!("  * `gets`   peeks at the top of the stack (read-only state projection).");
+    println!("  * `run_state_t` returns both the produced value and the final state.");
+    println!("  * No explicit stack is threaded through any function argument.");
+}

--- a/examples/state_unique_id.rs
+++ b/examples/state_unique_id.rs
@@ -1,0 +1,102 @@
+//! Do-notation with StateT: fresh-id / gensym generator example.
+//!
+//! Demonstrates the State monad threading a mutable `u64` counter through a
+//! multi-step computation, producing monotonically increasing unique identifiers
+//! without any explicit counter passing at each step.
+//!
+//! Run with: `cargo run --example state_unique_id --features do-notation`
+
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::transformers::state::{MonadState, State, StateTKind};
+
+/// Type alias: a stateful computation that threads a `u64` counter and produces `A`.
+/// `State<S, A>` = `StateT<S, IdentityKind, A>`.
+type Gen<A> = State<u64, A>;
+
+/// Kind marker alias used in the `mdo!` block header.
+type SKind = StateTKind<u64, IdentityKind>;
+
+/// Allocates a fresh id: returns the current counter as the id, then advances
+/// the counter by one.  `state(|n| (n, n + 1))` means "value = n, new_state = n + 1".
+fn fresh() -> Gen<u64> {
+    <SKind as MonadState<u64, u64, IdentityKind>>::state(|n| (n, n + 1))
+}
+
+/// Assigns monotonically-increasing unique ids to the three labels in a single
+/// `mdo!` block.  The `u64` ids are `Copy` and therefore cross bind levels freely;
+/// the label `&str` literals are assembled in the terminal `pure(...)`.
+fn assign_ids() -> Gen<Vec<(&'static str, u64)>> {
+    mdo! {
+        SKind;
+        a <- fresh();
+        b <- fresh();
+        c <- fresh();
+        pure(vec![("alpha", a), ("beta", b), ("gamma", c)])
+    }
+}
+
+fn main() {
+    println!("=== Do-notation with StateT: Fresh-Id / Gensym Generator ===\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 1: run_state_t — inspect both the produced value and the final counter.
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 1: run_state_t — value and final counter together");
+    let comp = assign_ids();
+    let Identity((ids, final_n)) = (comp.run_state_t)(0);
+    println!("  Assigned ids : {:?}", ids);
+    println!("  Final counter: {}", final_n);
+    assert_eq!(
+        ids,
+        vec![("alpha", 0), ("beta", 1), ("gamma", 2)],
+        "ids must be 0-based and monotonically increasing"
+    );
+    assert_eq!(final_n, 3, "counter must advance once per fresh()");
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 2: eval_state_t — project only the produced value.
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 2: eval_state_t — project only the assigned ids");
+    let comp2 = assign_ids();
+    let Identity(ids2) = comp2.eval_state_t(0);
+    println!("  Assigned ids: {:?}", ids2);
+    assert_eq!(ids2, vec![("alpha", 0), ("beta", 1), ("gamma", 2)]);
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 3: exec_state_t — project only the final counter.
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 3: exec_state_t — project only the final counter");
+    let comp3 = assign_ids();
+    let Identity(final_counter) = comp3.exec_state_t(0);
+    println!("  Final counter: {}", final_counter);
+    assert_eq!(final_counter, 3, "three fresh() calls must advance to 3");
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 4: first id is 0 — counter is 0-based.
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("Test 4: first fresh() id is 0 (0-based counter)");
+    let first_id_comp = fresh();
+    let Identity((first_id, next_counter)) = (first_id_comp.run_state_t)(0);
+    println!("  First id     : {}", first_id);
+    println!("  Next counter : {}", next_counter);
+    assert_eq!(first_id, 0, "first id must be 0");
+    assert_eq!(
+        next_counter, 1,
+        "counter must advance to 1 after one fresh()"
+    );
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Summary
+    // ─────────────────────────────────────────────────────────────────────────────
+    println!("=== All tests passed! ===");
+    println!("\nKey insight: `mdo!` with `StateT` threads the counter automatically:");
+    println!("  Each `fresh()` call reads the current counter as the id and returns");
+    println!("  new_state = counter + 1.  The `mdo!` desugaring chains the three");
+    println!("  calls via nested `bind`s so the counter is never passed by hand.");
+    println!("  The u64 ids are Copy, so they cross bind-levels freely in the block.");
+}


### PR DESCRIPTION
## Summary

Adds four runnable, **self-verifying** examples demonstrating the `StateT` State monad (merged in #6), mirroring the existing `examples/reader_config.rs` style. Each threads its state through a multi-step computation via `mdo!` do-notation, exercises the `get`/`put`/`modify`/`gets`/`state` ops and all three runners (`run_state_t`/`eval_state_t`/`exec_state_t`), and its `main()` asserts deterministic expected output — so each example doubles as a test.

| Example | Scenario | State | Asserts |
|---|---|---|---|
| `state_stack_machine` | RPN / stack calculator | `Vec<i64>` (operand stack) | `3 4 + 5 *` == 35, stack `[35]` |
| `state_unique_id` | fresh-id / gensym generator | `u64` counter | ids 0/1/2, final counter 3 |
| `state_rng_lcg` | deterministic LCG pseudo-random generator | `u64` seed | pinned dice `[6,3,6,5,6]` from seed 42, all in `1..=6`, reproducible |
| `state_bank_account` | running-balance ledger | `i64` cents | mid 12550, final 8550 (= \$85.50) |

## Changes

- **`examples/state_*.rs`** (4 new) — the examples.
- **`Cargo.toml`** — registers all four as `[[example]]` with `required-features = ["do-notation"]` (so they're skipped, not broken, when the feature is off).
- **`README.md`** — a new "State monad examples" subsection with run commands.

## Run

```bash
cargo run --example state_stack_machine --features do-notation
cargo run --example state_unique_id    --features do-notation
cargo run --example state_rng_lcg      --features do-notation
cargo run --example state_bank_account --features do-notation
```

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --examples --features do-notation` and each example runs to exit 0 (asserts pass)
- `cargo build --examples` (no feature) is a no-op — the gated examples are correctly skipped
- `cargo test --all-features` unaffected

Docs/examples only — no library code changes.