### PR TITLE
docs(examples): add real-world WriterT examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,19 @@ required-features = ["do-notation"]
 [[example]]
 name = "state_bank_account"
 required-features = ["do-notation"]
+
+[[example]]
+name = "writer_audit_log"
+required-features = ["do-notation"]
+
+[[example]]
+name = "writer_cost_monoid"
+required-features = ["do-notation"]
+
+[[example]]
+name = "writer_listen_censor"
+required-features = ["do-notation"]
+
+[[example]]
+name = "writer_eval_trace"
+required-features = ["do-notation"]

--- a/README.md
+++ b/README.md
@@ -140,6 +140,25 @@ cargo run --example state_bank_account --features do-notation
 
 See [`monadify::mdo`](https://docs.rs/monadify) documentation for full details.
 
+### Writer monad examples
+
+These demonstrate the `WriterT` Writer monad accumulating a monoidal log through a
+computation via `mdo!` do-notation — `tell` appends to the log while the result is
+threaded as usual:
+
+- `writer_audit_log.rs` — order/payment pipeline whose `Vec<String>` audit trail is the Writer log (`tell`)
+- `writer_cost_monoid.rs` — running cost accumulated via a user-defined `Sum(u64)` monoid (your own `Semigroup`/`Monoid` impl)
+- `writer_listen_censor.rs` — scoped, redacting logger using `listen` (capture a sub-computation's log) and `censor` (rewrite the log)
+- `writer_eval_trace.rs` — arithmetic evaluator accumulating a `String` step-by-step trace
+
+Run any of them with (each requires the `do-notation` feature):
+```bash
+cargo run --example writer_audit_log     --features do-notation
+cargo run --example writer_cost_monoid   --features do-notation
+cargo run --example writer_listen_censor --features do-notation
+cargo run --example writer_eval_trace    --features do-notation
+```
+
 ## Building the Project
 
 To build the library:

--- a/examples/writer_audit_log.rs
+++ b/examples/writer_audit_log.rs
@@ -1,0 +1,108 @@
+//! Do-notation with WriterT: order/payment processing audit log example.
+//!
+//! Demonstrates accumulating a monoidal audit trail through an order/payment
+//! pipeline using `mdo!` do-blocks and `Writer<Vec<String>, A>`.
+//! Each pipeline step appends one log entry via `tell`; the logs are combined
+//! monoidally by `bind` — no log vector is ever threaded through arguments.
+//!
+//! Run with: `cargo run --example writer_audit_log --features do-notation`
+
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::transformers::writer::{MonadWriter, Writer, WriterTKind};
+
+/// Type alias: a computation that accumulates a `Vec<String>` audit log and
+/// produces a value `A`.
+/// `Writer<W, A> = WriterT<W, IdentityKind, A>`.
+type Logged<A> = Writer<Vec<String>, A>;
+
+/// Kind marker alias for the `mdo!` macro: `WriterTKind<Vec<String>, IdentityKind>`.
+type WKind = WriterTKind<Vec<String>, IdentityKind>;
+
+// ── Helper wrappers ───────────────────────────────────────────────────────────
+
+/// Appends a single audit entry to the log, yielding unit.
+fn step(s: &str) -> Logged<()> {
+    <WKind as MonadWriter<Vec<String>, (), IdentityKind>>::tell(vec![s.to_string()])
+}
+
+// ── Pipeline ─────────────────────────────────────────────────────────────────
+
+/// Order/payment processing pipeline for order #42 totalling $100.
+///
+/// Three audit steps — validate, charge, ship — each append one log entry.
+/// The final value is the captured amount in cents (`100u64`).
+/// Each `_ <- tell` binds `()` (which is `Copy`), so no non-`Copy` capture
+/// restriction is triggered across `mdo!` nesting levels.
+fn pipeline() -> Logged<u64> {
+    mdo! {
+        WKind;
+        _ <- step("validate: order #42 ok");
+        _ <- step("charge: $100 captured");
+        _ <- step("ship: order #42 dispatched");
+        pure(100u64)
+    }
+}
+
+fn main() {
+    println!("=== Do-notation with WriterT: Order/Payment Audit Log ===\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: run_writer_t — both value and accumulated log
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("Test 1: run_writer_t — value and full audit trail");
+    let Identity((value, trail)) = pipeline().run_writer_t;
+    assert_eq!(value, 100u64, "captured amount must be 100");
+    assert_eq!(
+        trail,
+        vec![
+            "validate: order #42 ok".to_string(),
+            "charge: $100 captured".to_string(),
+            "ship: order #42 dispatched".to_string(),
+        ],
+        "audit trail must contain exactly the three ordered entries"
+    );
+    println!("  Value (captured amount): {}", value);
+    println!("  Audit trail:");
+    for (i, entry) in trail.iter().enumerate() {
+        println!("    [{}] {}", i + 1, entry);
+    }
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: eval_writer_t — value only (log discarded)
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("Test 2: eval_writer_t — value only");
+    let Identity(v) = pipeline().eval_writer_t();
+    assert_eq!(v, 100, "eval_writer_t must return the captured amount 100");
+    println!("  eval_writer_t -> {}", v);
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 3: exec_writer_t — log only (value discarded)
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("Test 3: exec_writer_t — audit log only");
+    let Identity(log) = pipeline().exec_writer_t();
+    assert_eq!(
+        log.len(),
+        3,
+        "exec_writer_t must return exactly 3 audit entries"
+    );
+    println!("  exec_writer_t -> {} entries", log.len());
+    for entry in &log {
+        println!("    - {}", entry);
+    }
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Summary
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("=== All tests passed! ===");
+    println!("\nKey insight: `mdo!` with `WriterT` accumulates the audit trail implicitly:");
+    println!("  * `tell`          appends one log entry and yields unit.");
+    println!("  * `bind`          sequences steps and combines their logs monoidally.");
+    println!("  * `run_writer_t`  is a field exposing `Identity<(value, log)>` directly.");
+    println!("  * `eval_writer_t` projects the produced value (log discarded).");
+    println!("  * `exec_writer_t` projects the accumulated log  (value discarded).");
+    println!("  * No log vector is ever threaded through any function argument.");
+}

--- a/examples/writer_cost_monoid.rs
+++ b/examples/writer_cost_monoid.rs
@@ -1,0 +1,113 @@
+//! Do-notation with WriterT: query-plan cost accumulation via a user-defined monoid.
+//!
+//! Demonstrates accumulating a running cost through a custom `Sum(u64)` monoid
+//! defined in this file — a "bring-your-own monoidal log" example using
+//! `mdo!` do-blocks and `Writer<Sum, A>`.
+//! Each `charge(n)` step silently appends its cost to the monoidal log; no
+//! explicit accumulator is threaded through any function argument.
+//!
+//! Run with: `cargo run --example writer_cost_monoid --features do-notation`
+
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::monoid::{Monoid, Semigroup};
+use monadify::transformers::writer::{MonadWriter, Writer, WriterTKind};
+
+// ── User-defined monoid ───────────────────────────────────────────────────────
+
+/// A newtype wrapper around `u64` that forms a monoid under wrapping addition.
+///
+/// `combine` is associative (`(a+b)+c == a+(b+c)` mod 2^64), and `Sum(0)` is
+/// the identity (`Sum(0).combine(x) == x`, `x.combine(Sum(0)) == x`).
+/// `WriterT` requires `W: Monoid + Clone`; both are satisfied because `Sum` is
+/// `Copy` (and hence `Clone` for free).
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Sum(u64);
+
+impl Semigroup for Sum {
+    fn combine(self, other: Sum) -> Sum {
+        Sum(self.0.wrapping_add(other.0))
+    }
+}
+
+impl Monoid for Sum {
+    fn empty() -> Sum {
+        Sum(0)
+    }
+}
+
+// ── Type aliases ──────────────────────────────────────────────────────────────
+
+/// A computation that accumulates a `Sum` cost log and produces `A`.
+/// `Writer<W, A> = WriterT<W, IdentityKind, A>`.
+type Costed<A> = Writer<Sum, A>;
+
+/// Kind marker alias for the `mdo!` macro: `WriterTKind<Sum, IdentityKind>`.
+type WKind = WriterTKind<Sum, IdentityKind>;
+
+// ── Helper wrapper ────────────────────────────────────────────────────────────
+
+/// Record a cost of `n` units, appending `Sum(n)` to the log and yielding unit.
+fn charge(n: u64) -> Costed<()> {
+    <WKind as MonadWriter<Sum, (), IdentityKind>>::tell(Sum(n))
+}
+
+// ── Programs ──────────────────────────────────────────────────────────────────
+
+/// Model a simple query plan: scan(5) → filter(2) → sort(10) → project(1).
+///
+/// Each operator charges its cost via `charge`; the log accumulates the total.
+fn plan() -> Costed<&'static str> {
+    mdo! {
+        WKind;
+        _ <- charge(5);   // scan
+        _ <- charge(2);   // filter
+        _ <- charge(10);  // sort
+        _ <- charge(1);   // project
+        pure("query result")
+    }
+}
+
+fn main() {
+    println!("=== Do-notation with WriterT: Query-Plan Cost Accumulation ===\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: exec_writer_t — accumulated cost log only
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("Test 1: exec_writer_t — total cost (scan=5, filter=2, sort=10, project=1)");
+    let Identity(total) = plan().exec_writer_t();
+    assert_eq!(total, Sum(18), "total cost must be Sum(18)");
+    println!("  Total cost: {:?} (expected Sum(18))", total);
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: eval_writer_t — produced value only (log discarded)
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("Test 2: eval_writer_t — produced value (log discarded)");
+    let Identity(v) = plan().eval_writer_t();
+    assert_eq!(v, "query result", "produced value must be \"query result\"");
+    println!("  Value: {:?} (expected \"query result\")", v);
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 3: run_writer_t — both value and log together
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("Test 3: run_writer_t — value and accumulated log together");
+    let Identity((result, cost)) = plan().run_writer_t;
+    assert_eq!(result, "query result");
+    assert_eq!(cost, Sum(18));
+    println!("  (value, cost): ({:?}, {:?})", result, cost);
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Summary
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("=== All tests passed! ===");
+    println!("\nKey insight: `mdo!` with `WriterT` accumulates the cost log implicitly:");
+    println!("  * `tell` (via `charge`) appends a `Sum(n)` to the log and yields unit.");
+    println!("  * `Semigroup::combine` (`wrapping_add`) stitches logs together at each bind.");
+    println!("  * `Monoid::empty` (`Sum(0)`) seeds the log in `pure`.");
+    println!("  * `exec_writer_t` extracts only the accumulated log: Identity<Sum>.");
+    println!("  * `eval_writer_t` extracts only the produced value: Identity<&str>.");
+    println!("  * No explicit accumulator is threaded through any function argument.");
+}

--- a/examples/writer_eval_trace.rs
+++ b/examples/writer_eval_trace.rs
@@ -1,0 +1,114 @@
+//! Do-notation with WriterT: arithmetic expression evaluator with step-by-step trace.
+//!
+//! Demonstrates accumulating a textual trace through an arithmetic evaluation
+//! using `mdo!` do-blocks and `Writer<String, A>`.
+//! Each arithmetic step emits a human-readable trace line via `tell`; the log
+//! is combined monoidally (string concatenation) by `bind` — no trace string is
+//! ever threaded through function arguments.
+//!
+//! Run with: `cargo run --example writer_eval_trace --features do-notation`
+
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::transformers::writer::{MonadWriter, Writer, WriterTKind};
+
+/// Type alias: a computation that accumulates a `String` trace log and
+/// produces a value `A`.
+/// `Writer<W, A> = WriterT<W, IdentityKind, A>`.
+type Traced<A> = Writer<String, A>;
+
+/// Kind marker alias for the `mdo!` macro: `WriterTKind<String, IdentityKind>`.
+type WKind = WriterTKind<String, IdentityKind>;
+
+// ── Helper wrappers ───────────────────────────────────────────────────────────
+
+/// Appends a single trace line to the log, yielding unit.
+fn trace(line: String) -> Traced<()> {
+    <WKind as MonadWriter<String, (), IdentityKind>>::tell(line)
+}
+
+// ── Step combinators ─────────────────────────────────────────────────────────
+
+/// Adds two integers and emits a trace line recording the operation.
+fn add(a: i64, b: i64) -> Traced<i64> {
+    mdo! { WKind;
+        _ <- trace(format!("add {} + {} = {}\n", a, b, a + b));
+        pure(a + b)
+    }
+}
+
+/// Multiplies two integers and emits a trace line recording the operation.
+fn mul(a: i64, b: i64) -> Traced<i64> {
+    mdo! { WKind;
+        _ <- trace(format!("mul {} * {} = {}\n", a, b, a * b));
+        pure(a * b)
+    }
+}
+
+// ── Evaluator ─────────────────────────────────────────────────────────────────
+
+/// Evaluates `(2 + 3) * 4` and accumulates a step-by-step trace.
+///
+/// `s` and `p` are `i64` (Copy), so they cross `mdo!` nesting levels freely
+/// without triggering the non-Copy capture restriction.
+fn eval() -> Traced<i64> {
+    mdo! { WKind;
+        s <- add(2, 3);
+        p <- mul(s, 4);
+        pure(p)
+    }
+}
+
+fn main() {
+    println!("=== Do-notation with WriterT: Arithmetic Expression Evaluator ===\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: eval_writer_t — value only (trace discarded)
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("Test 1: eval_writer_t — produced value only");
+    let Identity(value) = eval().eval_writer_t();
+    assert_eq!(value, 20, "eval_writer_t must return 20 for (2+3)*4");
+    println!("  eval_writer_t -> {} (expected 20)", value);
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: exec_writer_t — trace log only (value discarded)
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("Test 2: exec_writer_t — accumulated trace log only");
+    let Identity(trace_log) = eval().exec_writer_t();
+    assert_eq!(
+        trace_log, "add 2 + 3 = 5\nmul 5 * 4 = 20\n",
+        "exec_writer_t must return the two-line trace in evaluation order"
+    );
+    println!("  exec_writer_t trace:");
+    for line in trace_log.lines() {
+        println!("    {}", line);
+    }
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 3: run_writer_t — both value and trace in one shot
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("Test 3: run_writer_t — value and trace together");
+    let Identity((result, full_trace)) = eval().run_writer_t;
+    assert_eq!(result, 20, "run_writer_t value must be 20");
+    assert_eq!(
+        full_trace, "add 2 + 3 = 5\nmul 5 * 4 = 20\n",
+        "run_writer_t trace must match the two-line evaluation log"
+    );
+    println!("  Result: {}", result);
+    println!("  Full trace:\n{}", full_trace);
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Summary
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("=== All tests passed! ===");
+    println!("\nKey insight: `mdo!` with `WriterT<String, _>` accumulates a step-by-step trace:");
+    println!("  * `tell`          appends one trace line and yields unit.");
+    println!("  * `bind`          sequences steps and concatenates their logs monoidally.");
+    println!("  * `run_writer_t`  is a field exposing `Identity<(value, log)>` directly.");
+    println!("  * `eval_writer_t` projects the produced value  (trace discarded).");
+    println!("  * `exec_writer_t` projects the accumulated log (value discarded).");
+    println!("  * No trace string is ever threaded through any function argument.");
+}

--- a/examples/writer_listen_censor.rs
+++ b/examples/writer_listen_censor.rs
@@ -1,0 +1,135 @@
+//! Do-notation with WriterT: scoped + redacting logger demo.
+//!
+//! Demonstrates `listen` and `censor` from `MonadWriter` using `mdo!` do-blocks
+//! and `Writer<Vec<String>, A>`.
+//! - `listen` exposes a computation's accumulated log as a value while leaving
+//!   the same log in the outer log.
+//! - `censor` rewrites a computation's log with a pure function, leaving the
+//!   value unchanged. Used here to redact sensitive entries before they appear
+//!   in the outer log.
+//!
+//! Run with: `cargo run --example writer_listen_censor --features do-notation`
+
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::transformers::writer::{MonadWriter, Writer, WriterTKind};
+
+/// Type alias: a computation that accumulates a `Vec<String>` log and produces `A`.
+/// `Writer<W, A> = WriterT<W, IdentityKind, A>`.
+type Logged<A> = Writer<Vec<String>, A>;
+
+/// Kind marker alias for the `mdo!` macro: `WriterTKind<Vec<String>, IdentityKind>`.
+type WKind = WriterTKind<Vec<String>, IdentityKind>;
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+/// Appends a single log entry, yielding unit.
+fn step(s: &str) -> Logged<()> {
+    <WKind as MonadWriter<Vec<String>, (), IdentityKind>>::tell(vec![s.to_string()])
+}
+
+// ── Shared sub-computation ────────────────────────────────────────────────────
+
+/// Auth sub-computation: emits three log entries and yields unit.
+fn auth_steps() -> Logged<()> {
+    mdo! {
+        WKind;
+        _ <- step("auth: begin");
+        _ <- step("auth: password=hunter2");
+        _ <- step("auth: ok");
+        pure(())
+    }
+}
+
+// ── Demos ─────────────────────────────────────────────────────────────────────
+
+/// Listen demo: captures the auth log as a value, exposing it alongside the
+/// outer log (which also contains the auth log after `listen`).
+fn listen_demo() -> Logged<Vec<String>> {
+    mdo! {
+        WKind;
+        captured <- <WKind as MonadWriter<Vec<String>, (), IdentityKind>>::listen(auth_steps());
+        pure(captured.1)
+    }
+}
+
+/// Censor demo: redacts the password entry in the auth log, then appends a
+/// final "main: done" entry from the surrounding context.
+fn censor_demo() -> Logged<()> {
+    mdo! {
+        WKind;
+        let redact = |log: Vec<String>| -> Vec<String> {
+            log.into_iter()
+                .map(|l| {
+                    if l.contains("password") {
+                        "auth: password=***REDACTED***".to_string()
+                    } else {
+                        l
+                    }
+                })
+                .collect()
+        };
+        _ <- <WKind as MonadWriter<Vec<String>, (), IdentityKind>>::censor(redact, auth_steps());
+        _ <- step("main: done");
+        pure(())
+    }
+}
+
+fn main() {
+    println!("=== Do-notation with WriterT: Scoped + Redacting Logger ===\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: listen — captured log equals the outer log
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("Test 1: listen — captured log exposed as value, same in outer log");
+    let Identity((listened, outer_log)) = listen_demo().run_writer_t;
+    let expected_auth_log = vec![
+        "auth: begin".to_string(),
+        "auth: password=hunter2".to_string(),
+        "auth: ok".to_string(),
+    ];
+    assert_eq!(
+        listened, expected_auth_log,
+        "listen must capture the full auth log as the returned value"
+    );
+    assert_eq!(
+        outer_log, listened,
+        "listen must also leave the same log in the outer log"
+    );
+    println!("  Captured log (value):  {:?}", listened);
+    println!("  Outer log:             {:?}", outer_log);
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: censor — password entry redacted, outer steps preserved
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("Test 2: censor — password entry redacted, outer log intact");
+    let Identity(final_log) = censor_demo().exec_writer_t();
+    assert_eq!(
+        final_log,
+        vec![
+            "auth: begin".to_string(),
+            "auth: password=***REDACTED***".to_string(),
+            "auth: ok".to_string(),
+            "main: done".to_string(),
+        ],
+        "censor must redact the password entry and preserve the outer step"
+    );
+    println!("  Final log:");
+    for (i, entry) in final_log.iter().enumerate() {
+        println!("    [{}] {}", i + 1, entry);
+    }
+    println!("  PASSED\n");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Summary
+    // ─────────────────────────────────────────────────────────────────────────
+    println!("=== All tests passed! ===");
+    println!("\nKey insight: `listen` and `censor` are dual log-inspection primitives:");
+    println!("  * `listen(m)`     — exposes m's accumulated log as the returned value");
+    println!("                      while also leaving that same log in the outer log.");
+    println!("  * `censor(f, m)`  — rewrites m's log with f, value unchanged;");
+    println!("                      the outer log sees only the rewritten entries.");
+    println!("  * `run_writer_t`  — a field: `Identity((value, log))`, destructure directly.");
+    println!("  * `exec_writer_t` — a method: returns `Identity<W>` (log only).");
+}


### PR DESCRIPTION
## Summary

Adds four runnable, self-verifying **WriterT** (Writer monad) examples, mirroring the StateT examples. Each prints a narrative *and* asserts deterministic output (panics on a wrong result), so every example doubles as a test. All are gated by `required-features = ["do-notation"]` (they use `mdo!`).

| Example | Log type | Demonstrates |
|---|---|---|
| `writer_audit_log` | `Vec<String>` | An order/payment pipeline whose audit trail is the Writer log (`tell`) |
| `writer_cost_monoid` | `Sum(u64)` *(user-defined)* | Bring-your-own monoid — the example defines `Sum` and `impl`s `Semigroup`/`Monoid`, then accumulates a cost |
| `writer_listen_censor` | `Vec<String>` | A scoped, redacting logger using `listen` (capture a sub-computation's log as a value) and `censor` (rewrite the log) |
| `writer_eval_trace` | `String` | An arithmetic evaluator accumulating a step-by-step textual trace |

## Run them

```bash
cargo run --example writer_audit_log     --features do-notation
cargo run --example writer_cost_monoid   --features do-notation
cargo run --example writer_listen_censor --features do-notation
cargo run --example writer_eval_trace    --features do-notation
```

## Changes
- Four new files under `examples/`.
- `Cargo.toml`: four `[[example]]` entries with `required-features = ["do-notation"]`.
- `README.md`: a new "Writer monad examples" subsection (parallel to the State one).

## Quality
- `cargo fmt --check` · `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- All four examples run to exit 0 with their asserts passing.
- `cargo test --all-features` unaffected (examples aren't part of the lib test tree).
- rust-reviewer: approved, no blocking issues — confirmed the `Sum` monoid is lawful, the `listen`/`censor` assertions match the implementation semantics, and the audit trail / `Sum(18)` / eval trace values are arithmetically correct.

Docs/examples only — no library change. Follows PR #8 (WriterT). Crate stays `0.2.0`.