### PR TITLE
feat(transformers): add WriterT monad transformer + Monoid + MonadTrans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ plus profunctor-encoded optics. v0.1.1, MIT, edition 2021, MSRV 1.66.
 The defining design simulates **Higher-Kinded Types (HKTs)** using Generic
 Associated Types: a `Kind` trait with `type Of<Arg>` plus lightweight marker
 structs (`OptionKind`, `VecKind`, `ResultKind<E>`, `CFnKind<X>`, `CFnOnceKind<X>`,
-`RcFnKind<X>`, `IdentityKind`, `ReaderTKind`, `StateTKind`). Traits are generic over the *marker*, and
+`RcFnKind<X>`, `IdentityKind`, `ReaderTKind`, `StateTKind`, `WriterTKind`). Traits are generic over the *marker*, and
 `Self::Of<A>` resolves to the concrete type (e.g. `OptionKind::Of<i32> == Option<i32>`).
 Core infrastructure lives in `src/kind_based/kind.rs`.
 
@@ -26,18 +26,26 @@ Core infrastructure lives in `src/kind_based/kind.rs`.
 - `src/identity.rs` — `Identity` monad. `src/transformers/reader.rs` — `ReaderT` +
   `MonadReader` (`ask`/`local`). `src/transformers/state.rs` — `StateT` +
   `MonadState` (`state`/`get`/`put`/`modify`/`gets`) + runners
-  `run`/`eval`/`exec_state_t`. `src/utils.rs` — `fn0!`..`fn3!` macros.
+  `run`/`eval`/`exec_state_t`. `src/transformers/writer.rs` — `WriterT` +
+  `MonadWriter` (`tell`/`writer`/`listen`/`censor`) + runner `exec_writer_t`.
+  `src/transformers/trans.rs` — `MonadTrans` (`lift`, impl'd for all three
+  transformers). `src/monoid.rs` — `Semigroup`/`Monoid` (`combine`/`empty`).
+  `src/utils.rs` — `fn0!`..`fn3!` macros.
 - `src/legacy/` — the older associated-type implementation, behind the `legacy`
   feature flag (kept for comparison/benchmarking; not the default).
 - `tests/{kind,legacy}/` — law-verifying test suites. `benches/compare.rs` —
   criterion benchmarks comparing kind-based vs native vs legacy.
 
 Concrete instances implementing the full hierarchy (where lawful): `Option`,
-`Result`, `Vec`, `Identity`, `RcFn`, `CFnOnce`, `ReaderT`, `StateT`. `StateT`'s
+`Result`, `Vec`, `Identity`, `RcFn`, `CFnOnce`, `ReaderT`, `StateT`, `WriterT`. `StateT`'s
 `Apply`/`Bind`/`Monad` require the **inner** monad to be `Bind`/`Monad` (state is
 threaded — a sequential dependency), unlike `ReaderT` whose `Apply` needs only an
 inner `Apply`; its four `MonadState` laws (get-get, get-put, put-get, put-put) are
-first-class and law-tested.
+first-class and law-tested. `WriterT` is in the **`ReaderT` family** (its `Apply`
+needs only an inner `Apply`) but adds a `W: Monoid` constraint on the log: `pure`
+seeds the log at `Monoid::empty`, every sequencing step `combine`s logs, and its
+key law `tell(w1) >> tell(w2) ≡ tell(w1 <> w2)` is law-tested. `MonadTrans::lift`
+embeds an inner `M::Of<A>` into any of the three transformers, adding no effect.
 
 ## Conventions
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ pub mod identity;
 pub mod kind_based;
 /// Provides the Kind-based `Monad` and `Bind` traits and their implementations.
 pub mod monad;
+/// Defines the `Semigroup` and `Monoid` algebraic traits and their instances.
+pub mod monoid;
 /// Implements `Profunctor`, `Strong`, and `Choice` traits, primarily for function types.
 pub mod profunctor;
 /// Contains monad transformers like `ReaderT`.
@@ -39,17 +41,21 @@ pub use monad::{Bind, Monad}; // Points to monad::kind::Bind and monad::kind::Mo
 pub use profunctor::{Choice, Profunctor, Strong};
 pub use transformers::reader::MonadReader; // Points to transformers::reader::kind::MonadReader
 pub use transformers::state::MonadState; // Points to transformers::state::kind::MonadState
+pub use transformers::trans::MonadTrans; // Points to transformers::trans::MonadTrans
+pub use transformers::writer::MonadWriter; // Points to transformers::writer::kind::MonadWriter
 
 // Public re-exports of key structs/types (optional, but can be convenient)
 pub use function::{CFnOnce, RcFn};
 pub use identity::Identity; // Points to identity::kind::Identity
 pub use transformers::reader::{Reader, ReaderT}; // Points to transformers::reader::kind::ReaderT etc.
 pub use transformers::state::{State, StateT}; // Points to transformers::state::kind::StateT etc.
+pub use transformers::writer::{Writer, WriterT}; // Points to transformers::writer::kind::WriterT etc.
 
 // Re-export Kind markers and core Kind traits by default
 pub use crate::identity::IdentityKind; // Changed from IdentityHKTMarker
 pub use crate::transformers::reader::ReaderTKind;
 pub use crate::transformers::state::StateTKind;
+pub use crate::transformers::writer::WriterTKind;
 pub use kind_based::kind::{
     CFnOnceKind,
     Kind,

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -1,0 +1,91 @@
+//! # Semigroup and Monoid
+//!
+//! Algebraic structures for *combinable* values. A [`Semigroup`] has an
+//! associative binary operation [`combine`](Semigroup::combine) (Haskell's
+//! `<>` / `mappend`); a [`Monoid`] additionally has an identity element
+//! [`empty`](Monoid::empty) (Haskell's `mempty`).
+//!
+//! These power the [`WriterT`](crate::transformers::writer) transformer, whose
+//! log type must accumulate monoidally: `tell` appends with `combine`, and
+//! `pure` starts the log at `empty`.
+//!
+//! ## Laws
+//!
+//! `Semigroup` — **associativity**:
+//! ```text
+//! a.combine(b).combine(c) == a.combine(b.combine(c))
+//! ```
+//! `Monoid` — **left and right identity**:
+//! ```text
+//! Monoid::empty().combine(x) == x
+//! x.combine(Monoid::empty()) == x
+//! ```
+//!
+//! ## Provided instances
+//! - `()` — the trivial monoid (one element, the no-op log).
+//! - `String` — concatenation, identity is `""`.
+//! - `Vec<T>` — concatenation, identity is `[]`.
+//!
+//! ```
+//! use monadify::monoid::{Semigroup, Monoid};
+//!
+//! assert_eq!("foo".to_string().combine("bar".to_string()), "foobar");
+//! assert_eq!(vec![1, 2].combine(vec![3]), vec![1, 2, 3]);
+//! assert_eq!(<String as Monoid>::empty().combine("x".to_string()), "x");
+//! ```
+
+/// A type with an associative binary operation, [`combine`](Self::combine).
+///
+/// Analogous to Haskell's `Semigroup` (`<>`). Implementations must be
+/// **associative**: `a.combine(b).combine(c) == a.combine(b.combine(c))`.
+pub trait Semigroup {
+    /// Combines two values associatively. Consumes both operands so the
+    /// implementation can reuse their allocations (e.g. `String`/`Vec`).
+    fn combine(self, other: Self) -> Self;
+}
+
+/// A [`Semigroup`] with an identity element, [`empty`](Self::empty).
+///
+/// Analogous to Haskell's `Monoid` (`mempty`). The identity must satisfy
+/// `empty().combine(x) == x` and `x.combine(empty()) == x`.
+pub trait Monoid: Semigroup {
+    /// The identity element: combining it with any value yields that value.
+    fn empty() -> Self;
+}
+
+// --- Trivial monoid: () ---
+
+impl Semigroup for () {
+    fn combine(self, _other: ()) {}
+}
+impl Monoid for () {
+    fn empty() {}
+}
+
+// --- String under concatenation ---
+
+impl Semigroup for String {
+    fn combine(mut self, other: String) -> String {
+        self.push_str(&other);
+        self
+    }
+}
+impl Monoid for String {
+    fn empty() -> String {
+        String::new()
+    }
+}
+
+// --- Vec<T> under concatenation ---
+
+impl<T> Semigroup for Vec<T> {
+    fn combine(mut self, mut other: Vec<T>) -> Vec<T> {
+        self.append(&mut other);
+        self
+    }
+}
+impl<T> Monoid for Vec<T> {
+    fn empty() -> Vec<T> {
+        Vec::new()
+    }
+}

--- a/src/transformers/mod.rs
+++ b/src/transformers/mod.rs
@@ -2,3 +2,5 @@
 
 pub mod reader;
 pub mod state;
+pub mod trans;
+pub mod writer;

--- a/src/transformers/trans.rs
+++ b/src/transformers/trans.rs
@@ -1,0 +1,110 @@
+//! # `MonadTrans`: lifting inner computations into a transformer
+//!
+//! A monad transformer `T m` adds an effect on top of an inner monad `m`. The
+//! [`MonadTrans`] trait captures the single operation every transformer shares:
+//! [`lift`](MonadTrans::lift), which embeds an inner computation `m a` into the
+//! transformed monad `T m a` while adding *no* effect of its own.
+//!
+//! This crate implements `MonadTrans` for all three transformers:
+//! [`ReaderTKind`](crate::transformers::reader::ReaderTKind),
+//! [`StateTKind`](crate::transformers::state::StateTKind), and
+//! [`WriterTKind`](crate::transformers::writer::WriterTKind).
+//!
+//! ## Law
+//!
+//! `lift` is a monad morphism — it must commute with `pure` and `bind`:
+//! ```text
+//! lift(m.pure(a))            == T::pure(a)
+//! lift(m.bind(x, k))         == T::bind(lift(x), |a| lift(k(a)))
+//! ```
+//! Intuitively: lifting a pure inner value is the transformer's own `pure`, and
+//! lifting a sequence of inner steps is the same as lifting each and sequencing
+//! in the transformer.
+//!
+//! ## Example
+//! ```
+//! use monadify::transformers::trans::MonadTrans;
+//! use monadify::transformers::writer::{Writer, WriterTKind};
+//! use monadify::{Applicative, Identity, IdentityKind};
+//!
+//! // Lift a pure inner `Identity(7)` into a `Writer<String, _>` — empty log.
+//! type W<A> = Writer<String, A>;
+//! let lifted: W<i32> = <WriterTKind<String, IdentityKind> as MonadTrans<i32, IdentityKind>>::lift(
+//!     IdentityKind::pure(7),
+//! );
+//! let Identity((v, log)) = lifted.run_writer_t;
+//! assert_eq!(v, 7);
+//! assert_eq!(log, ""); // lifting adds no log
+//! ```
+
+use crate::functor::kind as functor_kind;
+use crate::kind_based::kind::{Kind, Kind1};
+use crate::monoid::Monoid;
+use crate::transformers::reader::kind::{ReaderT, ReaderTKind};
+use crate::transformers::state::kind::{StateT, StateTKind};
+use crate::transformers::writer::kind::{WriterT, WriterTKind};
+
+/// Lifts an inner monadic computation into a monad transformer.
+///
+/// `Self` is the transformer's Kind marker (e.g.
+/// [`WriterTKind`](crate::transformers::writer::WriterTKind)); `MKind` is the
+/// inner monad's marker. [`lift`](Self::lift) maps `MKind::Of<A>` to
+/// `Self::Of<A>`, adding none of the transformer's own effect (an empty log,
+/// an unchanged state, an ignored environment).
+///
+/// # Type Parameters
+/// - `A`: the value type of the lifted computation.
+/// - `MKind`: the Kind marker of the inner monad.
+pub trait MonadTrans<A, MKind: Kind1>: Kind {
+    /// Embeds `inner: MKind::Of<A>` into the transformer `Self::Of<A>`.
+    fn lift(inner: MKind::Of<A>) -> Self::Of<A>;
+}
+
+// `ReaderT`: ignore the environment, yielding the inner computation as-is.
+// The carrier is a `Fn(R) -> M::Of<A>` that may run repeatedly, so the inner
+// value must be `Clone`.
+impl<R, MKind, A> MonadTrans<A, MKind> for ReaderTKind<R, MKind>
+where
+    R: 'static,
+    A: 'static,
+    MKind: Kind1 + 'static,
+    MKind::Of<A>: Clone + 'static,
+{
+    fn lift(inner: MKind::Of<A>) -> ReaderT<R, MKind, A> {
+        ReaderT::new(move |_r: R| inner.clone())
+    }
+}
+
+// `StateT`: thread the state through unchanged, pairing the inner value with it.
+// The carrier runs per starting state, so the inner value must be `Clone`.
+impl<S, MKind, A> MonadTrans<A, MKind> for StateTKind<S, MKind>
+where
+    S: Clone + 'static,
+    A: 'static,
+    MKind: functor_kind::Functor<A, (A, S)> + Kind1 + 'static,
+    MKind::Of<A>: Clone + 'static,
+    MKind::Of<(A, S)>: 'static,
+{
+    fn lift(inner: MKind::Of<A>) -> StateT<S, MKind, A> {
+        StateT::new(move |s: S| {
+            <MKind as functor_kind::Functor<A, (A, S)>>::map(inner.clone(), move |a| (a, s.clone()))
+        })
+    }
+}
+
+// `WriterT`: pair the inner value with an empty log. No `Clone` needed — the
+// inner value is consumed exactly once.
+impl<W, MKind, A> MonadTrans<A, MKind> for WriterTKind<W, MKind>
+where
+    W: Monoid + 'static,
+    A: 'static,
+    MKind: functor_kind::Functor<A, (A, W)> + Kind1 + 'static,
+    MKind::Of<A>: 'static,
+    MKind::Of<(A, W)>: 'static,
+{
+    fn lift(inner: MKind::Of<A>) -> WriterT<W, MKind, A> {
+        let paired: MKind::Of<(A, W)> =
+            <MKind as functor_kind::Functor<A, (A, W)>>::map(inner, move |a| (a, W::empty()));
+        WriterT::new(paired)
+    }
+}

--- a/src/transformers/writer.rs
+++ b/src/transformers/writer.rs
@@ -1,0 +1,434 @@
+//! # WriterT Monad Transformer for the `monadify` library
+// Kind-based version is the default (mirrors `reader.rs`/`state.rs`).
+
+pub mod kind {
+    //! # Kind-based WriterT Monad Transformer
+    //!
+    //! `WriterT` (Writer Transformer) augments an underlying monad (`MKind`, a
+    //! Kind marker) with a **monoidal output log** of type `W`. A computation
+    //! `WriterT<W, MKind, A>` is simply a wrapped inner value
+    //! `MKind::Of<(A, W)>` — the produced value paired with an accumulated log.
+    //!
+    //! ## Relationship to [`ReaderT`](crate::transformers::reader) and [`StateT`](crate::transformers::state)
+    //!
+    //! `WriterT` belongs to the **`ReaderT` family**: [`apply`](apply_kind::Apply::apply)
+    //! needs only an inner [`Apply`](apply_kind::Apply), because two independent
+    //! computations' logs are simply *combined* — there is no sequential data
+    //! dependency like `StateT`'s threaded state. The new ingredient is that the
+    //! log type `W` must be a [`Monoid`](crate::monoid::Monoid): [`pure`](applicative_kind::Applicative::pure)
+    //! seeds the log with [`Monoid::empty`], and every sequencing step
+    //! [`combine`](crate::monoid::Semigroup::combine)s the two logs.
+    //!
+    //! Unlike `ReaderT`/`StateT`, the carrier is a **value**, not a function, so
+    //! there is no `run_*` closure to call — [`run_writer_t`](WriterT::run_writer_t)
+    //! is the inner `MKind::Of<(A, W)>` directly. The tuple order `(A, W) =
+    //! (value, log)` is fixed and never reordered.
+    //!
+    //! ## Key Components
+    //! - [`WriterT<W, MKind, A>`]: the computation, wrapping `MKind::Of<(A, W)>`.
+    //! - [`WriterTKind<W, MKind>`]: the Kind marker for `WriterT`.
+    //! - [`MonadWriter<W, A, MKind>`]: a trait providing `tell`, `writer`,
+    //!   `listen`, and `censor`.
+    //! - [`Writer<W, A>`]: alias for `WriterT<W, IdentityKind, A>` (the plain Writer monad).
+    //!
+    //! ## Example
+    //! ```
+    //! use monadify::transformers::writer::{Writer, WriterT, WriterTKind, MonadWriter};
+    //! use monadify::IdentityKind;
+    //! use monadify::Identity;
+    //! use monadify::monad::kind::Bind;
+    //!
+    //! type Logged<A> = Writer<String, A>;          // WriterT<String, IdentityKind, A>
+    //! type LoggedKind = WriterTKind<String, IdentityKind>;
+    //!
+    //! // `tell` appends to the log and yields unit.
+    //! let step = |msg: &str| <LoggedKind as MonadWriter<String, (), IdentityKind>>::tell(msg.to_string());
+    //!
+    //! // Sequence two log-writes; the logs concatenate monoidally.
+    //! let prog: Logged<()> = LoggedKind::bind(step("hello "), move |_| step("world"));
+    //! let Identity(((), log)) = prog.run_writer_t;
+    //! assert_eq!(log, "hello world");
+    //!
+    //! // `exec_writer_t` keeps only the log.
+    //! let prog2: Logged<()> = LoggedKind::bind(step("a"), move |_| step("b"));
+    //! assert_eq!(prog2.exec_writer_t(), Identity("ab".to_string()));
+    //! ```
+
+    use crate::applicative::kind as applicative_kind;
+    use crate::apply::kind as apply_kind;
+    use crate::function::RcFn; // Apply's function container (CFn removed in 0.2.0).
+    use crate::functor::kind as functor_kind;
+    use crate::identity::kind::IdentityKind;
+    use crate::kind_based::kind::{Kind, Kind1};
+    use crate::monad::kind as monad_kind;
+    use crate::monoid::Monoid;
+    use std::marker::PhantomData;
+
+    /// The `WriterT` monad transformer for Kind-encoded types.
+    ///
+    /// `WriterT<W, MKind, A>` wraps an inner value `MKind::Of<(A, W)>`: the
+    /// produced value `A` paired with an accumulated monoidal log `W`. The value
+    /// is stored in [`run_writer_t`](Self::run_writer_t).
+    ///
+    /// # Type Parameters
+    /// - `W`: the log type (must be a [`Monoid`](crate::monoid::Monoid) for the
+    ///   `Applicative`/`Monad` instances).
+    /// - `MKind`: the Kind marker for the inner monad (must implement [`Kind1`]).
+    /// - `A`: the value produced alongside the log.
+    pub struct WriterT<W, MKind: Kind1, A> {
+        /// The wrapped inner computation: `MKind::Of<(A, W)>` (value-then-log).
+        pub run_writer_t: MKind::Of<(A, W)>,
+        _phantom_w: PhantomData<W>,
+        _phantom_m_kind: PhantomData<MKind>,
+        _phantom_a: PhantomData<A>,
+    }
+
+    // Manual `Clone` bounded on the projected inner type (mirrors `RcFn`): a
+    // derived `Clone` would demand `W: Clone, MKind: Clone, A: Clone`, none of
+    // which is the real requirement — only `MKind::Of<(A, W)>: Clone` is.
+    impl<W, MKind: Kind1, A> Clone for WriterT<W, MKind, A>
+    where
+        MKind::Of<(A, W)>: Clone,
+    {
+        fn clone(&self) -> Self {
+            WriterT {
+                run_writer_t: self.run_writer_t.clone(),
+                _phantom_w: PhantomData,
+                _phantom_m_kind: PhantomData,
+                _phantom_a: PhantomData,
+            }
+        }
+    }
+
+    impl<W, MKind: Kind1, A> WriterT<W, MKind, A> {
+        /// Creates a new `WriterT` from an inner value `MKind::Of<(A, W)>`.
+        pub fn new(inner: MKind::Of<(A, W)>) -> Self {
+            WriterT {
+                run_writer_t: inner,
+                _phantom_w: PhantomData,
+                _phantom_m_kind: PhantomData,
+                _phantom_a: PhantomData,
+            }
+        }
+    }
+
+    /// The Kind marker for `WriterT<W, MKind, _>`.
+    ///
+    /// Used to implement [`Functor`](functor_kind::Functor),
+    /// [`Apply`](apply_kind::Apply), [`Applicative`](applicative_kind::Applicative),
+    /// [`Bind`](monad_kind::Bind), and [`Monad`](monad_kind::Monad) for the
+    /// `WriterT` type constructor.
+    ///
+    /// # Type Parameters
+    /// - `W`: the log type.
+    /// - `MKind`: the Kind marker for the inner monad.
+    #[derive(Default)]
+    pub struct WriterTKind<W, MKind: Kind1>(PhantomData<(W, MKind)>);
+
+    impl<W, MKind: Kind1> Kind for WriterTKind<W, MKind> {
+        type Of<A> = WriterT<W, MKind, A>;
+    }
+    // Kind1 is provided by the blanket impl in kind_based/kind.rs.
+
+    /// A type alias for `WriterT` with [`IdentityKind`] as the inner monad.
+    /// This is the plain Writer monad: `Writer<W, A>` wraps `Identity<(A, W)>`.
+    pub type Writer<W, A> = WriterT<W, IdentityKind, A>;
+
+    // --- Kind Trait Implementations for WriterTKind ---
+
+    impl<W, MKind, A, B> functor_kind::Functor<A, B> for WriterTKind<W, MKind>
+    where
+        W: 'static,
+        MKind: functor_kind::Functor<(A, W), (B, W)> + Kind1 + 'static,
+        A: 'static,
+        B: 'static,
+        MKind::Of<(A, W)>: 'static,
+        MKind::Of<(B, W)>: 'static,
+    {
+        /// Maps `A -> B` over the produced value, leaving the log untouched.
+        /// The mapping happens within the inner monad `MKind`.
+        fn map(
+            input: WriterT<W, MKind, A>,
+            func: impl FnMut(A) -> B + Clone + 'static,
+        ) -> WriterT<W, MKind, B> {
+            let mut f = func;
+            WriterT::new(MKind::map(input.run_writer_t, move |(a, w)| (f(a), w)))
+        }
+    }
+
+    impl<W, MKind, A, B> apply_kind::Apply<A, B> for WriterTKind<W, MKind>
+    where
+        W: Monoid + Clone + 'static,
+        A: 'static,
+        B: 'static,
+        // `Apply<A, B>: Functor<A, B>` (the inner `Functor<(A,W),(B,W)>` bound),
+        // plus the inner `Functor` that lifts the function pair into a function
+        // on pairs, plus the inner `Apply` that combines the two computations.
+        MKind: functor_kind::Functor<(A, W), (B, W)>
+            + functor_kind::Functor<(RcFn<A, B>, W), RcFn<(A, W), (B, W)>>
+            + apply_kind::Apply<(A, W), (B, W)>
+            + Kind1
+            + 'static,
+        MKind::Of<(A, W)>: 'static,
+        MKind::Of<(B, W)>: 'static,
+        MKind::Of<(RcFn<A, B>, W)>: 'static,
+        MKind::Of<RcFn<(A, W), (B, W)>>: 'static,
+    {
+        /// Applies a wrapped function to a wrapped value, **combining the logs**.
+        /// The two computations are independent (no data dependency), so this is
+        /// derived from the inner monad's `apply`; the result log is
+        /// `func_log.combine(value_log)`.
+        fn apply(
+            value_container: WriterT<W, MKind, A>,
+            function_container: WriterT<W, MKind, RcFn<A, B>>,
+        ) -> WriterT<W, MKind, B> {
+            // Lift the function pair `(g, w1)` into a function on value pairs
+            // `(a, w2) -> (g(a), w1 <> w2)`, then apply it inside `MKind`.
+            #[allow(clippy::type_complexity)]
+            let m_lifted: MKind::Of<RcFn<(A, W), (B, W)>> = MKind::map(
+                function_container.run_writer_t,
+                |(g, w1): (RcFn<A, B>, W)| {
+                    RcFn::new(move |(a, w2): (A, W)| (g.call(a), w1.clone().combine(w2)))
+                },
+            );
+            WriterT::new(MKind::apply(value_container.run_writer_t, m_lifted))
+        }
+    }
+
+    impl<W, MKind, T> applicative_kind::Applicative<T> for WriterTKind<W, MKind>
+    where
+        W: Monoid + Clone + 'static,
+        T: 'static, // `pure` consumes the value once — no `Clone` needed (unlike `ReaderT`).
+        // `Applicative<T>: Apply<T, T>`, so the full `Apply<T, T>` bound set is
+        // dragged in here; `pure` itself needs the inner `Applicative<(T, W)>`.
+        MKind: functor_kind::Functor<(T, W), (T, W)>
+            + functor_kind::Functor<(RcFn<T, T>, W), RcFn<(T, W), (T, W)>>
+            + apply_kind::Apply<(T, W), (T, W)>
+            + applicative_kind::Applicative<(T, W)>
+            + Kind1
+            + 'static,
+        MKind::Of<(T, W)>: 'static,
+        MKind::Of<(RcFn<T, T>, W)>: 'static,
+        MKind::Of<RcFn<(T, W), (T, W)>>: 'static,
+    {
+        /// Lifts a value `T` into `WriterT` with an **empty** log:
+        /// `MKind::pure((value, Monoid::empty()))`.
+        fn pure(value: T) -> WriterT<W, MKind, T> {
+            WriterT::new(MKind::pure((value, W::empty())))
+        }
+    }
+
+    impl<W, MKind, A, B> monad_kind::Bind<A, B> for WriterTKind<W, MKind>
+    where
+        W: Monoid + Clone + 'static,
+        A: 'static,
+        B: 'static,
+        // `Bind<A, B>: Apply<A, B>`, so the full `Apply<A, B>` bound set is
+        // dragged in, plus the inner `Bind`/`Functor` the `bind` body uses to
+        // sequence the two computations and combine their logs.
+        MKind: functor_kind::Functor<(A, W), (B, W)>
+            + functor_kind::Functor<(RcFn<A, B>, W), RcFn<(A, W), (B, W)>>
+            + apply_kind::Apply<(A, W), (B, W)>
+            + monad_kind::Bind<(A, W), (B, W)>
+            + functor_kind::Functor<(B, W), (B, W)>
+            + Kind1
+            + 'static,
+        MKind::Of<(A, W)>: 'static,
+        MKind::Of<(B, W)>: 'static,
+        MKind::Of<(RcFn<A, B>, W)>: 'static,
+        MKind::Of<RcFn<(A, W), (B, W)>>: 'static,
+    {
+        /// Sequentially composes a `WriterT` with a function producing the next
+        /// `WriterT`, **combining the logs**: the first computation's log `w1`
+        /// is prepended to the second's log `w2`, giving `w1.combine(w2)`.
+        fn bind(
+            input: WriterT<W, MKind, A>,
+            func: impl FnMut(A) -> WriterT<W, MKind, B> + Clone + 'static,
+        ) -> WriterT<W, MKind, B> {
+            let mut f = func;
+            WriterT::new(MKind::bind(input.run_writer_t, move |(a, w1): (A, W)| {
+                let next: WriterT<W, MKind, B> = f(a);
+                // `w1` is already owned here; move it straight into the inner
+                // closure, which clones per call (the inner map may run >1 time).
+                MKind::map(next.run_writer_t, move |(b, w2): (B, W)| {
+                    (b, w1.clone().combine(w2))
+                })
+            }))
+        }
+    }
+
+    impl<W, MKind, A> monad_kind::Monad<A> for WriterTKind<W, MKind>
+    where
+        W: Monoid + Clone + 'static,
+        A: Clone + 'static,
+        // `Monad<A>: Applicative<A>: Apply<A, A>`, so the full `Apply<A, A>`
+        // bound set is dragged in, plus the inner `Bind`/`Functor` `join` uses.
+        MKind: functor_kind::Functor<(A, W), (A, W)>
+            + functor_kind::Functor<(RcFn<A, A>, W), RcFn<(A, W), (A, W)>>
+            + apply_kind::Apply<(A, W), (A, W)>
+            + applicative_kind::Applicative<(A, W)>
+            + monad_kind::Bind<(WriterT<W, MKind, A>, W), (A, W)>
+            + Kind1
+            + 'static,
+        MKind::Of<(A, W)>: 'static,
+        MKind::Of<(RcFn<A, A>, W)>: 'static,
+        MKind::Of<RcFn<(A, W), (A, W)>>: 'static,
+        MKind::Of<(WriterT<W, MKind, A>, W)>: 'static,
+    {
+        /// Flattens a nested `WriterT<W, MKind, WriterT<W, MKind, A>>`: run the
+        /// outer computation to obtain the inner one and the outer log `w1`,
+        /// then combine `w1` with the inner computation's log `w2`.
+        fn join(mma: WriterT<W, MKind, WriterT<W, MKind, A>>) -> WriterT<W, MKind, A> {
+            WriterT::new(<MKind as monad_kind::Bind<
+                (WriterT<W, MKind, A>, W),
+                (A, W),
+            >>::bind(
+                mma.run_writer_t,
+                move |(inner, w1): (WriterT<W, MKind, A>, W)| {
+                    <MKind as functor_kind::Functor<(A, W), (A, W)>>::map(
+                        inner.run_writer_t,
+                        move |(a, w2): (A, W)| (a, w1.clone().combine(w2)),
+                    )
+                },
+            ))
+        }
+    }
+
+    // --- Runner (log projection) ---
+
+    impl<W, MKind: Kind1, A> WriterT<W, MKind, A> {
+        /// Runs the computation and keeps only the produced value, discarding
+        /// the log: `MKind::Of<A>` (inner `Functor`, projecting `fst`).
+        pub fn eval_writer_t(self) -> MKind::Of<A>
+        where
+            W: 'static,
+            A: 'static,
+            MKind: functor_kind::Functor<(A, W), A> + 'static,
+            MKind::Of<(A, W)>: 'static,
+        {
+            MKind::map(self.run_writer_t, |(a, _w)| a)
+        }
+
+        /// Runs the computation and keeps only the accumulated log, discarding
+        /// the value: `MKind::Of<W>` (inner `Functor`, projecting `snd`).
+        pub fn exec_writer_t(self) -> MKind::Of<W>
+        where
+            W: 'static,
+            A: 'static,
+            MKind: functor_kind::Functor<(A, W), W> + 'static,
+            MKind::Of<(A, W)>: 'static,
+        {
+            MKind::map(self.run_writer_t, |(_a, w)| w)
+        }
+    }
+
+    /// Trait for monads that accumulate a monoidal output log `W`.
+    ///
+    /// The Writer analog of [`MonadReader`](crate::transformers::reader::MonadReader)
+    /// (`ask`/`local`) and [`MonadState`](crate::transformers::state::MonadState)
+    /// (`get`/`put`/…). The primitive is [`tell`](Self::tell); [`writer`](Self::writer)
+    /// is the general constructor, while [`listen`](Self::listen) and
+    /// [`censor`](Self::censor) inspect and rewrite the log.
+    ///
+    /// `tell`/`writer` need only the inner [`Applicative`](applicative_kind::Applicative);
+    /// `listen`/`censor` need only the inner [`Functor`](functor_kind::Functor).
+    ///
+    /// # Type Parameters
+    /// - `W`: the log type.
+    /// - `A`: the value type carried by the computation.
+    /// - `MKind`: the Kind marker for the inner monad.
+    pub trait MonadWriter<W, A, MKind: Kind1>
+    where
+        Self: Sized,
+    {
+        /// Appends `w` to the log, producing unit: `((), w)`. The primitive.
+        fn tell(w: W) -> WriterT<W, MKind, ()>
+        where
+            W: 'static,
+            MKind: applicative_kind::Applicative<((), W)> + 'static,
+            MKind::Of<((), W)>: 'static;
+
+        /// The general constructor: embeds a `(value, log)` pair directly.
+        fn writer(value: A, log: W) -> WriterT<W, MKind, A>
+        where
+            W: 'static,
+            A: Clone + 'static,
+            MKind: applicative_kind::Applicative<(A, W)> + 'static,
+            MKind::Of<(A, W)>: 'static;
+
+        /// Exposes the accumulated log alongside the value, leaving it in place:
+        /// turns a `WriterT<W, M, A>` into `WriterT<W, M, (A, W)>` with the same log.
+        fn listen(m: WriterT<W, MKind, A>) -> WriterT<W, MKind, (A, W)>
+        where
+            W: Clone + 'static,
+            A: 'static,
+            MKind: functor_kind::Functor<(A, W), ((A, W), W)> + 'static,
+            MKind::Of<(A, W)>: 'static,
+            MKind::Of<((A, W), W)>: 'static;
+
+        /// Rewrites the log with `f`, leaving the value unchanged: `(a, f(w))`.
+        /// (The ergonomic specialization of Haskell's `pass`.)
+        fn censor<F>(f: F, m: WriterT<W, MKind, A>) -> WriterT<W, MKind, A>
+        where
+            W: 'static,
+            A: 'static,
+            MKind: functor_kind::Functor<(A, W), (A, W)> + 'static,
+            MKind::Of<(A, W)>: 'static,
+            F: Fn(W) -> W + Clone + 'static;
+    }
+
+    impl<W, MKindImpl, A> MonadWriter<W, A, MKindImpl> for WriterTKind<W, MKindImpl>
+    where
+        W: 'static,
+        A: 'static,
+        MKindImpl: Kind1 + 'static,
+    {
+        fn tell(w: W) -> WriterT<W, MKindImpl, ()>
+        where
+            W: 'static,
+            MKindImpl: applicative_kind::Applicative<((), W)> + 'static,
+            MKindImpl::Of<((), W)>: 'static,
+        {
+            WriterT::new(MKindImpl::pure(((), w)))
+        }
+
+        fn writer(value: A, log: W) -> WriterT<W, MKindImpl, A>
+        where
+            W: 'static,
+            A: Clone + 'static,
+            MKindImpl: applicative_kind::Applicative<(A, W)> + 'static,
+            MKindImpl::Of<(A, W)>: 'static,
+        {
+            WriterT::new(MKindImpl::pure((value, log)))
+        }
+
+        fn listen(m: WriterT<W, MKindImpl, A>) -> WriterT<W, MKindImpl, (A, W)>
+        where
+            W: Clone + 'static,
+            A: 'static,
+            MKindImpl: functor_kind::Functor<(A, W), ((A, W), W)> + 'static,
+            MKindImpl::Of<(A, W)>: 'static,
+            MKindImpl::Of<((A, W), W)>: 'static,
+        {
+            WriterT::new(MKindImpl::map(m.run_writer_t, |(a, w): (A, W)| {
+                ((a, w.clone()), w)
+            }))
+        }
+
+        fn censor<F>(f: F, m: WriterT<W, MKindImpl, A>) -> WriterT<W, MKindImpl, A>
+        where
+            W: 'static,
+            A: 'static,
+            MKindImpl: functor_kind::Functor<(A, W), (A, W)> + 'static,
+            MKindImpl::Of<(A, W)>: 'static,
+            F: Fn(W) -> W + Clone + 'static,
+        {
+            WriterT::new(MKindImpl::map(m.run_writer_t, move |(a, w): (A, W)| {
+                (a, f(w))
+            }))
+        }
+    }
+}
+
+// Directly export Kind-based versions
+pub use kind::{MonadWriter, Writer, WriterT, WriterTKind};

--- a/tests/kind/do_notation/mod.rs
+++ b/tests/kind/do_notation/mod.rs
@@ -24,3 +24,4 @@ pub mod reader;
 pub mod result;
 pub mod state;
 pub mod vec;
+pub mod writer;

--- a/tests/kind/do_notation/writer.rs
+++ b/tests/kind/do_notation/writer.rs
@@ -1,0 +1,120 @@
+//! `mdo!` do-block tests for `WriterTKind` (the Writer monad: accumulating a log).
+//!
+//! Gated by the parent `do_notation` module's `#![cfg(feature = "do-notation")]`.
+//!
+//! ## What we test
+//!
+//! The "real power" of Writer is that a monoidal log is silently accumulated —
+//! every `tell` step appends to it — while the do-block carries ordinary values.
+//! These tests use `Writer<Vec<i32>, A>` (`WriterT<Vec<i32>, IdentityKind, A>`)
+//! so each run yields `Identity<(A, Vec<i32>)>` and the focus is on log
+//! accumulation.
+//!
+//! 1. **Log accumulation** — successive `tell` steps concatenate their logs.
+//! 2. **Equivalence** — the `mdo!` block produces the identical `(value, log)`
+//!    to a hand-written nested `bind` chain.
+//! 3. **Deeper chains** — depth > 2 confirms the desugaring.
+//! 4. **proptest** — `mdo!` vs hand-written `bind`, run-and-compared over
+//!    generated log values.
+//!
+//! `guard` is intentionally absent: `WriterT` has no lawful zero, so a `guard`
+//! inside a Writer do-block is a deliberate compile error (same as Reader/State).
+//! `WriterT` is `Clone` when its inner `M::Of<(A, W)>` is, so the `.clone()` the
+//! macro emits works for `IdentityKind`.
+
+use monadify::applicative::kind::Applicative;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::monad::kind::Bind;
+use monadify::transformers::writer::{MonadWriter, Writer, WriterTKind};
+use proptest::prelude::*;
+
+type WKind = WriterTKind<Vec<i32>, IdentityKind>;
+type Logged<A> = Writer<Vec<i32>, A>;
+
+fn tell(n: i32) -> Logged<()> {
+    <WKind as MonadWriter<Vec<i32>, (), IdentityKind>>::tell(vec![n])
+}
+fn run_id<A>(w: Logged<A>) -> (A, Vec<i32>) {
+    let Identity(pair) = w.run_writer_t;
+    pair
+}
+
+// ── 1. Log accumulation in a do-block ────────────────────────────────────────
+
+#[test]
+fn writer_mdo_accumulates_log() {
+    let comp: Logged<i32> = mdo! {
+        WKind;
+        _ <- tell(1);
+        _ <- tell(2);
+        _ <- tell(3);
+        WKind::pure(42)
+    };
+    assert_eq!(run_id(comp), (42, vec![1, 2, 3]));
+}
+
+#[test]
+fn writer_mdo_interleaves_values_and_log() {
+    let comp: Logged<i32> = mdo! {
+        WKind;
+        _ <- tell(10);
+        x <- <WKind as MonadWriter<Vec<i32>, i32, IdentityKind>>::writer(5, vec![20]);
+        _ <- tell(30);
+        WKind::pure(x + 1)
+    };
+    // value: writer yields 5, +1 => 6; log: [10] <> [20] <> [30] == [10, 20, 30].
+    assert_eq!(run_id(comp), (6, vec![10, 20, 30]));
+}
+
+// ── 2. Equivalence with a hand-written bind chain ────────────────────────────
+
+#[test]
+fn writer_mdo_equivalent_to_manual_bind() {
+    let via_mdo: Logged<i32> = mdo! {
+        WKind;
+        _ <- tell(1);
+        _ <- tell(2);
+        WKind::pure(7)
+    };
+
+    let via_bind: Logged<i32> = WKind::bind(tell(1), move |_| {
+        WKind::bind(tell(2), move |_| WKind::pure(7))
+    });
+
+    assert_eq!(run_id(via_mdo), run_id(via_bind));
+}
+
+// ── 3. Deeper chain (depth > 2) ──────────────────────────────────────────────
+
+#[test]
+fn writer_mdo_four_step_chain() {
+    let comp: Logged<i32> = mdo! {
+        WKind;
+        _ <- tell(1);
+        _ <- tell(2);
+        _ <- tell(3);
+        _ <- tell(4);
+        WKind::pure(0)
+    };
+    assert_eq!(run_id(comp), (0, vec![1, 2, 3, 4]));
+}
+
+// ── 4. proptest: mdo! == manual bind, run-and-compared ───────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    #[test]
+    fn writer_mdo_matches_manual_over_generated_logs(a in any::<i32>(), b in any::<i32>(), v in any::<i32>()) {
+        let via_mdo: Logged<i32> = mdo! {
+            WKind;
+            _ <- tell(a);
+            _ <- tell(b);
+            WKind::pure(v)
+        };
+        let via_bind: Logged<i32> =
+            WKind::bind(tell(a), move |_| WKind::bind(tell(b), move |_| WKind::pure(v)));
+        prop_assert_eq!(run_id(via_mdo), run_id(via_bind));
+    }
+}

--- a/tests/kind/mod.rs
+++ b/tests/kind/mod.rs
@@ -9,6 +9,7 @@ pub mod identity;
 #[allow(clippy::module_inception)]
 pub mod kind;
 pub mod monad;
+pub mod monoid;
 pub mod proptest_laws;
 pub mod transformers;
 

--- a/tests/kind/monoid.rs
+++ b/tests/kind/monoid.rs
@@ -1,0 +1,55 @@
+//! Law tests for the `Semigroup`/`Monoid` instances (`()`, `String`, `Vec<T>`).
+//!
+//! Verifies associativity of `combine` and left/right identity of `empty`.
+
+use monadify::monoid::{Monoid, Semigroup};
+
+// ── () : the trivial monoid ──────────────────────────────────────────────────
+
+#[test]
+fn unit_monoid_is_trivial() {
+    #[allow(clippy::unit_arg, clippy::let_unit_value)]
+    let combined = ().combine(());
+    assert_eq!(combined, ());
+    assert_eq!(<() as Monoid>::empty(), ());
+}
+
+// ── String under concatenation ──────────────────────────────────────────────
+
+#[test]
+fn string_semigroup_associativity() {
+    let a = "foo".to_string();
+    let b = "bar".to_string();
+    let c = "baz".to_string();
+    let left = a.clone().combine(b.clone()).combine(c.clone());
+    let right = a.combine(b.combine(c));
+    assert_eq!(left, right);
+    assert_eq!(left, "foobarbaz");
+}
+
+#[test]
+fn string_monoid_identity() {
+    let x = "hello".to_string();
+    assert_eq!(String::empty().combine(x.clone()), x);
+    assert_eq!(x.clone().combine(String::empty()), x);
+}
+
+// ── Vec<T> under concatenation ──────────────────────────────────────────────
+
+#[test]
+fn vec_semigroup_associativity() {
+    let a = vec![1, 2];
+    let b = vec![3];
+    let c = vec![4, 5];
+    let left = a.clone().combine(b.clone()).combine(c.clone());
+    let right = a.combine(b.combine(c));
+    assert_eq!(left, right);
+    assert_eq!(left, vec![1, 2, 3, 4, 5]);
+}
+
+#[test]
+fn vec_monoid_identity() {
+    let x = vec!['a', 'b', 'c'];
+    assert_eq!(Vec::empty().combine(x.clone()), x);
+    assert_eq!(x.clone().combine(Vec::empty()), x);
+}

--- a/tests/kind/proptest_laws/mod.rs
+++ b/tests/kind/proptest_laws/mod.rs
@@ -20,6 +20,7 @@ pub mod functor;
 pub mod monad;
 pub mod rcfn;
 pub mod state;
+pub mod writer;
 
 // --- Arbitrary strategies (reusable across the law-family modules) ---
 

--- a/tests/kind/proptest_laws/writer.rs
+++ b/tests/kind/proptest_laws/writer.rs
@@ -1,0 +1,113 @@
+//! Property-based (`proptest`) law tests for `WriterTKind` (the Writer transformer).
+//!
+//! Companion to the example-based tests in
+//! `tests/kind/transformers/writer.rs`. The plain `Writer<W, A>` (inner
+//! `IdentityKind`) has structural `Eq` once unwrapped, so laws compare the
+//! produced `(value, log)` pair directly.
+//!
+//! Covers the three Monad laws plus the Writer-specific laws (`tell` appends
+//! monoidally, `tell(empty) == pure(())`) over `WriterTKind<Vec<i32>,
+//! IdentityKind>`, with Kleisli arrows materialized from generated `linear_fn`
+//! slope/intercept parameters and generated log values.
+
+use super::linear_fn;
+use monadify::applicative::kind::Applicative;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::monad::kind::Bind;
+use monadify::monoid::{Monoid, Semigroup};
+use monadify::transformers::writer::{MonadWriter, Writer, WriterTKind};
+use proptest::prelude::*;
+
+type W<A> = Writer<Vec<i32>, A>;
+type WKind = WriterTKind<Vec<i32>, IdentityKind>;
+
+fn run<A>(w: W<A>) -> (A, Vec<i32>) {
+    let Identity(pair) = w.run_writer_t;
+    pair
+}
+
+/// A logging Kleisli arrow: maps the value by a linear fn and appends `log`.
+fn arrow(slope: i32, intercept: i32, log: Vec<i32>) -> impl Fn(i32) -> W<i32> + Clone {
+    move |x: i32| {
+        let mut lf = linear_fn(slope, intercept);
+        let v = lf(x);
+        <WKind as MonadWriter<Vec<i32>, i32, IdentityKind>>::writer(v, log.clone())
+    }
+}
+
+fn arb_log() -> impl Strategy<Value = Vec<i32>> {
+    prop::collection::vec(any::<i32>(), 0..=8)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    // --- Monad laws (logging) ---
+
+    /// Left identity: `bind(pure(a), f) == f(a)`.
+    #[test]
+    fn writer_monad_left_identity(a in any::<i32>(),
+                                  (sl, ic) in (any::<i32>(), any::<i32>()), log in arb_log()) {
+        let f = arrow(sl, ic, log);
+        let lhs = WKind::bind(WKind::pure(a), f.clone());
+        let rhs = f(a);
+        prop_assert_eq!(run(lhs), run(rhs));
+    }
+
+    /// Right identity: `bind(m, pure) == m`.
+    #[test]
+    fn writer_monad_right_identity(v in any::<i32>(), log in arb_log()) {
+        let m = || <WKind as MonadWriter<Vec<i32>, i32, IdentityKind>>::writer(v, log.clone());
+        let lhs = WKind::bind(m(), WKind::pure);
+        prop_assert_eq!(run(lhs), run(m()));
+    }
+
+    /// Associativity: `bind(bind(m, f), g) == bind(m, |x| bind(f(x), g))`.
+    #[test]
+    fn writer_monad_associativity(v in any::<i32>(), m_log in arb_log(),
+                                  (sl1, ic1) in (any::<i32>(), any::<i32>()), log1 in arb_log(),
+                                  (sl2, ic2) in (any::<i32>(), any::<i32>()), log2 in arb_log()) {
+        let f = arrow(sl1, ic1, log1);
+        let g = arrow(sl2, ic2, log2);
+        let m = || <WKind as MonadWriter<Vec<i32>, i32, IdentityKind>>::writer(v, m_log.clone());
+
+        let lhs = WKind::bind(WKind::bind(m(), f.clone()), g.clone());
+        let rhs = WKind::bind(m(), move |x| WKind::bind(f(x), g.clone()));
+        prop_assert_eq!(run(lhs), run(rhs));
+    }
+
+    // --- Writer-specific laws ---
+
+    /// `tell(w1) >> tell(w2) == tell(w1 <> w2)`.
+    #[test]
+    fn writer_tell_appends_monoidally(w1 in arb_log(), w2 in arb_log()) {
+        let tell = |w: Vec<i32>| <WKind as MonadWriter<Vec<i32>, (), IdentityKind>>::tell(w);
+        let lhs = WKind::bind(tell(w1.clone()), {
+            let w2 = w2.clone();
+            move |_| tell(w2.clone())
+        });
+        let rhs = tell(w1.combine(w2));
+        prop_assert_eq!(run(lhs), run(rhs));
+    }
+
+    /// `tell(empty) == pure(())`.
+    #[test]
+    fn writer_tell_empty_is_pure_unit(_ignored in any::<bool>()) {
+        let lhs = <WKind as MonadWriter<Vec<i32>, (), IdentityKind>>::tell(Vec::empty());
+        let rhs: W<()> = WKind::pure(());
+        prop_assert_eq!(run(lhs), run(rhs));
+    }
+
+    /// `censor` then run == apply the rewrite to the final log.
+    #[test]
+    fn writer_censor_rewrites_log(w in arb_log()) {
+        let tell = <WKind as MonadWriter<Vec<i32>, (), IdentityKind>>::tell(w.clone());
+        let censored = <WKind as MonadWriter<Vec<i32>, (), IdentityKind>>::censor(
+            |mut log: Vec<i32>| { log.reverse(); log },
+            tell,
+        );
+        let mut expected = w;
+        expected.reverse();
+        prop_assert_eq!(run(censored).1, expected);
+    }
+}

--- a/tests/kind/transformers/mod.rs
+++ b/tests/kind/transformers/mod.rs
@@ -2,3 +2,7 @@
 pub mod reader;
 #[cfg(not(feature = "legacy"))]
 pub mod state;
+#[cfg(not(feature = "legacy"))]
+pub mod trans;
+#[cfg(not(feature = "legacy"))]
+pub mod writer;

--- a/tests/kind/transformers/trans.rs
+++ b/tests/kind/transformers/trans.rs
@@ -1,0 +1,93 @@
+//! Tests for `MonadTrans::lift` across all three transformers.
+//!
+//! `lift` embeds an inner `M::Of<A>` into a transformer, adding none of the
+//! transformer's own effect: an ignored environment (`ReaderT`), an unchanged
+//! threaded state (`StateT`), or an empty log (`WriterT`). We also check the
+//! monad-morphism identity `lift(pure(a)) == pure(a)` for each.
+
+use monadify::applicative::kind::Applicative;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::transformers::reader::{Reader, ReaderTKind};
+use monadify::transformers::state::{State, StateTKind};
+use monadify::transformers::trans::MonadTrans;
+use monadify::transformers::writer::{Writer, WriterTKind};
+
+// ── ReaderT: lift ignores the environment ───────────────────────────────────
+
+#[test]
+fn reader_lift_ignores_env() {
+    type RKind = ReaderTKind<i32, IdentityKind>;
+    let lifted: Reader<i32, &'static str> =
+        <RKind as MonadTrans<&'static str, IdentityKind>>::lift(IdentityKind::pure("hi"));
+    // The lifted computation yields the inner value for any environment.
+    assert_eq!((lifted.run_reader_t)(0), Identity("hi"));
+}
+
+#[test]
+fn reader_lift_equals_pure() {
+    // lift(pure(a)) == pure(a)
+    type RKind = ReaderTKind<i32, IdentityKind>;
+    let lifted: Reader<i32, i32> =
+        <RKind as MonadTrans<i32, IdentityKind>>::lift(IdentityKind::pure(5));
+    let pured: Reader<i32, i32> = RKind::pure(5);
+    assert_eq!((lifted.run_reader_t)(42), (pured.run_reader_t)(42));
+}
+
+// ── StateT: lift threads state unchanged ────────────────────────────────────
+
+#[test]
+fn state_lift_threads_state_unchanged() {
+    type SKind = StateTKind<i32, IdentityKind>;
+    let lifted: State<i32, &'static str> =
+        <SKind as MonadTrans<&'static str, IdentityKind>>::lift(IdentityKind::pure("v"));
+    // Value comes from the inner computation; state passes through untouched.
+    assert_eq!((lifted.run_state_t)(99), Identity(("v", 99)));
+}
+
+#[test]
+fn state_lift_equals_pure() {
+    type SKind = StateTKind<i32, IdentityKind>;
+    let lifted: State<i32, i32> =
+        <SKind as MonadTrans<i32, IdentityKind>>::lift(IdentityKind::pure(8));
+    let pured: State<i32, i32> = SKind::pure(8);
+    assert_eq!((lifted.run_state_t)(3), (pured.run_state_t)(3));
+}
+
+// ── WriterT: lift adds an empty log ─────────────────────────────────────────
+
+#[test]
+fn writer_lift_adds_empty_log() {
+    type WKind = WriterTKind<String, IdentityKind>;
+    let lifted: Writer<String, i32> =
+        <WKind as MonadTrans<i32, IdentityKind>>::lift(IdentityKind::pure(7));
+    let Identity((v, log)) = lifted.run_writer_t;
+    assert_eq!(v, 7);
+    assert_eq!(log, ""); // empty log
+}
+
+#[test]
+fn writer_lift_equals_pure() {
+    type WKind = WriterTKind<String, IdentityKind>;
+    let lifted: Writer<String, i32> =
+        <WKind as MonadTrans<i32, IdentityKind>>::lift(IdentityKind::pure(6));
+    let pured: Writer<String, i32> = WKind::pure(6);
+    assert_eq!(lifted.run_writer_t, pured.run_writer_t);
+}
+
+// ── Effectful inner monad: lift over OptionKind ─────────────────────────────
+
+#[test]
+fn writer_lift_over_option_some() {
+    use monadify::OptionKind;
+    type WKind = WriterTKind<String, OptionKind>;
+    let lifted = <WKind as MonadTrans<i32, OptionKind>>::lift(Some(11));
+    assert_eq!(lifted.run_writer_t, Some((11, String::new())));
+}
+
+#[test]
+fn writer_lift_over_option_none() {
+    use monadify::OptionKind;
+    type WKind = WriterTKind<String, OptionKind>;
+    let lifted = <WKind as MonadTrans<i32, OptionKind>>::lift(None);
+    assert_eq!(lifted.run_writer_t, None);
+}

--- a/tests/kind/transformers/writer.rs
+++ b/tests/kind/transformers/writer.rs
@@ -1,0 +1,206 @@
+//! Example-based law tests for `WriterTKind` (the Writer monad transformer).
+//!
+//! `WriterT<W, M, A>` wraps `M::Of<(A, W)>`. The plain `Writer<W, A>` (inner
+//! `IdentityKind`) has structural `Eq` once unwrapped, so most laws compare the
+//! produced `(value, log)` pair directly; for the effectful inner monad we use
+//! `OptionKind` and compare `Option<(A, W)>` (including `None` short-circuit).
+//!
+//! Coverage: Functor/Applicative/Apply/Bind/Monad smoke tests, the three Monad
+//! laws, and the four `MonadWriter` operations (`tell`, `writer`, `listen`,
+//! `censor`) — in particular the key Writer law `tell(w1) >> tell(w2) ==
+//! tell(w1 <> w2)`.
+
+use monadify::applicative::kind::Applicative;
+use monadify::apply::kind::Apply;
+use monadify::function::RcFn;
+use monadify::functor::kind::Functor;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::monad::kind::{Bind, Monad};
+use monadify::monoid::Monoid;
+use monadify::transformers::writer::{MonadWriter, Writer, WriterT, WriterTKind};
+use monadify::OptionKind;
+
+// ── Identity-inner helpers (the plain Writer monad over a String log) ────────
+
+type W<A> = Writer<String, A>; // WriterT<String, IdentityKind, A>
+type WKind = WriterTKind<String, IdentityKind>;
+
+/// Unwrap a `Writer<String, A>` to its `(value, log)` pair.
+fn run_id<A>(w: W<A>) -> (A, String) {
+    let Identity(pair) = w.run_writer_t;
+    pair
+}
+
+fn tell(s: &str) -> W<()> {
+    <WKind as MonadWriter<String, (), IdentityKind>>::tell(s.to_string())
+}
+
+// ── Functor / Applicative / Apply / Bind / Monad smoke tests ────────────────
+
+#[test]
+fn functor_map_preserves_log() {
+    // map touches the value, never the log.
+    let w: W<i32> =
+        <WKind as MonadWriter<String, i32, IdentityKind>>::writer(10, "log".to_string());
+    let mapped = WKind::map(w, |v| v * 2);
+    assert_eq!(run_id(mapped), (20, "log".to_string()));
+}
+
+#[test]
+fn applicative_pure_has_empty_log() {
+    let w: W<i32> = WKind::pure(42);
+    assert_eq!(run_id(w), (42, String::empty()));
+}
+
+#[test]
+fn apply_combines_logs_function_first() {
+    // value carries log "v"; function carries log "f".
+    let value: W<i32> =
+        <WKind as MonadWriter<String, i32, IdentityKind>>::writer(5, "v".to_string());
+    let func: W<RcFn<i32, i32>> =
+        WriterT::new(Identity((RcFn::new(|a: i32| a * 10), "f".to_string())));
+    let applied = <WKind as Apply<i32, i32>>::apply(value, func);
+    // function log precedes value log: "f" <> "v" == "fv"; value 5 * 10 == 50.
+    assert_eq!(run_id(applied), (50, "fv".to_string()));
+}
+
+#[test]
+fn bind_combines_logs_in_order() {
+    let m: W<i32> = <WKind as MonadWriter<String, i32, IdentityKind>>::writer(1, "a".to_string());
+    let bound = WKind::bind(m, |x| {
+        <WKind as MonadWriter<String, i32, IdentityKind>>::writer(x + 1, "b".to_string())
+    });
+    // input log "a" then next log "b": "ab"; value 1 + 1 == 2.
+    assert_eq!(run_id(bound), (2, "ab".to_string()));
+}
+
+#[test]
+fn join_flattens_combining_logs() {
+    let inner: W<i32> =
+        <WKind as MonadWriter<String, i32, IdentityKind>>::writer(7, "in".to_string());
+    let nested: W<W<i32>> = WriterT::new(Identity((inner, "out".to_string())));
+    let flat = WKind::join(nested);
+    // outer log "out" then inner log "in": "outin".
+    assert_eq!(run_id(flat), (7, "outin".to_string()));
+}
+
+// ── Monad laws (observational over the produced (value, log) pair) ───────────
+
+#[test]
+fn monad_left_identity() {
+    // pure(a).bind(f) == f(a)
+    let f =
+        |x: i32| <WKind as MonadWriter<String, i32, IdentityKind>>::writer(x * 3, "f".to_string());
+    let lhs = WKind::bind(WKind::pure(4), f);
+    let rhs = f(4);
+    assert_eq!(run_id(lhs), run_id(rhs));
+}
+
+#[test]
+fn monad_right_identity() {
+    // m.bind(pure) == m
+    let m: W<i32> = <WKind as MonadWriter<String, i32, IdentityKind>>::writer(9, "m".to_string());
+    let m2: W<i32> = <WKind as MonadWriter<String, i32, IdentityKind>>::writer(9, "m".to_string());
+    let lhs = WKind::bind(m, WKind::pure);
+    assert_eq!(run_id(lhs), run_id(m2));
+}
+
+#[test]
+fn monad_associativity() {
+    // m.bind(f).bind(g) == m.bind(|x| f(x).bind(g))
+    let f =
+        |x: i32| <WKind as MonadWriter<String, i32, IdentityKind>>::writer(x + 1, "f".to_string());
+    let g =
+        |y: i32| <WKind as MonadWriter<String, i32, IdentityKind>>::writer(y * 2, "g".to_string());
+
+    let m: W<i32> = <WKind as MonadWriter<String, i32, IdentityKind>>::writer(3, "m".to_string());
+    let lhs = WKind::bind(WKind::bind(m, f), g);
+
+    let m2: W<i32> = <WKind as MonadWriter<String, i32, IdentityKind>>::writer(3, "m".to_string());
+    let rhs = WKind::bind(m2, move |x| WKind::bind(f(x), g));
+
+    assert_eq!(run_id(lhs), run_id(rhs));
+}
+
+// ── MonadWriter operations ──────────────────────────────────────────────────
+
+#[test]
+fn writer_tell_appends_monoidally() {
+    // THE Writer law: tell(w1) >> tell(w2) == tell(w1 <> w2)
+    let lhs = WKind::bind(tell("foo"), move |_| tell("bar"));
+    let rhs = tell("foobar");
+    assert_eq!(run_id(lhs.clone()), run_id(rhs));
+    assert_eq!(run_id(lhs).1, "foobar");
+}
+
+#[test]
+fn writer_tell_empty_is_pure_unit() {
+    // tell(empty) == pure(())
+    let lhs = <WKind as MonadWriter<String, (), IdentityKind>>::tell(String::empty());
+    let rhs: W<()> = WKind::pure(());
+    assert_eq!(run_id(lhs), run_id(rhs));
+}
+
+#[test]
+fn writer_constructs_value_and_log() {
+    let w = <WKind as MonadWriter<String, i32, IdentityKind>>::writer(99, "note".to_string());
+    assert_eq!(run_id(w), (99, "note".to_string()));
+}
+
+#[test]
+fn writer_listen_exposes_log() {
+    // listen(tell(w)) yields value ((), w) with the log left in place == w.
+    let listened = <WKind as MonadWriter<String, (), IdentityKind>>::listen(tell("xyz"));
+    let ((unit, exposed), log) = run_id(listened);
+    assert_eq!(unit, ());
+    assert_eq!(exposed, "xyz");
+    assert_eq!(log, "xyz");
+}
+
+#[test]
+fn writer_censor_rewrites_log() {
+    // censor(f, tell(w)) rewrites the log to f(w), leaving the value.
+    let censored = <WKind as MonadWriter<String, (), IdentityKind>>::censor(
+        |w: String| w.to_uppercase(),
+        tell("quiet"),
+    );
+    assert_eq!(run_id(censored), ((), "QUIET".to_string()));
+}
+
+#[test]
+fn writer_vec_log_accumulates() {
+    // A Vec<&str> log accumulates as an event list across binds.
+    type EvKind = WriterTKind<Vec<i32>, IdentityKind>;
+    let ev = |n: i32| <EvKind as MonadWriter<Vec<i32>, (), IdentityKind>>::tell(vec![n]);
+    let prog = EvKind::bind(ev(1), move |_| EvKind::bind(ev(2), move |_| ev(3)));
+    let Identity(((), log)) = prog.run_writer_t;
+    assert_eq!(log, vec![1, 2, 3]);
+}
+
+// ── Effectful inner monad: OptionKind threading + None short-circuit ──────────
+
+type OptW<A> = WriterT<String, OptionKind, A>;
+type OptWKind = WriterTKind<String, OptionKind>;
+
+#[test]
+fn option_inner_threads_log_when_some() {
+    let tell_opt = |s: &str| <OptWKind as MonadWriter<String, (), OptionKind>>::tell(s.to_string());
+    let prog = OptWKind::bind(tell_opt("a"), move |_| tell_opt("b"));
+    assert_eq!(prog.run_writer_t, Some(((), "ab".to_string())));
+}
+
+#[test]
+fn option_inner_none_short_circuits() {
+    // A computation that fails inside the inner Option discards the log.
+    let failing: OptW<i32> = WriterT::new(None);
+    let bound = OptWKind::bind(failing, |x| {
+        <OptWKind as MonadWriter<String, i32, OptionKind>>::writer(x, "never".to_string())
+    });
+    assert_eq!(bound.run_writer_t, None);
+}
+
+#[test]
+fn option_inner_pure_empty_log() {
+    let w: OptW<i32> = OptWKind::pure(7);
+    assert_eq!(w.run_writer_t, Some((7, String::empty())));
+}


### PR DESCRIPTION
## Summary

Adds **WriterT**, the third monad transformer (after ReaderT and StateT), together with the **Monoid** abstraction it requires and a general **MonadTrans/lift** trait — now justified by three implementors.

`WriterT<W, M, A>` wraps an inner value `M::Of<(A, W)>` (a *value*, not a function — structurally unlike Reader/State which wrap `Rc<dyn Fn>`). It belongs to the **ReaderT family**: `apply` needs only an inner `Apply` because logs are *combined* (no sequential data dependency like StateT's threaded state). The new ingredient is `W: Monoid` — `pure` seeds the log at `empty`, every sequencing step `combine`s logs, and the key Writer law `tell(w1) >> tell(w2) ≡ tell(w1 <> w2)` is law-tested.

## What's included

**New abstractions**
- `src/monoid.rs` — `Semigroup { combine }` + `Monoid: Semigroup { empty }`; instances for `()`, `String`, `Vec<T>`. (monadify had no Monoid trait before.)
- `src/transformers/writer.rs` — `WriterT`/`WriterTKind`/`Writer` with the full `Functor → Apply → Applicative → Bind → Monad` hierarchy, the `MonadWriter` trait (`tell`/`writer`/`listen`/`censor`), and runners `eval_writer_t`/`exec_writer_t`.
- `src/transformers/trans.rs` — `MonadTrans::lift`, implemented for **ReaderTKind, StateTKind, and WriterTKind**. Reader/State `lift` require the inner value `Clone` (their `Fn` carriers rerun); Writer does not (value consumed once).

**Wiring** — `lib.rs` (new `monoid` module + crate-root re-exports), `transformers/mod.rs`, `CLAUDE.md` (marker list, Layout, instances).

## Tests (46 new, all pass)
- Monoid/Semigroup laws (associativity, identity) for `()`, `String`, `Vec<T>`
- WriterT example laws: Functor/Applicative/Apply/Bind/Monad smoke + 3 Monad laws + `MonadWriter` ops, over `IdentityKind` and `OptionKind` (incl. `None` short-circuit)
- `lift` across all three transformers + the `lift(pure a) == pure a` morphism law
- `mdo!` do-notation (incl. proptest) and proptest property laws over `Vec<i32>` logs

## Quality gates — all green
`fmt` · `clippy --all-targets --all-features -D warnings` · default (266) · legacy · do-notation (410) · all-features · doc-tests (24) · **MSRV 1.66** fresh-lock (default + all-features) · zero-dependency guard (Rc/std only, no new deps).

## Review
rust-reviewer: law analysis clean (`pure`/`apply`/`bind`/`join`/`listen`/`censor` + both `lift` laws all lawful). Addressed: crate-root re-exports, dropped a spurious `T: Clone` on `pure`, removed a redundant clone in `bind`, added `eval_writer_t` for symmetry with StateT.

## Notes
- Additive and non-breaking. Closes the `lift`/`MonadTrans` follow-up left open by StateT.
- Unreleased: crate stays `0.2.0`; StateT + WriterT would ship in a future `0.3.0`.
- Runnable Writer examples are a likely follow-up PR (mirroring the StateT examples PR).