### PR TITLE
feat(transformers): add ExceptT monad transformer + MonadError

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ plus profunctor-encoded optics. v0.1.1, MIT, edition 2021, MSRV 1.66.
 The defining design simulates **Higher-Kinded Types (HKTs)** using Generic
 Associated Types: a `Kind` trait with `type Of<Arg>` plus lightweight marker
 structs (`OptionKind`, `VecKind`, `ResultKind<E>`, `CFnKind<X>`, `CFnOnceKind<X>`,
-`RcFnKind<X>`, `IdentityKind`, `ReaderTKind`, `StateTKind`, `WriterTKind`). Traits are generic over the *marker*, and
+`RcFnKind<X>`, `IdentityKind`, `ReaderTKind`, `StateTKind`, `WriterTKind`, `ExceptTKind`). Traits are generic over the *marker*, and
 `Self::Of<A>` resolves to the concrete type (e.g. `OptionKind::Of<i32> == Option<i32>`).
 Core infrastructure lives in `src/kind_based/kind.rs`.
 
@@ -28,7 +28,9 @@ Core infrastructure lives in `src/kind_based/kind.rs`.
   `MonadState` (`state`/`get`/`put`/`modify`/`gets`) + runners
   `run`/`eval`/`exec_state_t`. `src/transformers/writer.rs` — `WriterT` +
   `MonadWriter` (`tell`/`writer`/`listen`/`censor`) + runner `exec_writer_t`.
-  `src/transformers/trans.rs` — `MonadTrans` (`lift`, impl'd for all three
+  `src/transformers/except.rs` — `ExceptT` + `MonadError`
+  (`throw_error`/`catch_error`/`lift_either`) + error-channel map `with_except_t`.
+  `src/transformers/trans.rs` — `MonadTrans` (`lift`, impl'd for all four
   transformers). `src/monoid.rs` — `Semigroup`/`Monoid` (`combine`/`empty`).
   `src/utils.rs` — `fn0!`..`fn3!` macros.
 - `src/legacy/` — the older associated-type implementation, behind the `legacy`
@@ -37,15 +39,28 @@ Core infrastructure lives in `src/kind_based/kind.rs`.
   criterion benchmarks comparing kind-based vs native vs legacy.
 
 Concrete instances implementing the full hierarchy (where lawful): `Option`,
-`Result`, `Vec`, `Identity`, `RcFn`, `CFnOnce`, `ReaderT`, `StateT`, `WriterT`. `StateT`'s
+`Result`, `Vec`, `Identity`, `RcFn`, `CFnOnce`, `ReaderT`, `StateT`, `WriterT`,
+`ExceptT`. `StateT`'s
 `Apply`/`Bind`/`Monad` require the **inner** monad to be `Bind`/`Monad` (state is
 threaded — a sequential dependency), unlike `ReaderT` whose `Apply` needs only an
 inner `Apply`; its four `MonadState` laws (get-get, get-put, put-get, put-put) are
 first-class and law-tested. `WriterT` is in the **`ReaderT` family** (its `Apply`
 needs only an inner `Apply`) but adds a `W: Monoid` constraint on the log: `pure`
 seeds the log at `Monoid::empty`, every sequencing step `combine`s logs, and its
-key law `tell(w1) >> tell(w2) ≡ tell(w1 <> w2)` is law-tested. `MonadTrans::lift`
-embeds an inner `M::Of<A>` into any of the three transformers, adding no effect.
+key law `tell(w1) >> tell(w2) ≡ tell(w1 <> w2)` is law-tested. `ExceptT` is a
+**hybrid**: it has a `WriterT`-shaped *value* carrier (`run_except_t:
+M::Of<Result<A, E>>`, manual `Clone` bounded on the projected inner type) but
+sits in the **`StateT` bound-family** — its `apply`/`bind`/`join` require the
+inner monad to be `Bind`/`Monad`, because short-circuiting on `Err` is a
+sequential data dependency and an inner-`Apply`-only `apply` would break the
+Applicative–Monad consistency law (matching Haskell's `instance (Monad m) =>
+Applicative (ExceptT e m)`). It imposes the **lightest payload constraint** of
+any transformer: `E: 'static` only — no `Monoid` (unlike `WriterT`'s `W`), no
+`Clone` (unlike `StateT`'s `S`). Its `MonadError` surface is `throw_error`
+(primitive), `catch_error`, and `lift_either`, with the catch laws (catch-throw,
+catch-pure) and throw-left-zero law-tested. `MonadTrans::lift` embeds an inner
+`M::Of<A>` into any of the four transformers, adding no effect (`ExceptT`'s
+`lift` wraps the value in `Ok`).
 
 ## Conventions
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub use apply::Apply; // Points to apply::kind::Apply
 pub use functor::Functor; // Points to functor::kind::Functor
 pub use monad::{Bind, Monad}; // Points to monad::kind::Bind and monad::kind::Monad
 pub use profunctor::{Choice, Profunctor, Strong};
+pub use transformers::except::MonadError; // Points to transformers::except::kind::MonadError
 pub use transformers::reader::MonadReader; // Points to transformers::reader::kind::MonadReader
 pub use transformers::state::MonadState; // Points to transformers::state::kind::MonadState
 pub use transformers::trans::MonadTrans; // Points to transformers::trans::MonadTrans
@@ -47,12 +48,14 @@ pub use transformers::writer::MonadWriter; // Points to transformers::writer::ki
 // Public re-exports of key structs/types (optional, but can be convenient)
 pub use function::{CFnOnce, RcFn};
 pub use identity::Identity; // Points to identity::kind::Identity
+pub use transformers::except::{Except, ExceptT}; // Points to transformers::except::kind::ExceptT etc.
 pub use transformers::reader::{Reader, ReaderT}; // Points to transformers::reader::kind::ReaderT etc.
 pub use transformers::state::{State, StateT}; // Points to transformers::state::kind::StateT etc.
 pub use transformers::writer::{Writer, WriterT}; // Points to transformers::writer::kind::WriterT etc.
 
 // Re-export Kind markers and core Kind traits by default
 pub use crate::identity::IdentityKind; // Changed from IdentityHKTMarker
+pub use crate::transformers::except::ExceptTKind;
 pub use crate::transformers::reader::ReaderTKind;
 pub use crate::transformers::state::StateTKind;
 pub use crate::transformers::writer::WriterTKind;

--- a/src/transformers/except.rs
+++ b/src/transformers/except.rs
@@ -1,0 +1,439 @@
+//! # ExceptT Monad Transformer for the `monadify` library
+// Kind-based version is the default (mirrors `writer.rs`/`state.rs`).
+
+pub mod kind {
+    //! # Kind-based ExceptT Monad Transformer
+    //!
+    //! `ExceptT` (Except Transformer) augments an underlying monad (`MKind`, a
+    //! Kind marker) with **short-circuiting error handling**. A computation
+    //! `ExceptT<E, MKind, A>` is simply a wrapped inner value
+    //! `MKind::Of<Result<A, E>>` — the produced value `A` or an error `E`.
+    //!
+    //! ## A hybrid of [`WriterT`](crate::transformers::writer) and [`StateT`](crate::transformers::state)
+    //!
+    //! `ExceptT` borrows its **carrier shape** from `WriterT`: the field
+    //! [`run_except_t`](ExceptT::run_except_t) holds a *value*
+    //! `MKind::Of<Result<A, E>>` directly (not an `Rc<dyn Fn>` like
+    //! `ReaderT`/`StateT`), and [`Clone`] is hand-written, bounded on the
+    //! projected inner type.
+    //!
+    //! But it belongs to the **`StateT` bound-family**: [`apply`](apply_kind::Apply::apply),
+    //! [`bind`](monad_kind::Bind::bind), and [`join`](monad_kind::Monad::join)
+    //! require the **inner** `MKind` to be a [`Bind`](monad_kind::Bind)/[`Monad`](monad_kind::Monad),
+    //! not merely an [`Apply`](apply_kind::Apply). Short-circuiting on `Err` is a
+    //! sequential data dependency — the result of the first computation must be
+    //! inspected before the second is run or skipped — which only the inner
+    //! monad's `bind` can express. (An inner-`Apply`-only `apply` that always ran
+    //! the second computation would violate the Applicative–Monad consistency
+    //! law; this matches Haskell's `instance (Monad m) => Applicative (ExceptT e m)`.)
+    //!
+    //! ## The lightest payload constraint of any transformer
+    //!
+    //! Unlike `WriterT` (whose log needs `W: Monoid`) and `StateT` (whose state
+    //! needs `S: Clone`), `ExceptT` constrains its error type `E` only by
+    //! `'static`. The error is propagated, never combined or duplicated. (A
+    //! concrete `E: Clone` is required only *transitively*, where a concrete inner
+    //! monad such as `Vec` makes `MKind::Of<Result<A, E>>: Clone` demand it.)
+    //!
+    //! The `Result<A, E>` order is fixed: `Result<value, error>` (Rust-native,
+    //! value-biased like Haskell's `Right`). Transposing it silently breaks the
+    //! monad laws.
+    //!
+    //! ## Key Components
+    //! - [`ExceptT<E, MKind, A>`]: the computation, wrapping `MKind::Of<Result<A, E>>`.
+    //! - [`ExceptTKind<E, MKind>`]: the Kind marker for `ExceptT`.
+    //! - [`MonadError<E, A, MKind>`]: a trait providing `throw_error`,
+    //!   `catch_error`, and `lift_either`.
+    //! - [`Except<E, A>`]: alias for `ExceptT<E, IdentityKind, A>` (the plain Except monad).
+    //!
+    //! ## Example
+    //! ```
+    //! use monadify::transformers::except::{Except, ExceptT, ExceptTKind, MonadError};
+    //! use monadify::IdentityKind;
+    //! use monadify::Identity;
+    //! use monadify::monad::kind::Bind;
+    //!
+    //! type Checked<A> = Except<String, A>;          // ExceptT<String, IdentityKind, A>
+    //! type CheckedKind = ExceptTKind<String, IdentityKind>;
+    //!
+    //! // `throw_error` injects an error; the rest of the bind chain is skipped.
+    //! let boom = |msg: &str| <CheckedKind as MonadError<String, i32, IdentityKind>>::throw_error(msg.to_string());
+    //!
+    //! let prog: Checked<i32> = CheckedKind::bind(boom("nope"), move |x| CheckedKind::bind(
+    //!     <CheckedKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(x + 1)),
+    //!     move |y| <CheckedKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(y * 2)),
+    //! ));
+    //! let Identity(res) = prog.run_except_t;
+    //! assert_eq!(res, Err("nope".to_string())); // short-circuited
+    //!
+    //! // `catch_error` recovers from the error.
+    //! let recovered: Checked<i32> = <CheckedKind as MonadError<String, i32, IdentityKind>>::catch_error(
+    //!     boom("bad"),
+    //!     |_e| <CheckedKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(0)),
+    //! );
+    //! let Identity(res2) = recovered.run_except_t;
+    //! assert_eq!(res2, Ok(0));
+    //! ```
+
+    use crate::applicative::kind as applicative_kind;
+    use crate::apply::kind as apply_kind;
+    use crate::function::RcFn; // Apply's function container (CFn removed in 0.2.0).
+    use crate::functor::kind as functor_kind;
+    use crate::identity::kind::IdentityKind;
+    use crate::kind_based::kind::{Kind, Kind1};
+    use crate::monad::kind as monad_kind;
+    use std::marker::PhantomData;
+
+    /// The `ExceptT` monad transformer for Kind-encoded types.
+    ///
+    /// `ExceptT<E, MKind, A>` wraps an inner value `MKind::Of<Result<A, E>>`: the
+    /// produced value `A` or an error `E`, inside the inner monad. The value is
+    /// stored in [`run_except_t`](Self::run_except_t).
+    ///
+    /// # Type Parameters
+    /// - `E`: the error type (constrained only by `'static`).
+    /// - `MKind`: the Kind marker for the inner monad (must implement [`Kind1`]).
+    /// - `A`: the value produced on the success (`Ok`) branch.
+    pub struct ExceptT<E, MKind: Kind1, A> {
+        /// The wrapped inner computation: `MKind::Of<Result<A, E>>` (value-or-error).
+        pub run_except_t: MKind::Of<Result<A, E>>,
+        _phantom_e: PhantomData<E>,
+        _phantom_m_kind: PhantomData<MKind>,
+        _phantom_a: PhantomData<A>,
+    }
+
+    // Manual `Clone` bounded on the projected inner type (mirrors `WriterT`): a
+    // derived `Clone` would demand `E: Clone, MKind: Clone, A: Clone`, none of
+    // which is the real requirement — only `MKind::Of<Result<A, E>>: Clone` is.
+    impl<E, MKind: Kind1, A> Clone for ExceptT<E, MKind, A>
+    where
+        MKind::Of<Result<A, E>>: Clone,
+    {
+        fn clone(&self) -> Self {
+            ExceptT {
+                run_except_t: self.run_except_t.clone(),
+                _phantom_e: PhantomData,
+                _phantom_m_kind: PhantomData,
+                _phantom_a: PhantomData,
+            }
+        }
+    }
+
+    impl<E, MKind: Kind1, A> ExceptT<E, MKind, A> {
+        /// Creates a new `ExceptT` from an inner value `MKind::Of<Result<A, E>>`.
+        pub fn new(inner: MKind::Of<Result<A, E>>) -> Self {
+            ExceptT {
+                run_except_t: inner,
+                _phantom_e: PhantomData,
+                _phantom_m_kind: PhantomData,
+                _phantom_a: PhantomData,
+            }
+        }
+    }
+
+    /// The Kind marker for `ExceptT<E, MKind, _>`.
+    ///
+    /// Used to implement [`Functor`](functor_kind::Functor),
+    /// [`Apply`](apply_kind::Apply), [`Applicative`](applicative_kind::Applicative),
+    /// [`Bind`](monad_kind::Bind), and [`Monad`](monad_kind::Monad) for the
+    /// `ExceptT` type constructor.
+    ///
+    /// # Type Parameters
+    /// - `E`: the error type.
+    /// - `MKind`: the Kind marker for the inner monad.
+    #[derive(Default)]
+    pub struct ExceptTKind<E, MKind: Kind1>(PhantomData<(E, MKind)>);
+
+    impl<E, MKind: Kind1> Kind for ExceptTKind<E, MKind> {
+        type Of<A> = ExceptT<E, MKind, A>;
+    }
+    // Kind1 is provided by the blanket impl in kind_based/kind.rs.
+
+    /// A type alias for `ExceptT` with [`IdentityKind`] as the inner monad.
+    /// This is the plain Except monad: `Except<E, A>` wraps `Identity<Result<A, E>>`.
+    pub type Except<E, A> = ExceptT<E, IdentityKind, A>;
+
+    // --- Kind Trait Implementations for ExceptTKind ---
+
+    impl<E, MKind, A, B> functor_kind::Functor<A, B> for ExceptTKind<E, MKind>
+    where
+        E: 'static,
+        MKind: functor_kind::Functor<Result<A, E>, Result<B, E>> + Kind1 + 'static,
+        A: 'static,
+        B: 'static,
+        MKind::Of<Result<A, E>>: 'static,
+        MKind::Of<Result<B, E>>: 'static,
+    {
+        /// Maps `A -> B` over the success branch, leaving any `Err` untouched.
+        /// The mapping happens within the inner monad `MKind`.
+        fn map(
+            input: ExceptT<E, MKind, A>,
+            func: impl FnMut(A) -> B + Clone + 'static,
+        ) -> ExceptT<E, MKind, B> {
+            let mut f = func;
+            ExceptT::new(MKind::map(input.run_except_t, move |r: Result<A, E>| {
+                r.map(&mut f)
+            }))
+        }
+    }
+
+    impl<E, MKind, A, B> apply_kind::Apply<A, B> for ExceptTKind<E, MKind>
+    where
+        E: 'static,
+        A: 'static,
+        B: 'static,
+        // `Apply<A, B>: Functor<A, B>` (the inner `Functor<Result<A,E>,Result<B,E>>`
+        // bound), plus the inner `Bind` that sequences the two computations to
+        // short-circuit on `Err`, plus the inner `Applicative` for `pure(Err(e))`.
+        MKind: functor_kind::Functor<Result<A, E>, Result<B, E>>
+            + monad_kind::Bind<Result<RcFn<A, B>, E>, Result<B, E>>
+            + applicative_kind::Applicative<Result<B, E>>
+            + Kind1
+            + 'static,
+        MKind::Of<Result<A, E>>: Clone + 'static,
+        MKind::Of<Result<B, E>>: 'static,
+        MKind::Of<Result<RcFn<A, B>, E>>: 'static,
+    {
+        /// Applies a wrapped function to a wrapped value, **short-circuiting on
+        /// `Err`**. Derived from the inner monad's `bind`: run the function
+        /// computation; if it is `Err`, propagate it without touching the value
+        /// computation; otherwise map the function over the value computation.
+        fn apply(
+            value_container: ExceptT<E, MKind, A>,
+            function_container: ExceptT<E, MKind, RcFn<A, B>>,
+        ) -> ExceptT<E, MKind, B> {
+            let value_run = value_container.run_except_t;
+            ExceptT::new(<MKind as monad_kind::Bind<
+                Result<RcFn<A, B>, E>,
+                Result<B, E>,
+            >>::bind(
+                function_container.run_except_t,
+                move |rf: Result<RcFn<A, B>, E>| match rf {
+                    Err(e) => MKind::pure(Err(e)),
+                    Ok(g) => <MKind as functor_kind::Functor<Result<A, E>, Result<B, E>>>::map(
+                        value_run.clone(),
+                        move |ra: Result<A, E>| ra.map(|a| g.call(a)),
+                    ),
+                },
+            ))
+        }
+    }
+
+    impl<E, MKind, T> applicative_kind::Applicative<T> for ExceptTKind<E, MKind>
+    where
+        E: 'static,
+        T: 'static, // `pure` consumes the value once — no `Clone` needed (like `WriterT`).
+        // `Applicative<T>: Apply<T, T>`, so the full `Apply<T, T>` bound set is
+        // dragged in here; `pure` itself needs only the inner `Applicative`.
+        MKind: functor_kind::Functor<Result<T, E>, Result<T, E>>
+            + monad_kind::Bind<Result<RcFn<T, T>, E>, Result<T, E>>
+            + applicative_kind::Applicative<Result<T, E>>
+            + Kind1
+            + 'static,
+        MKind::Of<Result<T, E>>: Clone + 'static,
+        MKind::Of<Result<RcFn<T, T>, E>>: 'static,
+    {
+        /// Lifts a value `T` into `ExceptT` on the success branch:
+        /// `MKind::pure(Ok(value))`.
+        fn pure(value: T) -> ExceptT<E, MKind, T> {
+            ExceptT::new(MKind::pure(Ok(value)))
+        }
+    }
+
+    impl<E, MKind, A, B> monad_kind::Bind<A, B> for ExceptTKind<E, MKind>
+    where
+        E: 'static,
+        A: 'static,
+        B: 'static,
+        // `Bind<A, B>: Apply<A, B>`, so the full `Apply<A, B>` bound set is dragged
+        // in, plus the inner `Bind<Result<A,E>, Result<B,E>>` the `bind` body uses.
+        MKind: functor_kind::Functor<Result<A, E>, Result<B, E>>
+            + monad_kind::Bind<Result<A, E>, Result<B, E>>
+            + monad_kind::Bind<Result<RcFn<A, B>, E>, Result<B, E>>
+            + applicative_kind::Applicative<Result<B, E>>
+            + Kind1
+            + 'static,
+        MKind::Of<Result<A, E>>: Clone + 'static,
+        MKind::Of<Result<B, E>>: 'static,
+        MKind::Of<Result<RcFn<A, B>, E>>: 'static,
+    {
+        /// Sequentially composes an `ExceptT` with a function producing the next
+        /// `ExceptT`, **short-circuiting on `Err`**: if the first computation
+        /// yields `Err(e)`, `func` is never called and `Err(e)` is propagated.
+        fn bind(
+            input: ExceptT<E, MKind, A>,
+            func: impl FnMut(A) -> ExceptT<E, MKind, B> + Clone + 'static,
+        ) -> ExceptT<E, MKind, B> {
+            let mut f = func;
+            ExceptT::new(
+                <MKind as monad_kind::Bind<Result<A, E>, Result<B, E>>>::bind(
+                    input.run_except_t,
+                    move |ra: Result<A, E>| match ra {
+                        Err(e) => MKind::pure(Err(e)),
+                        Ok(a) => f(a).run_except_t,
+                    },
+                ),
+            )
+        }
+    }
+
+    impl<E, MKind, A> monad_kind::Monad<A> for ExceptTKind<E, MKind>
+    where
+        E: 'static,
+        A: 'static,
+        // `Monad<A>: Applicative<A>: Apply<A, A>`, so the full `Apply<A, A>` bound
+        // set is dragged in, plus the inner `Bind` over `Result<ExceptT<…>, E>`.
+        MKind: functor_kind::Functor<Result<A, E>, Result<A, E>>
+            + monad_kind::Bind<Result<A, E>, Result<A, E>>
+            + monad_kind::Bind<Result<RcFn<A, A>, E>, Result<A, E>>
+            + monad_kind::Bind<Result<ExceptT<E, MKind, A>, E>, Result<A, E>>
+            + applicative_kind::Applicative<Result<A, E>>
+            + Kind1
+            + 'static,
+        MKind::Of<Result<A, E>>: Clone + 'static,
+        MKind::Of<Result<RcFn<A, A>, E>>: 'static,
+        MKind::Of<Result<ExceptT<E, MKind, A>, E>>: 'static,
+    {
+        /// Flattens a nested `ExceptT<E, MKind, ExceptT<E, MKind, A>>`: run the
+        /// outer computation; if it is `Err`, propagate it, otherwise run the
+        /// inner computation it produced.
+        fn join(mma: ExceptT<E, MKind, ExceptT<E, MKind, A>>) -> ExceptT<E, MKind, A> {
+            ExceptT::new(<MKind as monad_kind::Bind<
+                Result<ExceptT<E, MKind, A>, E>,
+                Result<A, E>,
+            >>::bind(
+                mma.run_except_t,
+                move |r: Result<ExceptT<E, MKind, A>, E>| match r {
+                    Err(e) => MKind::pure(Err(e)),
+                    Ok(inner) => inner.run_except_t,
+                },
+            ))
+        }
+    }
+
+    // --- Error-channel map (the analog of WriterT's `censor`) ---
+
+    impl<E, MKind: Kind1, A> ExceptT<E, MKind, A> {
+        /// Maps the error channel `E -> E2`, leaving the success value unchanged:
+        /// `Err(e) -> Err(f(e))`, `Ok(a) -> Ok(a)` (inner `Functor`).
+        ///
+        /// The Rust analog of Haskell's `withExceptT`.
+        pub fn with_except_t<E2, F>(self, f: F) -> ExceptT<E2, MKind, A>
+        where
+            E: 'static,
+            E2: 'static,
+            A: 'static,
+            MKind: functor_kind::Functor<Result<A, E>, Result<A, E2>> + 'static,
+            MKind::Of<Result<A, E>>: 'static,
+            MKind::Of<Result<A, E2>>: 'static,
+            F: FnMut(E) -> E2 + Clone + 'static,
+        {
+            let mut f = f;
+            ExceptT::new(MKind::map(self.run_except_t, move |r: Result<A, E>| {
+                r.map_err(&mut f)
+            }))
+        }
+    }
+
+    /// Trait for monads that support throwing and catching errors of type `E`.
+    ///
+    /// The Except analog of [`MonadReader`](crate::transformers::reader::MonadReader)
+    /// (`ask`/`local`), [`MonadState`](crate::transformers::state::MonadState)
+    /// (`get`/`put`/…), and [`MonadWriter`](crate::transformers::writer::MonadWriter)
+    /// (`tell`/…). The primitive is [`throw_error`](Self::throw_error);
+    /// [`catch_error`](Self::catch_error) recovers from a thrown error, and
+    /// [`lift_either`](Self::lift_either) embeds a pure `Result`.
+    ///
+    /// `throw_error`/`lift_either` need only the inner [`Applicative`](applicative_kind::Applicative);
+    /// `catch_error` needs the inner [`Bind`](monad_kind::Bind) (it must inspect
+    /// the `Result` to decide whether to run the handler).
+    ///
+    /// # Type Parameters
+    /// - `E`: the error type.
+    /// - `A`: the value type carried by the computation.
+    /// - `MKind`: the Kind marker for the inner monad.
+    pub trait MonadError<E, A, MKind: Kind1>
+    where
+        Self: Sized,
+    {
+        /// Injects an error, short-circuiting: `MKind::pure(Err(e))`. The primitive.
+        fn throw_error(e: E) -> ExceptT<E, MKind, A>
+        where
+            E: 'static,
+            A: 'static,
+            MKind: applicative_kind::Applicative<Result<A, E>> + 'static,
+            MKind::Of<Result<A, E>>: 'static;
+
+        /// Runs `m`; if it produced `Err(e)`, runs `handler(e)` instead;
+        /// otherwise passes the `Ok` value through unchanged.
+        fn catch_error<F>(m: ExceptT<E, MKind, A>, handler: F) -> ExceptT<E, MKind, A>
+        where
+            E: 'static,
+            A: 'static,
+            MKind: monad_kind::Bind<Result<A, E>, Result<A, E>>
+                + applicative_kind::Applicative<Result<A, E>>
+                + 'static,
+            MKind::Of<Result<A, E>>: 'static,
+            F: Fn(E) -> ExceptT<E, MKind, A> + Clone + 'static;
+
+        /// Embeds a pure `Result<A, E>` directly: `MKind::pure(r)`.
+        fn lift_either(r: Result<A, E>) -> ExceptT<E, MKind, A>
+        where
+            E: 'static,
+            A: 'static,
+            MKind: applicative_kind::Applicative<Result<A, E>> + 'static,
+            MKind::Of<Result<A, E>>: 'static;
+    }
+
+    impl<E, MKindImpl, A> MonadError<E, A, MKindImpl> for ExceptTKind<E, MKindImpl>
+    where
+        E: 'static,
+        A: 'static,
+        MKindImpl: Kind1 + 'static,
+    {
+        fn throw_error(e: E) -> ExceptT<E, MKindImpl, A>
+        where
+            E: 'static,
+            A: 'static,
+            MKindImpl: applicative_kind::Applicative<Result<A, E>> + 'static,
+            MKindImpl::Of<Result<A, E>>: 'static,
+        {
+            ExceptT::new(MKindImpl::pure(Err(e)))
+        }
+
+        fn catch_error<F>(m: ExceptT<E, MKindImpl, A>, handler: F) -> ExceptT<E, MKindImpl, A>
+        where
+            E: 'static,
+            A: 'static,
+            MKindImpl: monad_kind::Bind<Result<A, E>, Result<A, E>>
+                + applicative_kind::Applicative<Result<A, E>>
+                + 'static,
+            MKindImpl::Of<Result<A, E>>: 'static,
+            F: Fn(E) -> ExceptT<E, MKindImpl, A> + Clone + 'static,
+        {
+            ExceptT::new(<MKindImpl as monad_kind::Bind<
+                Result<A, E>,
+                Result<A, E>,
+            >>::bind(
+                m.run_except_t,
+                move |r: Result<A, E>| match r {
+                    Ok(a) => MKindImpl::pure(Ok(a)),
+                    Err(e) => handler(e).run_except_t,
+                },
+            ))
+        }
+
+        fn lift_either(r: Result<A, E>) -> ExceptT<E, MKindImpl, A>
+        where
+            E: 'static,
+            A: 'static,
+            MKindImpl: applicative_kind::Applicative<Result<A, E>> + 'static,
+            MKindImpl::Of<Result<A, E>>: 'static,
+        {
+            ExceptT::new(MKindImpl::pure(r))
+        }
+    }
+}
+
+// Directly export Kind-based versions
+pub use kind::{Except, ExceptT, ExceptTKind, MonadError};

--- a/src/transformers/mod.rs
+++ b/src/transformers/mod.rs
@@ -1,5 +1,6 @@
 //! Monad transformers.
 
+pub mod except;
 pub mod reader;
 pub mod state;
 pub mod trans;

--- a/src/transformers/trans.rs
+++ b/src/transformers/trans.rs
@@ -5,10 +5,11 @@
 //! [`lift`](MonadTrans::lift), which embeds an inner computation `m a` into the
 //! transformed monad `T m a` while adding *no* effect of its own.
 //!
-//! This crate implements `MonadTrans` for all three transformers:
+//! This crate implements `MonadTrans` for all four transformers:
 //! [`ReaderTKind`](crate::transformers::reader::ReaderTKind),
-//! [`StateTKind`](crate::transformers::state::StateTKind), and
-//! [`WriterTKind`](crate::transformers::writer::WriterTKind).
+//! [`StateTKind`](crate::transformers::state::StateTKind),
+//! [`WriterTKind`](crate::transformers::writer::WriterTKind), and
+//! [`ExceptTKind`](crate::transformers::except::ExceptTKind).
 //!
 //! ## Law
 //!
@@ -40,6 +41,7 @@
 use crate::functor::kind as functor_kind;
 use crate::kind_based::kind::{Kind, Kind1};
 use crate::monoid::Monoid;
+use crate::transformers::except::kind::{ExceptT, ExceptTKind};
 use crate::transformers::reader::kind::{ReaderT, ReaderTKind};
 use crate::transformers::state::kind::{StateT, StateTKind};
 use crate::transformers::writer::kind::{WriterT, WriterTKind};
@@ -106,5 +108,22 @@ where
         let paired: MKind::Of<(A, W)> =
             <MKind as functor_kind::Functor<A, (A, W)>>::map(inner, move |a| (a, W::empty()));
         WriterT::new(paired)
+    }
+}
+
+// `ExceptT`: wrap the inner value on the success branch with `Ok`. No `Clone`
+// needed — the inner value is consumed exactly once (like `WriterT`).
+impl<E, MKind, A> MonadTrans<A, MKind> for ExceptTKind<E, MKind>
+where
+    E: 'static,
+    A: 'static,
+    MKind: functor_kind::Functor<A, Result<A, E>> + Kind1 + 'static,
+    MKind::Of<A>: 'static,
+    MKind::Of<Result<A, E>>: 'static,
+{
+    fn lift(inner: MKind::Of<A>) -> ExceptT<E, MKind, A> {
+        let wrapped: MKind::Of<Result<A, E>> =
+            <MKind as functor_kind::Functor<A, Result<A, E>>>::map(inner, Ok);
+        ExceptT::new(wrapped)
     }
 }

--- a/tests/kind/do_notation/except.rs
+++ b/tests/kind/do_notation/except.rs
@@ -1,0 +1,108 @@
+//! `mdo!` do-block tests for `ExceptTKind` (the Except monad: short-circuit on error).
+//!
+//! Gated by the parent `do_notation` module's `#![cfg(feature = "do-notation")]`.
+//!
+//! ## What we test
+//!
+//! The "real power" of Except is that an error silently aborts the rest of the
+//! do-block — once a step throws, no later `bind` runs. These tests use
+//! `Except<String, A>` (`ExceptT<String, IdentityKind, A>`) so each run yields
+//! `Identity<Result<A, String>>`.
+//!
+//! 1. **Happy path** — every step is `Ok`, the block produces `Ok(value)`.
+//! 2. **Short-circuit** — a `throw_error` aborts the block; later binds do not run.
+//! 3. **Equivalence** — the `mdo!` block produces the identical `Result` to a
+//!    hand-written nested `bind` chain.
+//! 4. **proptest** — `mdo!` vs hand-written `bind`, run-and-compared.
+//!
+//! `guard` is intentionally absent: `ExceptT` has no lawful zero, so a `guard`
+//! inside an Except do-block is a deliberate compile error (same as Reader/
+//! State/Writer). `ExceptT` is `Clone` when its inner `M::Of<Result<A, E>>` is,
+//! so the `.clone()` the macro emits works for `IdentityKind`.
+
+use monadify::applicative::kind::Applicative;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::monad::kind::Bind;
+use monadify::transformers::except::{Except, ExceptTKind, MonadError};
+use proptest::prelude::*;
+
+type EKind = ExceptTKind<String, IdentityKind>;
+type Checked<A> = Except<String, A>;
+
+fn ok(n: i32) -> Checked<i32> {
+    <EKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(n))
+}
+fn boom(msg: &str) -> Checked<i32> {
+    <EKind as MonadError<String, i32, IdentityKind>>::throw_error(msg.to_string())
+}
+fn run_id<A>(m: Checked<A>) -> Result<A, String> {
+    let Identity(r) = m.run_except_t;
+    r
+}
+
+// ── 1. Happy path ────────────────────────────────────────────────────────────
+
+#[test]
+fn except_mdo_happy_path() {
+    let comp: Checked<i32> = mdo! {
+        EKind;
+        x <- ok(1);
+        y <- ok(2);
+        z <- ok(3);
+        EKind::pure(x + y + z)
+    };
+    assert_eq!(run_id(comp), Ok(6));
+}
+
+// ── 2. Short-circuit: a throw aborts the rest of the block ───────────────────
+
+#[test]
+fn except_mdo_short_circuits_on_throw() {
+    let comp: Checked<i32> = mdo! {
+        EKind;
+        x <- ok(1);
+        _ <- boom("stop");
+        y <- ok(99); // never runs
+        EKind::pure(x + y)
+    };
+    assert_eq!(run_id(comp), Err("stop".to_string()));
+}
+
+// ── 3. Equivalence with a hand-written bind chain ────────────────────────────
+
+#[test]
+fn except_mdo_equivalent_to_manual_bind() {
+    let via_mdo: Checked<i32> = mdo! {
+        EKind;
+        x <- ok(2);
+        _ <- boom("e");
+        EKind::pure(x)
+    };
+    let via_bind: Checked<i32> = EKind::bind(ok(2), move |x| {
+        EKind::bind(boom("e"), move |_| EKind::pure(x))
+    });
+    assert_eq!(run_id(via_mdo), run_id(via_bind));
+}
+
+// ── 4. proptest: mdo! == manual bind, run-and-compared ───────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    #[test]
+    fn except_mdo_matches_manual(a in any::<i32>(), b in any::<i32>(), throws in any::<bool>()) {
+        let mid = move || -> Checked<i32> {
+            if throws { boom("x") } else { ok(b) }
+        };
+        let via_mdo: Checked<i32> = mdo! {
+            EKind;
+            x <- ok(a);
+            y <- mid();
+            EKind::pure(x.wrapping_add(y))
+        };
+        let via_bind: Checked<i32> =
+            EKind::bind(ok(a), move |x| EKind::bind(mid(), move |y| EKind::pure(x.wrapping_add(y))));
+        prop_assert_eq!(run_id(via_mdo), run_id(via_bind));
+    }
+}

--- a/tests/kind/do_notation/mod.rs
+++ b/tests/kind/do_notation/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod auto_pure;
 pub mod cfn_unsupported;
+pub mod except;
 pub mod identity;
 pub mod laws;
 pub mod option;

--- a/tests/kind/proptest_laws/except.rs
+++ b/tests/kind/proptest_laws/except.rs
@@ -1,0 +1,181 @@
+//! Property-based (`proptest`) law tests for `ExceptTKind` (the Except transformer).
+//!
+//! Companion to the example-based tests in
+//! `tests/kind/transformers/except.rs`. The plain `Except<E, A>` (inner
+//! `IdentityKind`) has structural `Eq` once unwrapped, so laws compare the
+//! produced `Result<A, E>` directly.
+//!
+//! Covers the three Monad laws and the `MonadError` laws (throw-left-zero,
+//! catch-throw, catch-pure) over `ExceptTKind<String, IdentityKind>`, plus the
+//! **Applicative–Monad consistency** law (`apply == bind-derived ap`) over the
+//! multiplicative `VecKind` inner — the law that pins `apply` to the
+//! short-circuiting inner-`Bind` definition and rules out the unlawful
+//! "run both effects" inner-`Apply`-only variant.
+
+use super::linear_fn;
+use monadify::applicative::kind::Applicative;
+use monadify::apply::kind::Apply;
+use monadify::function::RcFn;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::kind_based::kind::VecKind;
+use monadify::monad::kind::Bind;
+use monadify::transformers::except::{Except, ExceptT, ExceptTKind, MonadError};
+use proptest::prelude::*;
+
+type E<A> = Except<String, A>;
+type EKind = ExceptTKind<String, IdentityKind>;
+
+fn run<A>(m: E<A>) -> Result<A, String> {
+    let Identity(r) = m.run_except_t;
+    r
+}
+
+/// A possibly-throwing Kleisli arrow: maps by a linear fn, or throws when
+/// `throw_at` matches the input (to exercise short-circuit paths).
+fn arrow(slope: i32, intercept: i32, err: String) -> impl Fn(i32) -> E<i32> + Clone {
+    move |x: i32| {
+        if x == 0 {
+            <EKind as MonadError<String, i32, IdentityKind>>::throw_error(err.clone())
+        } else {
+            let mut lf = linear_fn(slope, intercept);
+            <EKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(lf(x)))
+        }
+    }
+}
+
+fn arb_result() -> impl Strategy<Value = Result<i32, String>> {
+    prop_oneof![any::<i32>().prop_map(Ok), "[a-z]{1,8}".prop_map(Err)]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    // --- Monad laws ---
+
+    /// Left identity: `bind(pure(a), f) == f(a)`.
+    #[test]
+    fn except_monad_left_identity(a in any::<i32>(),
+                                  (sl, ic) in (any::<i32>(), any::<i32>()), err in "[a-z]{1,8}") {
+        let f = arrow(sl, ic, err);
+        let lhs = EKind::bind(EKind::pure(a), f.clone());
+        let rhs = f(a);
+        prop_assert_eq!(run(lhs), run(rhs));
+    }
+
+    /// Right identity: `bind(m, pure) == m`.
+    #[test]
+    fn except_monad_right_identity(r in arb_result()) {
+        let m = || ExceptT::<String, IdentityKind, i32>::new(Identity(r.clone()));
+        let lhs = EKind::bind(m(), EKind::pure);
+        prop_assert_eq!(run(lhs), run(m()));
+    }
+
+    /// Associativity: `bind(bind(m, f), g) == bind(m, |x| bind(f(x), g))`.
+    #[test]
+    fn except_monad_associativity(r in arb_result(),
+                                  (sl1, ic1) in (any::<i32>(), any::<i32>()), e1 in "[a-z]{1,8}",
+                                  (sl2, ic2) in (any::<i32>(), any::<i32>()), e2 in "[a-z]{1,8}") {
+        let f = arrow(sl1, ic1, e1);
+        let g = arrow(sl2, ic2, e2);
+        let m = || ExceptT::<String, IdentityKind, i32>::new(Identity(r.clone()));
+        let lhs = EKind::bind(EKind::bind(m(), f.clone()), g.clone());
+        let rhs = EKind::bind(m(), move |x| EKind::bind(f(x), g.clone()));
+        prop_assert_eq!(run(lhs), run(rhs));
+    }
+
+    // --- MonadError laws ---
+
+    /// Throw is a left zero for bind: `bind(throw(e), k) == throw(e)`.
+    #[test]
+    fn except_throw_left_zero(err in "[a-z]{1,8}", (sl, ic) in (any::<i32>(), any::<i32>())) {
+        let k = arrow(sl, ic, "unused".to_string());
+        let lhs = EKind::bind(
+            <EKind as MonadError<String, i32, IdentityKind>>::throw_error(err.clone()),
+            k,
+        );
+        let rhs = <EKind as MonadError<String, i32, IdentityKind>>::throw_error(err);
+        prop_assert_eq!(run(lhs), run(rhs));
+    }
+
+    /// catch-throw: `catch(throw(e), h) == h(e)`.
+    #[test]
+    fn except_catch_throw(err in "[a-z]{1,8}", n in any::<i32>()) {
+        let h = move |_e: String| <EKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(n));
+        let lhs = <EKind as MonadError<String, i32, IdentityKind>>::catch_error(
+            <EKind as MonadError<String, i32, IdentityKind>>::throw_error(err.clone()),
+            h,
+        );
+        let rhs = h(err);
+        prop_assert_eq!(run(lhs), run(rhs));
+    }
+
+    /// catch-pure: `catch(pure(a), h) == pure(a)` (handler never runs).
+    #[test]
+    fn except_catch_pure(a in any::<i32>()) {
+        let h = |_e: String| <EKind as MonadError<String, i32, IdentityKind>>::throw_error("ignored".to_string());
+        let lhs = <EKind as MonadError<String, i32, IdentityKind>>::catch_error(EKind::pure(a), h);
+        prop_assert_eq!(run(lhs), Ok(a));
+    }
+}
+
+// --- Applicative–Monad consistency over the multiplicative VecKind inner ---
+
+type Ve<A> = ExceptT<String, VecKind, A>;
+type VeKind = ExceptTKind<String, VecKind>;
+
+fn run_vec<A>(m: Ve<A>) -> Vec<Result<A, String>> {
+    m.run_except_t
+}
+
+/// `flags` builds a function container `Vec<Result<RcFn, String>>`: `true`
+/// slots carry the linear function, `false` slots carry an `Err`.
+fn build_func(flags: &[bool], slope: i32, intercept: i32) -> Ve<RcFn<i32, i32>> {
+    let v: Vec<Result<RcFn<i32, i32>, String>> = flags
+        .iter()
+        .map(|&ok| {
+            if ok {
+                Ok(RcFn::new(move |x: i32| {
+                    x.wrapping_mul(slope).wrapping_add(intercept)
+                }))
+            } else {
+                Err("ferr".to_string())
+            }
+        })
+        .collect();
+    ExceptT::new(v)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 192, ..ProptestConfig::default() })]
+
+    /// `apply(value, func) == bind(func, |g| bind(value, |a| pure(g(a))))`.
+    ///
+    /// Over `VecKind` the two only agree if `apply` short-circuits `Err` by
+    /// inner `bind` (running the value side once per `Ok` function element and
+    /// not at all per `Err`). The unlawful inner-`Apply`-only `apply` would run
+    /// the value side unconditionally and disagree on cardinality.
+    #[test]
+    fn except_apply_equals_monad_ap(
+        value in prop::collection::vec(
+            prop_oneof![any::<i32>().prop_map(Ok::<i32, String>), "[a-z]{1,4}".prop_map(Err)],
+            0..=5),
+        flags in prop::collection::vec(any::<bool>(), 0..=5),
+        slope in any::<i32>(), intercept in any::<i32>(),
+    ) {
+        let value_ex: Ve<i32> = ExceptT::new(value);
+
+        // apply(value, func)
+        let via_apply = <VeKind as Apply<i32, i32>>::apply(
+            value_ex.clone(),
+            build_func(&flags, slope, intercept),
+        );
+
+        // monad-derived ap: bind(func, |g| bind(value, |a| pure(g(a))))
+        let via_ap = VeKind::bind(build_func(&flags, slope, intercept), move |g: RcFn<i32, i32>| {
+            let g = g.clone();
+            VeKind::bind(value_ex.clone(), move |a: i32| VeKind::pure(g.call(a)))
+        });
+
+        prop_assert_eq!(run_vec(via_apply), run_vec(via_ap));
+    }
+}

--- a/tests/kind/proptest_laws/mod.rs
+++ b/tests/kind/proptest_laws/mod.rs
@@ -16,6 +16,7 @@ use proptest::prelude::*;
 
 pub mod applicative;
 pub mod apply;
+pub mod except;
 pub mod functor;
 pub mod monad;
 pub mod rcfn;

--- a/tests/kind/transformers/except.rs
+++ b/tests/kind/transformers/except.rs
@@ -1,0 +1,247 @@
+//! Example-based law tests for `ExceptTKind` (the Except monad transformer).
+//!
+//! `ExceptT<E, M, A>` wraps `M::Of<Result<A, E>>`. The plain `Except<E, A>`
+//! (inner `IdentityKind`) has structural `Eq` once unwrapped, so most laws
+//! compare the produced `Result<A, E>` directly; for the effectful inner monad
+//! we use `OptionKind` and compare `Option<Result<A, E>>` (including the inner
+//! `None`).
+//!
+//! Coverage: Functor/Applicative/Apply/Bind/Monad smoke tests (with `Err`
+//! short-circuit), the three Monad laws, and the `MonadError` operations
+//! (`throw_error`, `catch_error`, `lift_either`) — in particular the laws
+//! catch-throw, catch-pure, and throw-left-zero.
+
+use monadify::applicative::kind::Applicative;
+use monadify::apply::kind::Apply;
+use monadify::function::RcFn;
+use monadify::functor::kind::Functor;
+use monadify::identity::{Identity, IdentityKind};
+use monadify::monad::kind::{Bind, Monad};
+use monadify::transformers::except::{Except, ExceptT, ExceptTKind, MonadError};
+use monadify::OptionKind;
+
+// ── Identity-inner helpers (the plain Except monad over a String error) ──────
+
+type E<A> = Except<String, A>; // ExceptT<String, IdentityKind, A>
+type EKind = ExceptTKind<String, IdentityKind>;
+
+/// Unwrap an `Except<String, A>` to its `Result<A, String>`.
+fn run_id<A>(m: E<A>) -> Result<A, String> {
+    let Identity(r) = m.run_except_t;
+    r
+}
+
+fn throw(msg: &str) -> E<i32> {
+    <EKind as MonadError<String, i32, IdentityKind>>::throw_error(msg.to_string())
+}
+
+fn ok(n: i32) -> E<i32> {
+    <EKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(n))
+}
+
+// ── Functor / Applicative / Apply / Bind / Monad smoke tests ────────────────
+
+#[test]
+fn functor_maps_over_ok() {
+    let mapped = EKind::map(ok(10), |v| v * 2);
+    assert_eq!(run_id(mapped), Ok(20));
+}
+
+#[test]
+fn functor_skips_err() {
+    // map leaves the error branch untouched.
+    let mapped = EKind::map(throw("boom"), |v| v * 2);
+    assert_eq!(run_id(mapped), Err("boom".to_string()));
+}
+
+#[test]
+fn applicative_pure_is_ok() {
+    let m: E<i32> = EKind::pure(42);
+    assert_eq!(run_id(m), Ok(42));
+}
+
+#[test]
+fn apply_applies_when_both_ok() {
+    let value: E<i32> = ok(5);
+    let func: E<RcFn<i32, i32>> = ExceptT::new(Identity(Ok(RcFn::new(|a: i32| a * 10))));
+    let applied = <EKind as Apply<i32, i32>>::apply(value, func);
+    assert_eq!(run_id(applied), Ok(50));
+}
+
+#[test]
+fn apply_short_circuits_on_err_function() {
+    // function side is Err => result is that Err, value side ignored.
+    let value: E<i32> = ok(5);
+    let func: E<RcFn<i32, i32>> = ExceptT::new(Identity(Err("nofunc".to_string())));
+    let applied = <EKind as Apply<i32, i32>>::apply(value, func);
+    assert_eq!(run_id(applied), Err("nofunc".to_string()));
+}
+
+#[test]
+fn apply_propagates_err_from_value_side() {
+    // value side is Err, function side Ok => result is the value's Err.
+    let value: E<i32> = throw("noval");
+    let func: E<RcFn<i32, i32>> = ExceptT::new(Identity(Ok(RcFn::new(|a: i32| a + 1))));
+    let applied = <EKind as Apply<i32, i32>>::apply(value, func);
+    assert_eq!(run_id(applied), Err("noval".to_string()));
+}
+
+#[test]
+fn bind_chains_when_ok() {
+    let bound = EKind::bind(ok(1), |x| ok(x + 1));
+    assert_eq!(run_id(bound), Ok(2));
+}
+
+#[test]
+fn bind_short_circuits_on_err() {
+    // the function is never called once an Err appears.
+    let bound = EKind::bind(throw("stop"), |x| ok(x + 100));
+    assert_eq!(run_id(bound), Err("stop".to_string()));
+}
+
+#[test]
+fn join_flattens_ok() {
+    let inner: E<i32> = ok(7);
+    let nested: E<E<i32>> = ExceptT::new(Identity(Ok(inner)));
+    let flat = EKind::join(nested);
+    assert_eq!(run_id(flat), Ok(7));
+}
+
+#[test]
+fn join_propagates_outer_err() {
+    let nested: E<E<i32>> = ExceptT::new(Identity(Err("outer".to_string())));
+    let flat = EKind::join(nested);
+    assert_eq!(run_id(flat), Err("outer".to_string()));
+}
+
+// ── Monad laws (observational over the produced Result) ──────────────────────
+
+#[test]
+fn monad_left_identity() {
+    // pure(a).bind(f) == f(a)
+    let f = |x: i32| ok(x * 3);
+    let lhs = EKind::bind(EKind::pure(4), f);
+    let rhs = f(4);
+    assert_eq!(run_id(lhs), run_id(rhs));
+}
+
+#[test]
+fn monad_right_identity() {
+    // m.bind(pure) == m
+    let lhs = EKind::bind(ok(9), EKind::pure);
+    assert_eq!(run_id(lhs), run_id(ok(9)));
+}
+
+#[test]
+fn monad_associativity() {
+    // m.bind(f).bind(g) == m.bind(|x| f(x).bind(g))
+    let f = |x: i32| ok(x + 1);
+    let g = |y: i32| ok(y * 2);
+    let lhs = EKind::bind(EKind::bind(ok(3), f), g);
+    let rhs = EKind::bind(ok(3), move |x| EKind::bind(f(x), g));
+    assert_eq!(run_id(lhs), run_id(rhs));
+}
+
+#[test]
+fn monad_associativity_with_err() {
+    // associativity holds even when the middle step throws.
+    let f = |_x: i32| throw("mid");
+    let g = |y: i32| ok(y * 2);
+    let lhs = EKind::bind(EKind::bind(ok(3), f), g);
+    let rhs = EKind::bind(ok(3), move |x| EKind::bind(f(x), g));
+    assert_eq!(run_id(lhs.clone()), run_id(rhs));
+    assert_eq!(run_id(lhs), Err("mid".to_string()));
+}
+
+// ── MonadError operations ───────────────────────────────────────────────────
+
+#[test]
+fn throw_left_zero() {
+    // THE error law: throw(e) >>= k == throw(e)
+    let lhs = EKind::bind(throw("e"), |x| ok(x + 1));
+    let rhs = throw("e");
+    assert_eq!(run_id(lhs), run_id(rhs));
+}
+
+#[test]
+fn catch_throw_runs_handler() {
+    // catch(throw(e), h) == h(e)
+    let h = |e: String| ok(e.len() as i32);
+    let lhs = <EKind as MonadError<String, i32, IdentityKind>>::catch_error(throw("err"), h);
+    let rhs = h("err".to_string());
+    assert_eq!(run_id(lhs.clone()), run_id(rhs));
+    assert_eq!(run_id(lhs), Ok(3)); // "err".len() == 3
+}
+
+#[test]
+fn catch_pure_ignores_handler() {
+    // catch(pure(a), h) == pure(a)  — the handler never runs on success.
+    let h = |_e: String| ok(-1);
+    let lhs = <EKind as MonadError<String, i32, IdentityKind>>::catch_error(ok(7), h);
+    assert_eq!(run_id(lhs), Ok(7));
+}
+
+#[test]
+fn lift_either_embeds_result() {
+    assert_eq!(run_id(ok(5)), Ok(5));
+    let err: E<i32> =
+        <EKind as MonadError<String, i32, IdentityKind>>::lift_either(Err("x".into()));
+    assert_eq!(run_id(err), Err("x".to_string()));
+}
+
+#[test]
+fn with_except_t_maps_error_channel() {
+    // with_except_t rewrites the error, leaving Ok untouched.
+    let mapped_err = throw("boom").with_except_t(|e: String| e.len());
+    let Identity(r) = mapped_err.run_except_t;
+    assert_eq!(r, Err(4)); // "boom".len() == 4
+
+    let mapped_ok = ok(9).with_except_t(|e: String| e.len());
+    let Identity(r2) = mapped_ok.run_except_t;
+    assert_eq!(r2, Ok(9));
+}
+
+// ── Effectful inner monad: OptionKind threading + inner None ─────────────────
+
+type OptE<A> = ExceptT<String, OptionKind, A>;
+type OptEKind = ExceptTKind<String, OptionKind>;
+
+#[test]
+fn option_inner_threads_ok() {
+    let m: OptE<i32> = OptEKind::pure(3);
+    let bound = OptEKind::bind(m, |x| {
+        <OptEKind as MonadError<String, i32, OptionKind>>::lift_either(Ok(x + 1))
+    });
+    assert_eq!(bound.run_except_t, Some(Ok(4)));
+}
+
+#[test]
+fn option_inner_carries_err() {
+    let thrown: OptE<i32> =
+        <OptEKind as MonadError<String, i32, OptionKind>>::throw_error("e".to_string());
+    let bound = OptEKind::bind(thrown, |x| {
+        <OptEKind as MonadError<String, i32, OptionKind>>::lift_either(Ok(x))
+    });
+    // The ExceptT-level error is carried in the inner Some.
+    assert_eq!(bound.run_except_t, Some(Err("e".to_string())));
+}
+
+#[test]
+fn option_inner_none_short_circuits() {
+    // A failure in the inner Option discards everything (distinct from an Err).
+    let failing: OptE<i32> = ExceptT::new(None);
+    let bound = OptEKind::bind(failing, |x| {
+        <OptEKind as MonadError<String, i32, OptionKind>>::lift_either(Ok(x))
+    });
+    assert_eq!(bound.run_except_t, None);
+}
+
+#[test]
+fn option_inner_catch_recovers() {
+    let thrown: OptE<i32> =
+        <OptEKind as MonadError<String, i32, OptionKind>>::throw_error("e".to_string());
+    let recovered = <OptEKind as MonadError<String, i32, OptionKind>>::catch_error(thrown, |_e| {
+        <OptEKind as MonadError<String, i32, OptionKind>>::lift_either(Ok(0))
+    });
+    assert_eq!(recovered.run_except_t, Some(Ok(0)));
+}

--- a/tests/kind/transformers/mod.rs
+++ b/tests/kind/transformers/mod.rs
@@ -1,4 +1,6 @@
 #[cfg(not(feature = "legacy"))]
+pub mod except;
+#[cfg(not(feature = "legacy"))]
 pub mod reader;
 #[cfg(not(feature = "legacy"))]
 pub mod state;

--- a/tests/kind/transformers/trans.rs
+++ b/tests/kind/transformers/trans.rs
@@ -91,3 +91,43 @@ fn writer_lift_over_option_none() {
     let lifted = <WKind as MonadTrans<i32, OptionKind>>::lift(None);
     assert_eq!(lifted.run_writer_t, None);
 }
+
+// ── ExceptT: lift wraps the inner value on the success (Ok) branch ───────────
+
+#[test]
+fn except_lift_wraps_ok() {
+    use monadify::transformers::except::{Except, ExceptTKind};
+    type EKind = ExceptTKind<String, IdentityKind>;
+    let lifted: Except<String, i32> =
+        <EKind as MonadTrans<i32, IdentityKind>>::lift(IdentityKind::pure(7));
+    let Identity(r) = lifted.run_except_t;
+    assert_eq!(r, Ok(7)); // lifting adds no error
+}
+
+#[test]
+fn except_lift_equals_pure() {
+    use monadify::transformers::except::{Except, ExceptTKind};
+    type EKind = ExceptTKind<String, IdentityKind>;
+    let lifted: Except<String, i32> =
+        <EKind as MonadTrans<i32, IdentityKind>>::lift(IdentityKind::pure(6));
+    let pured: Except<String, i32> = EKind::pure(6);
+    assert_eq!(lifted.run_except_t, pured.run_except_t);
+}
+
+#[test]
+fn except_lift_over_option_some() {
+    use monadify::transformers::except::ExceptTKind;
+    use monadify::OptionKind;
+    type EKind = ExceptTKind<String, OptionKind>;
+    let lifted = <EKind as MonadTrans<i32, OptionKind>>::lift(Some(11));
+    assert_eq!(lifted.run_except_t, Some(Ok(11)));
+}
+
+#[test]
+fn except_lift_over_option_none() {
+    use monadify::transformers::except::ExceptTKind;
+    use monadify::OptionKind;
+    type EKind = ExceptTKind<String, OptionKind>;
+    let lifted = <EKind as MonadTrans<i32, OptionKind>>::lift(None);
+    assert_eq!(lifted.run_except_t, None::<Result<i32, String>>);
+}


### PR DESCRIPTION
## Summary

Adds **`ExceptT`** — the Except/error monad transformer — the fourth transformer after `ReaderT`/`StateT`/`WriterT`. `ExceptT<E, M, A> ≅ M::Of<Result<A, E>>` adds short-circuiting error handling over an inner monad, with an mtl-style `MonadError` surface.

This implements the findings from the prior `monadify/except-implementation` research run (research → blueprint → ADR → implementation).

## Design: a hybrid

`ExceptT` borrows its **carrier shape from `WriterT`** (a *value* `run_except_t: M::Of<Result<A, E>>`, not an `Rc<dyn Fn>`; manual `Clone` bounded only on `M::Of<Result<A, E>>: Clone`) but sits in the **`StateT` bound-family**: `apply`/`bind`/`join` require the inner monad to be `Bind`/`Monad`.

- **Why inner `Bind`:** short-circuiting on `Err` is a sequential data dependency — the first result must be inspected before the second is run or skipped. An inner-`Apply`-only `apply` (run both, combine) would break the **Applicative–Monad consistency law**, matching Haskell's `instance (Monad m) => Applicative (ExceptT e m)`. The proptest `except_apply_equals_monad_ap` over `VecKind` pins `apply` to the inner-bind definition.
- **Lightest payload constraint of any transformer:** `E: 'static` only — no `Monoid` (unlike `WriterT`'s `W`), no `Clone` (unlike `StateT`'s `S`). A concrete `E: Clone` is required only transitively (e.g. with a `Vec` inner).
- Reuses `std::result::Result` (zero-dep; `ResultKind<E>` already lawful); order pinned `Result<value, error>`.

## What's included

- **`src/transformers/except.rs`** — `ExceptT`/`ExceptTKind`/`Except`, full `Functor`/`Apply`/`Applicative`/`Bind`/`Monad`, the `MonadError` trait (`throw_error`/`catch_error`/`lift_either`), and the error-channel map `with_except_t`.
- **`src/transformers/trans.rs`** — the 4th `MonadTrans::lift` impl (`lift = map(_, Ok)`).
- **`src/lib.rs`, `src/transformers/mod.rs`** — re-exports + wiring.
- **`CLAUDE.md`** — marker list, Layout, instances, and the hybrid framing.

## Tests (laws are first-class)

- **Example** (`tests/kind/transformers/except.rs`): Functor/Apply/Bind/Monad smoke + `Err` short-circuit, the 3 Monad laws, `MonadError` ops, `with_except_t`, and effectful `OptionKind`-inner cases (incl. inner `None` vs `Err`).
- **proptest** (`tests/kind/proptest_laws/except.rs`): Monad laws, throw-left-zero, catch-throw, catch-pure, and the **Applicative–Monad consistency** law over `VecKind`.
- **do-notation** (`tests/kind/do_notation/except.rs`): `mdo!` short-circuit (a `throw_error` aborts the block).
- **trans** (`tests/kind/transformers/trans.rs`): `ExceptT` `lift` cases.

## Test plan / quality gates (all green locally)

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test` (default), `--features legacy`, `--features do-notation`, `--all-features`
- [x] doc-tests (`--all-features --doc`, incl. the new ExceptT doctest)
- [x] MSRV 1.66 fresh-lock (default + all-features)
- [x] zero-dependency guard (no syn/quote/proc-macro2 in normal deps)

Additive and non-breaking (a new module). `rust-reviewer` pass: **APPROVE**, no CRITICAL/HIGH.