### PR TITLE
docs(examples): add real-world ExceptT examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,9 @@ Core infrastructure lives in `src/kind_based/kind.rs`.
   `MonadWriter` (`tell`/`writer`/`listen`/`censor`) + runner `exec_writer_t`.
   `src/transformers/except.rs` — `ExceptT` + `MonadError`
   (`throw_error`/`catch_error`/`lift_either`) + error-channel map `with_except_t`.
+  `ExceptT` also provides inherent `ok`/`throw`/`from_result`/`catch` as the
+  ergonomic concrete forms of the `MonadError` surface (the trait stays for generic
+  code).
   `src/transformers/trans.rs` — `MonadTrans` (`lift`, impl'd for all four
   transformers). `src/monoid.rs` — `Semigroup`/`Monoid` (`combine`/`empty`).
   `src/utils.rs` — `fn0!`..`fn3!` macros.
@@ -58,7 +61,9 @@ Applicative (ExceptT e m)`). It imposes the **lightest payload constraint** of
 any transformer: `E: 'static` only — no `Monoid` (unlike `WriterT`'s `W`), no
 `Clone` (unlike `StateT`'s `S`). Its `MonadError` surface is `throw_error`
 (primitive), `catch_error`, and `lift_either`, with the catch laws (catch-throw,
-catch-pure) and throw-left-zero law-tested. `MonadTrans::lift` embeds an inner
+catch-pure) and throw-left-zero law-tested. `ExceptT` also provides inherent
+`ok`/`throw`/`from_result`/`catch` as the ergonomic concrete forms of the
+`MonadError` surface (the trait stays for generic code). `MonadTrans::lift` embeds an inner
 `M::Of<A>` into any of the four transformers, adding no effect (`ExceptT`'s
 `lift` wraps the value in `Ok`).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,19 @@ required-features = ["do-notation"]
 [[example]]
 name = "writer_eval_trace"
 required-features = ["do-notation"]
+
+[[example]]
+name = "except_form_validation"
+required-features = ["do-notation"]
+
+[[example]]
+name = "except_safe_calculator"
+required-features = ["do-notation"]
+
+[[example]]
+name = "except_config_loader"
+required-features = ["do-notation"]
+
+[[example]]
+name = "except_order_pipeline"
+required-features = ["do-notation"]

--- a/README.md
+++ b/README.md
@@ -159,6 +159,25 @@ cargo run --example writer_listen_censor --features do-notation
 cargo run --example writer_eval_trace    --features do-notation
 ```
 
+### Except monad examples
+
+These demonstrate the `ExceptT` Except monad short-circuiting on the first error
+via `mdo!` do-notation — a failed step aborts the computation, and `catch_error`
+can recover:
+
+- `except_form_validation.rs` — user-registration form validation that short-circuits on the first invalid field
+- `except_safe_calculator.rs` — calculator that throws on divide-by-zero / domain errors and recovers via `catch_error`
+- `except_config_loader.rs` — parse config string fields, unifying parse errors via `with_except_t`
+- `except_order_pipeline.rs` — order pipeline (validate → reserve → charge) that aborts on the first failure
+
+Run any of them with (each requires the `do-notation` feature):
+```bash
+cargo run --example except_form_validation --features do-notation
+cargo run --example except_safe_calculator --features do-notation
+cargo run --example except_config_loader   --features do-notation
+cargo run --example except_order_pipeline   --features do-notation
+```
+
 ## Building the Project
 
 To build the library:

--- a/examples/except_config_loader.rs
+++ b/examples/except_config_loader.rs
@@ -1,0 +1,122 @@
+//! Config loader example demonstrating `ExceptT` for heterogeneous parse error unification.
+//!
+//! Two raw string fields — port and retries — are parsed independently. Each parse
+//! produces an `ExceptT<ParseIntError, IdentityKind, _>`. The error channel is then
+//! remapped via `with_except_t` into a domain-specific `ConfigError`. The two
+//! `Checked<_>` computations are sequenced with `bind` so the first bad field
+//! short-circuits and the second is never attempted.
+//!
+//! Run with: `cargo run --example except_config_loader --features do-notation`
+
+use monadify::monad::kind::Bind;
+use monadify::transformers::except::{Except, ExceptT, ExceptTKind, MonadError};
+use monadify::{Identity, IdentityKind};
+use std::num::ParseIntError;
+
+/// Domain error distinguishing which config field failed to parse.
+#[derive(Clone, PartialEq, Debug)]
+enum ConfigError {
+    BadPort(String),
+    BadRetries(String),
+}
+
+/// Fully parsed configuration.
+#[derive(PartialEq, Debug)]
+struct Config {
+    port: u16,
+    retries: u32,
+}
+
+/// `Except<ConfigError, A>` = `ExceptT<ConfigError, IdentityKind, A>`.
+type Checked<A> = Except<ConfigError, A>;
+
+/// Kind marker alias used for sequencing `Checked<_>` computations with `bind`.
+type CKind = ExceptTKind<ConfigError, IdentityKind>;
+
+/// Parse `port_s` as `u16` and `retries_s` as `u32`, unifying any
+/// `ParseIntError` into `ConfigError` via `with_except_t`.
+///
+/// The first bad field short-circuits: if `port_s` fails, `retries_s` is
+/// never parsed.
+fn load(port_s: &str, retries_s: &str) -> Checked<Config> {
+    // Build ExceptT<ParseIntError, IdentityKind, u16> from the parse result, then
+    // remap the error channel ParseIntError -> ConfigError::BadPort.
+    let port_raw: ExceptT<ParseIntError, IdentityKind, u16> =
+        <ExceptTKind<ParseIntError, IdentityKind> as MonadError<
+            ParseIntError,
+            u16,
+            IdentityKind,
+        >>::lift_either(port_s.parse::<u16>());
+    let port_c: Checked<u16> = port_raw.with_except_t(|e| ConfigError::BadPort(e.to_string()));
+
+    // Same for retries, remapping to ConfigError::BadRetries.
+    let retries_raw: ExceptT<ParseIntError, IdentityKind, u32> =
+        <ExceptTKind<ParseIntError, IdentityKind> as MonadError<
+            ParseIntError,
+            u32,
+            IdentityKind,
+        >>::lift_either(retries_s.parse::<u32>());
+    let retries_c: Checked<u32> =
+        retries_raw.with_except_t(|e| ConfigError::BadRetries(e.to_string()));
+
+    // Sequence: port_c >>= \port -> retries_c >>= \retries -> Ok(Config { .. })
+    // Short-circuit: Err in port_c skips the inner bind entirely.
+    CKind::bind(port_c, move |port| {
+        CKind::bind(retries_c.clone(), move |retries| {
+            <CKind as MonadError<ConfigError, Config, IdentityKind>>::lift_either(Ok(Config {
+                port,
+                retries,
+            }))
+        })
+    })
+}
+
+fn main() {
+    println!("=== ExceptT Config Loader: unifying parse errors via with_except_t ===\n");
+
+    // Test 1: both fields valid.
+    let Identity(res1) = load("8080", "3").run_except_t;
+    assert_eq!(
+        res1,
+        Ok(Config {
+            port: 8080,
+            retries: 3
+        }),
+        "Test 1 failed"
+    );
+    println!("load(\"8080\", \"3\")      => {:?}  PASSED", res1);
+
+    // Test 2: bad port (non-numeric string) => BadPort; retries never parsed.
+    let Identity(res2) = load("notaport", "3").run_except_t;
+    assert!(
+        matches!(res2, Err(ConfigError::BadPort(_))),
+        "Test 2 failed: expected Err(BadPort(_)), got {:?}",
+        res2
+    );
+    println!("load(\"notaport\", \"3\")  => {:?}  PASSED", res2);
+
+    // Test 3: port ok, bad retries => BadRetries.
+    let Identity(res3) = load("8080", "xx").run_except_t;
+    assert!(
+        matches!(res3, Err(ConfigError::BadRetries(_))),
+        "Test 3 failed: expected Err(BadRetries(_)), got {:?}",
+        res3
+    );
+    println!("load(\"8080\", \"xx\")     => {:?}  PASSED", res3);
+
+    // Test 4: port overflow (99999 > u16::MAX 65535) => ParseIntError => BadPort.
+    let Identity(res4) = load("99999", "3").run_except_t;
+    assert!(
+        matches!(res4, Err(ConfigError::BadPort(_))),
+        "Test 4 failed: expected Err(BadPort(_)), got {:?}",
+        res4
+    );
+    println!("load(\"99999\", \"3\")     => {:?}  PASSED", res4);
+
+    println!("\n=== All assertions passed! ===");
+    println!("\nKey insight:");
+    println!("  * lift_either      wraps a Result into ExceptT<ParseIntError, IdentityKind, _>.");
+    println!("  * with_except_t    remaps the error channel: ParseIntError -> ConfigError.");
+    println!("  * bind             sequences Checked<_> steps, short-circuiting on Err.");
+    println!("  * run_except_t     is a field exposing Identity<Result<Config, ConfigError>>.");
+}

--- a/examples/except_config_loader.rs
+++ b/examples/except_config_loader.rs
@@ -9,7 +9,7 @@
 //! Run with: `cargo run --example except_config_loader --features do-notation`
 
 use monadify::monad::kind::Bind;
-use monadify::transformers::except::{Except, ExceptT, ExceptTKind, MonadError};
+use monadify::transformers::except::{Except, ExceptT, ExceptTKind};
 use monadify::{Identity, IdentityKind};
 use std::num::ParseIntError;
 
@@ -42,20 +42,12 @@ fn load(port_s: &str, retries_s: &str) -> Checked<Config> {
     // Build ExceptT<ParseIntError, IdentityKind, u16> from the parse result, then
     // remap the error channel ParseIntError -> ConfigError::BadPort.
     let port_raw: ExceptT<ParseIntError, IdentityKind, u16> =
-        <ExceptTKind<ParseIntError, IdentityKind> as MonadError<
-            ParseIntError,
-            u16,
-            IdentityKind,
-        >>::lift_either(port_s.parse::<u16>());
+        ExceptT::from_result(port_s.parse::<u16>());
     let port_c: Checked<u16> = port_raw.with_except_t(|e| ConfigError::BadPort(e.to_string()));
 
     // Same for retries, remapping to ConfigError::BadRetries.
     let retries_raw: ExceptT<ParseIntError, IdentityKind, u32> =
-        <ExceptTKind<ParseIntError, IdentityKind> as MonadError<
-            ParseIntError,
-            u32,
-            IdentityKind,
-        >>::lift_either(retries_s.parse::<u32>());
+        ExceptT::from_result(retries_s.parse::<u32>());
     let retries_c: Checked<u32> =
         retries_raw.with_except_t(|e| ConfigError::BadRetries(e.to_string()));
 
@@ -63,10 +55,7 @@ fn load(port_s: &str, retries_s: &str) -> Checked<Config> {
     // Short-circuit: Err in port_c skips the inner bind entirely.
     CKind::bind(port_c, move |port| {
         CKind::bind(retries_c.clone(), move |retries| {
-            <CKind as MonadError<ConfigError, Config, IdentityKind>>::lift_either(Ok(Config {
-                port,
-                retries,
-            }))
+            Checked::ok(Config { port, retries })
         })
     })
 }
@@ -115,7 +104,9 @@ fn main() {
 
     println!("\n=== All assertions passed! ===");
     println!("\nKey insight:");
-    println!("  * lift_either      wraps a Result into ExceptT<ParseIntError, IdentityKind, _>.");
+    println!(
+        "  * ExceptT::from_result  wraps a Result into ExceptT<ParseIntError, IdentityKind, _>."
+    );
     println!("  * with_except_t    remaps the error channel: ParseIntError -> ConfigError.");
     println!("  * bind             sequences Checked<_> steps, short-circuiting on Err.");
     println!("  * run_except_t     is a field exposing Identity<Result<Config, ConfigError>>.");

--- a/examples/except_form_validation.rs
+++ b/examples/except_form_validation.rs
@@ -1,0 +1,209 @@
+//! Except-monad demo: user-registration form validation.
+//!
+//! Demonstrates how `Except<ValidationError, _>` short-circuits on the FIRST
+//! invalid field in a user-registration form. Three validation steps are
+//! sequenced with `mdo!`; the moment one step calls `throw_error`, all later
+//! steps are skipped and the error propagates — later checks never run.
+//!
+//! ## Design notes
+//!
+//! Each `check_*` helper is a standalone function whose result is an owned
+//! `Checked<_>` value. `check_password` accepts `(username, email)` by value so
+//! those strings become bind-result *parameters* of the depth-1 closure rather
+//! than captured state of the depth-0 closure — this is the key to keeping every
+//! generated `move` closure `FnMut` despite the values being non-`Copy`.
+//!
+//! Run with:
+//! ```text
+//! cargo run --quiet --example except_form_validation --features do-notation
+//! ```
+
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::transformers::except::{Except, ExceptTKind, MonadError};
+
+// ── Domain types ──────────────────────────────────────────────────────────────
+
+/// Possible validation failures for a user-registration form.
+#[derive(Clone, PartialEq, Debug)]
+enum ValidationError {
+    /// The username field was left empty.
+    EmptyUsername,
+    /// The password is shorter than 8 characters.
+    PasswordTooShort,
+    /// The email address does not contain `@`.
+    InvalidEmail,
+}
+
+/// A successfully validated and constructed user.
+#[derive(Debug, Clone, PartialEq)]
+struct User {
+    username: String,
+    email: String,
+}
+
+// ── Kind aliases ──────────────────────────────────────────────────────────────
+
+/// `Except<ValidationError, A>` = `ExceptT<ValidationError, IdentityKind, A>`.
+/// Unwrap a value via `let Identity(res) = prog.run_except_t`.
+type Checked<A> = Except<ValidationError, A>;
+
+/// Kind marker for the `mdo!` macro first argument.
+type CKind = ExceptTKind<ValidationError, IdentityKind>;
+
+// ── Validation steps ──────────────────────────────────────────────────────────
+
+/// Step 1 — username must be non-empty.
+///
+/// Returns the validated username so step 2 can receive it as a bind-result
+/// parameter rather than a captured variable.
+fn check_username(username: String) -> Checked<String> {
+    if username.is_empty() {
+        <CKind as MonadError<ValidationError, String, IdentityKind>>::throw_error(
+            ValidationError::EmptyUsername,
+        )
+    } else {
+        <CKind as MonadError<ValidationError, String, IdentityKind>>::lift_either(Ok(username))
+    }
+}
+
+/// Step 2 — password must be at least 8 characters.
+///
+/// Accepts `username` and `email` by value and carries them forward as
+/// `Ok((username, email))` on success. This threading pattern keeps both strings
+/// as bind-result *parameters* of the depth-1 closure, avoiding a captured-state
+/// move that would turn the depth-0 closure into `FnOnce`.
+fn check_password(username: String, password: String, email: String) -> Checked<(String, String)> {
+    if password.len() < 8 {
+        <CKind as MonadError<ValidationError, (String, String), IdentityKind>>::throw_error(
+            ValidationError::PasswordTooShort,
+        )
+    } else {
+        <CKind as MonadError<ValidationError, (String, String), IdentityKind>>::lift_either(Ok((
+            username, email,
+        )))
+    }
+}
+
+/// Step 3 — email must contain `@`.
+///
+/// Builds the final `User` on success.
+fn check_email(username: String, email: String) -> Checked<User> {
+    if !email.contains('@') {
+        <CKind as MonadError<ValidationError, User, IdentityKind>>::throw_error(
+            ValidationError::InvalidEmail,
+        )
+    } else {
+        <CKind as MonadError<ValidationError, User, IdentityKind>>::lift_either(Ok(User {
+            username,
+            email,
+        }))
+    }
+}
+
+// ── Top-level validator ───────────────────────────────────────────────────────
+
+/// Validates a registration form in field order: username -> password -> email.
+///
+/// The `mdo!` block sequences three `Except` computations. If any step calls
+/// `throw_error`, the `ExceptT::bind` implementation propagates the error
+/// without invoking the remaining steps.
+///
+/// `password` and `email` are cloned in the bind expression for step 2 so
+/// they remain in the depth-0 closure as borrows (`.clone()`) rather than
+/// consumed moves — this keeps the depth-0 continuation `FnMut + Clone`.
+fn validate_form(username: String, password: String, email: String) -> Checked<User> {
+    mdo! {
+        CKind;
+        un        <- check_username(username);
+        (un2, em) <- check_password(un, password.clone(), email.clone());
+        user      <- check_email(un2, em);
+        pure(user)
+    }
+}
+
+// ── Helpers for running ───────────────────────────────────────────────────────
+
+/// Runs a `Checked<User>` computation and returns the inner `Result`.
+fn run(prog: Checked<User>) -> Result<User, ValidationError> {
+    let Identity(res) = prog.run_except_t;
+    res
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+
+fn main() {
+    println!("=== Except-monad: User-Registration Form Validation ===\n");
+
+    // ── Test 1: all fields valid ──────────────────────────────────────────────
+    println!("Test 1: valid form — expects Ok(User)");
+    let result = run(validate_form(
+        "alice".to_string(),
+        "supersecret".to_string(),
+        "alice@example.com".to_string(),
+    ));
+    assert_eq!(
+        result,
+        Ok(User {
+            username: "alice".to_string(),
+            email: "alice@example.com".to_string(),
+        }),
+        "valid form must produce Ok(User)"
+    );
+    println!("  Ok(User {{ username: \"alice\", email: \"alice@example.com\" }})");
+    println!("  PASSED\n");
+
+    // ── Test 2: empty username — short-circuits at step 1 ────────────────────
+    println!("Test 2: empty username — expects Err(EmptyUsername)");
+    let result = run(validate_form(
+        "".to_string(),
+        "supersecret".to_string(),
+        "alice@example.com".to_string(),
+    ));
+    assert_eq!(
+        result,
+        Err(ValidationError::EmptyUsername),
+        "empty username must short-circuit with EmptyUsername"
+    );
+    println!("  Err(EmptyUsername) -- password and email checks never ran");
+    println!("  PASSED\n");
+
+    // ── Test 3: short password — short-circuits at step 2 ────────────────────
+    println!("Test 3: valid username, short password — expects Err(PasswordTooShort)");
+    let result = run(validate_form(
+        "alice".to_string(),
+        "abc".to_string(),
+        "alice@example.com".to_string(),
+    ));
+    assert_eq!(
+        result,
+        Err(ValidationError::PasswordTooShort),
+        "short password must short-circuit with PasswordTooShort"
+    );
+    println!("  Err(PasswordTooShort) -- email check never ran");
+    println!("  PASSED\n");
+
+    // ── Test 4: bad email — short-circuits at step 3 ─────────────────────────
+    println!("Test 4: valid username and password, bad email — expects Err(InvalidEmail)");
+    let result = run(validate_form(
+        "alice".to_string(),
+        "supersecret".to_string(),
+        "notanemail".to_string(),
+    ));
+    assert_eq!(
+        result,
+        Err(ValidationError::InvalidEmail),
+        "invalid email must short-circuit with InvalidEmail"
+    );
+    println!("  Err(InvalidEmail)");
+    println!("  PASSED\n");
+
+    println!("=== All assertions passed! ===\n");
+    println!("Key insight: `mdo!` with `Except<ValidationError, _>` sequences validation:");
+    println!("  * `throw_error(e)`      injects an error; all later `bind` steps are skipped.");
+    println!("  * `lift_either(Ok(x))`  lifts a success value into the Except monad.");
+    println!("  * `ExceptT::bind`       propagates `Err` without running the continuation.");
+    println!("  * `run_except_t`        is a VALUE field; unwrap via `let Identity(res) = prog.run_except_t`.");
+    println!("  * Each step carries forward the data the next step needs as its bind-result");
+    println!("    parameter, keeping all generated `move` closures `FnMut + Clone`.");
+}

--- a/examples/except_form_validation.rs
+++ b/examples/except_form_validation.rs
@@ -20,7 +20,7 @@
 
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
-use monadify::transformers::except::{Except, ExceptTKind, MonadError};
+use monadify::transformers::except::{Except, ExceptTKind};
 
 // ── Domain types ──────────────────────────────────────────────────────────────
 
@@ -59,11 +59,9 @@ type CKind = ExceptTKind<ValidationError, IdentityKind>;
 /// parameter rather than a captured variable.
 fn check_username(username: String) -> Checked<String> {
     if username.is_empty() {
-        <CKind as MonadError<ValidationError, String, IdentityKind>>::throw_error(
-            ValidationError::EmptyUsername,
-        )
+        Checked::throw(ValidationError::EmptyUsername)
     } else {
-        <CKind as MonadError<ValidationError, String, IdentityKind>>::lift_either(Ok(username))
+        Checked::ok(username)
     }
 }
 
@@ -75,13 +73,9 @@ fn check_username(username: String) -> Checked<String> {
 /// move that would turn the depth-0 closure into `FnOnce`.
 fn check_password(username: String, password: String, email: String) -> Checked<(String, String)> {
     if password.len() < 8 {
-        <CKind as MonadError<ValidationError, (String, String), IdentityKind>>::throw_error(
-            ValidationError::PasswordTooShort,
-        )
+        Checked::throw(ValidationError::PasswordTooShort)
     } else {
-        <CKind as MonadError<ValidationError, (String, String), IdentityKind>>::lift_either(Ok((
-            username, email,
-        )))
+        Checked::ok((username, email))
     }
 }
 
@@ -90,14 +84,9 @@ fn check_password(username: String, password: String, email: String) -> Checked<
 /// Builds the final `User` on success.
 fn check_email(username: String, email: String) -> Checked<User> {
     if !email.contains('@') {
-        <CKind as MonadError<ValidationError, User, IdentityKind>>::throw_error(
-            ValidationError::InvalidEmail,
-        )
+        Checked::throw(ValidationError::InvalidEmail)
     } else {
-        <CKind as MonadError<ValidationError, User, IdentityKind>>::lift_either(Ok(User {
-            username,
-            email,
-        }))
+        Checked::ok(User { username, email })
     }
 }
 
@@ -200,8 +189,8 @@ fn main() {
 
     println!("=== All assertions passed! ===\n");
     println!("Key insight: `mdo!` with `Except<ValidationError, _>` sequences validation:");
-    println!("  * `throw_error(e)`      injects an error; all later `bind` steps are skipped.");
-    println!("  * `lift_either(Ok(x))`  lifts a success value into the Except monad.");
+    println!("  * `Checked::throw(e)`   injects an error; all later `bind` steps are skipped.");
+    println!("  * `Checked::ok(x)`      lifts a success value into the Except monad.");
     println!("  * `ExceptT::bind`       propagates `Err` without running the continuation.");
     println!("  * `run_except_t`        is a VALUE field; unwrap via `let Identity(res) = prog.run_except_t`.");
     println!("  * Each step carries forward the data the next step needs as its bind-result");

--- a/examples/except_order_pipeline.rs
+++ b/examples/except_order_pipeline.rs
@@ -3,8 +3,8 @@
 //!
 //! Demonstrates:
 //! - `mdo!` over `Except<OrderError, _>` short-circuiting on the first `Err`.
-//! - `throw_error` and `lift_either` from `MonadError`.
-//! - `catch_error` for recovery from a failed pipeline.
+//! - `ExceptT::throw` and `ExceptT::ok` from the inherent ergonomic API.
+//! - `.catch(..)` for recovery from a failed pipeline.
 //! - A thread-local counter proving `charge_card` is never invoked when an
 //!   earlier stage fails (short-circuit guarantee).
 //!
@@ -14,7 +14,7 @@ use std::cell::Cell;
 
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
-use monadify::transformers::except::{Except, ExceptTKind, MonadError};
+use monadify::transformers::except::{Except, ExceptTKind};
 
 // ── Domain types ──────────────────────────────────────────────────────────────
 
@@ -64,17 +64,17 @@ fn charge_count() -> u32 {
 
 fn validate_cart(o: Order) -> Checked<Order> {
     if o.items == 0 {
-        <CKind as MonadError<OrderError, Order, IdentityKind>>::throw_error(OrderError::EmptyCart)
+        Checked::throw(OrderError::EmptyCart)
     } else {
-        <CKind as MonadError<OrderError, Order, IdentityKind>>::lift_either(Ok(o))
+        Checked::ok(o)
     }
 }
 
 fn reserve_stock(o: Order) -> Checked<Order> {
     if !o.in_stock {
-        <CKind as MonadError<OrderError, Order, IdentityKind>>::throw_error(OrderError::OutOfStock)
+        Checked::throw(OrderError::OutOfStock)
     } else {
-        <CKind as MonadError<OrderError, Order, IdentityKind>>::lift_either(Ok(o))
+        Checked::ok(o)
     }
 }
 
@@ -82,13 +82,9 @@ fn charge_card(o: Order) -> Checked<Receipt> {
     // Incremented at the START — a count of 0 proves this function never ran.
     CHARGE_COUNT.with(|c| c.set(c.get() + 1));
     if !o.card_ok {
-        <CKind as MonadError<OrderError, Receipt, IdentityKind>>::throw_error(
-            OrderError::PaymentDeclined,
-        )
+        Checked::throw(OrderError::PaymentDeclined)
     } else {
-        <CKind as MonadError<OrderError, Receipt, IdentityKind>>::lift_either(Ok(Receipt {
-            total: o.total,
-        }))
+        Checked::ok(Receipt { total: o.total })
     }
 }
 
@@ -203,7 +199,7 @@ fn main() {
     );
     println!("Test 4 PASS — declined card => Err(PaymentDeclined)");
 
-    // ── Test 5: catch_error recovery ─────────────────────────────────────────
+    // ── Test 5: catch recovery ────────────────────────────────────────────────
     reset_counter();
     let failing = Order {
         items: 0,
@@ -211,25 +207,18 @@ fn main() {
         card_ok: true,
         total: 0,
     };
-    let recovered = <CKind as MonadError<OrderError, Receipt, IdentityKind>>::catch_error(
-        run_pipeline(failing),
-        |_e| {
-            <CKind as MonadError<OrderError, Receipt, IdentityKind>>::lift_either(Ok(Receipt {
-                total: 0,
-            }))
-        },
-    );
+    let recovered = run_pipeline(failing).catch(|_e| Checked::ok(Receipt { total: 0 }));
     assert_eq!(
         run(recovered),
         Ok(Receipt { total: 0 }),
-        "catch_error must recover from EmptyCart with a fallback Receipt"
+        "catch must recover from EmptyCart with a fallback Receipt"
     );
-    println!("Test 5 PASS — catch_error(EmptyCart) => Ok(Receipt {{ total: 0 }}) [recovery]");
+    println!("Test 5 PASS — catch(EmptyCart) => Ok(Receipt {{ total: 0 }}) [recovery]");
 
     println!("\n=== All 5 tests passed! ===");
     println!();
     println!("Key insights:");
     println!("  mdo! with ExceptT short-circuits: an Err in any stage skips all later stages.");
     println!("  charge_card count=0 proves it was never entered when an earlier stage failed.");
-    println!("  catch_error turns a failed pipeline into a fallback success computation.");
+    println!("  .catch(..) turns a failed pipeline into a fallback success computation.");
 }

--- a/examples/except_order_pipeline.rs
+++ b/examples/except_order_pipeline.rs
@@ -1,0 +1,235 @@
+//! Order pipeline via `ExceptT`: validate → reserve stock → charge card,
+//! aborting on the first failure.
+//!
+//! Demonstrates:
+//! - `mdo!` over `Except<OrderError, _>` short-circuiting on the first `Err`.
+//! - `throw_error` and `lift_either` from `MonadError`.
+//! - `catch_error` for recovery from a failed pipeline.
+//! - A thread-local counter proving `charge_card` is never invoked when an
+//!   earlier stage fails (short-circuit guarantee).
+//!
+//! Run: `cargo run --quiet --example except_order_pipeline --features do-notation`
+
+use std::cell::Cell;
+
+use monadify::identity::{Identity, IdentityKind};
+use monadify::mdo;
+use monadify::transformers::except::{Except, ExceptTKind, MonadError};
+
+// ── Domain types ──────────────────────────────────────────────────────────────
+
+#[derive(Clone, PartialEq, Debug)]
+enum OrderError {
+    EmptyCart,
+    OutOfStock,
+    PaymentDeclined,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+struct Receipt {
+    total: u32,
+}
+
+#[derive(Clone)]
+struct Order {
+    items: u32,
+    in_stock: bool,
+    card_ok: bool,
+    total: u32,
+}
+
+// ── Kind aliases ──────────────────────────────────────────────────────────────
+
+/// A computation that may fail with `OrderError` and produce a value of type `A`.
+type Checked<A> = Except<OrderError, A>;
+
+/// Kind marker for `mdo!` — `ExceptT<OrderError, IdentityKind, _>`.
+type CKind = ExceptTKind<OrderError, IdentityKind>;
+
+// ── Side-effect counter — proves charge_card never runs on early failure ───────
+
+thread_local! {
+    static CHARGE_COUNT: Cell<u32> = const { Cell::new(0) };
+}
+
+fn reset_counter() {
+    CHARGE_COUNT.with(|c| c.set(0));
+}
+
+fn charge_count() -> u32 {
+    CHARGE_COUNT.with(|c| c.get())
+}
+
+// ── Pipeline stage functions ──────────────────────────────────────────────────
+
+fn validate_cart(o: Order) -> Checked<Order> {
+    if o.items == 0 {
+        <CKind as MonadError<OrderError, Order, IdentityKind>>::throw_error(OrderError::EmptyCart)
+    } else {
+        <CKind as MonadError<OrderError, Order, IdentityKind>>::lift_either(Ok(o))
+    }
+}
+
+fn reserve_stock(o: Order) -> Checked<Order> {
+    if !o.in_stock {
+        <CKind as MonadError<OrderError, Order, IdentityKind>>::throw_error(OrderError::OutOfStock)
+    } else {
+        <CKind as MonadError<OrderError, Order, IdentityKind>>::lift_either(Ok(o))
+    }
+}
+
+fn charge_card(o: Order) -> Checked<Receipt> {
+    // Incremented at the START — a count of 0 proves this function never ran.
+    CHARGE_COUNT.with(|c| c.set(c.get() + 1));
+    if !o.card_ok {
+        <CKind as MonadError<OrderError, Receipt, IdentityKind>>::throw_error(
+            OrderError::PaymentDeclined,
+        )
+    } else {
+        <CKind as MonadError<OrderError, Receipt, IdentityKind>>::lift_either(Ok(Receipt {
+            total: o.total,
+        }))
+    }
+}
+
+// ── Order pipeline ────────────────────────────────────────────────────────────
+
+/// Three-stage order pipeline in a `mdo!` block.
+///
+/// An `Err` from any stage is propagated immediately; all later stages are
+/// skipped — they never execute.
+fn run_pipeline(o: Order) -> Checked<Receipt> {
+    mdo! {
+        CKind;
+        o2 <- validate_cart(o);
+        o3 <- reserve_stock(o2);
+        r  <- charge_card(o3);
+        pure(r)
+    }
+}
+
+/// Unwrap the `Identity` wrapper to obtain the inner `Result`.
+fn run<A>(m: Checked<A>) -> Result<A, OrderError> {
+    let Identity(r) = m.run_except_t;
+    r
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+fn main() {
+    println!("=== ExceptT Order Pipeline: short-circuit on first failure ===\n");
+
+    // ── Test 1: valid order succeeds ──────────────────────────────────────────
+    reset_counter();
+    let valid = Order {
+        items: 2,
+        in_stock: true,
+        card_ok: true,
+        total: 150,
+    };
+    let result = run(run_pipeline(valid));
+    assert_eq!(
+        result,
+        Ok(Receipt { total: 150 }),
+        "valid order must produce Ok(Receipt)"
+    );
+    assert_eq!(
+        charge_count(),
+        1,
+        "charge_card must run exactly once for a valid order"
+    );
+    println!("Test 1 PASS — valid order => Ok(Receipt {{ total: 150 }})");
+
+    // ── Test 2: empty cart — charge_card must NOT run ─────────────────────────
+    reset_counter();
+    let empty = Order {
+        items: 0,
+        in_stock: true,
+        card_ok: true,
+        total: 50,
+    };
+    let result = run(run_pipeline(empty));
+    assert_eq!(
+        result,
+        Err(OrderError::EmptyCart),
+        "empty cart must fail with EmptyCart"
+    );
+    assert_eq!(
+        charge_count(),
+        0,
+        "charge_card must NOT run when validate_cart fails (short-circuit)"
+    );
+    println!("Test 2 PASS — empty cart => Err(EmptyCart); charge_card count=0 (never called)");
+
+    // ── Test 3: out of stock — charge_card must NOT run ───────────────────────
+    reset_counter();
+    let no_stock = Order {
+        items: 3,
+        in_stock: false,
+        card_ok: true,
+        total: 200,
+    };
+    let result = run(run_pipeline(no_stock));
+    assert_eq!(
+        result,
+        Err(OrderError::OutOfStock),
+        "no stock must fail with OutOfStock"
+    );
+    assert_eq!(
+        charge_count(),
+        0,
+        "charge_card must NOT run when reserve_stock fails (short-circuit)"
+    );
+    println!("Test 3 PASS — out of stock => Err(OutOfStock); charge_card count=0 (never called)");
+
+    // ── Test 4: payment declined ──────────────────────────────────────────────
+    reset_counter();
+    let declined = Order {
+        items: 1,
+        in_stock: true,
+        card_ok: false,
+        total: 75,
+    };
+    let result = run(run_pipeline(declined));
+    assert_eq!(
+        result,
+        Err(OrderError::PaymentDeclined),
+        "declined card must fail with PaymentDeclined"
+    );
+    assert_eq!(
+        charge_count(),
+        1,
+        "charge_card must run (and then fail) when the card is declined"
+    );
+    println!("Test 4 PASS — declined card => Err(PaymentDeclined)");
+
+    // ── Test 5: catch_error recovery ─────────────────────────────────────────
+    reset_counter();
+    let failing = Order {
+        items: 0,
+        in_stock: true,
+        card_ok: true,
+        total: 0,
+    };
+    let recovered = <CKind as MonadError<OrderError, Receipt, IdentityKind>>::catch_error(
+        run_pipeline(failing),
+        |_e| {
+            <CKind as MonadError<OrderError, Receipt, IdentityKind>>::lift_either(Ok(Receipt {
+                total: 0,
+            }))
+        },
+    );
+    assert_eq!(
+        run(recovered),
+        Ok(Receipt { total: 0 }),
+        "catch_error must recover from EmptyCart with a fallback Receipt"
+    );
+    println!("Test 5 PASS — catch_error(EmptyCart) => Ok(Receipt {{ total: 0 }}) [recovery]");
+
+    println!("\n=== All 5 tests passed! ===");
+    println!();
+    println!("Key insights:");
+    println!("  mdo! with ExceptT short-circuits: an Err in any stage skips all later stages.");
+    println!("  charge_card count=0 proves it was never entered when an earlier stage failed.");
+    println!("  catch_error turns a failed pipeline into a fallback success computation.");
+}

--- a/examples/except_safe_calculator.rs
+++ b/examples/except_safe_calculator.rs
@@ -1,14 +1,14 @@
 //! Safe calculator using the `Except` monad for domain-error recovery.
 //!
-//! Demonstrates `throw_error`, `lift_either`, and `catch_error` with
+//! Demonstrates `throw`, `ok`, and `catch` with
 //! `ExceptT` over `IdentityKind`.  Division-by-zero and square-root-of-negative
-//! are modelled as typed errors; `catch_error` intercepts them and substitutes
+//! are modelled as typed errors; `catch` intercepts them and substitutes
 //! a fallback value without touching successful computations.
 //!
 //! Run with: `cargo run --example except_safe_calculator --features do-notation`
 
 use monadify::monad::kind::Bind;
-use monadify::transformers::except::{Except, ExceptTKind, MonadError};
+use monadify::transformers::except::{Except, ExceptTKind};
 use monadify::{Identity, IdentityKind};
 
 // ── Error type ────────────────────────────────────────────────────────────────
@@ -36,18 +36,18 @@ type CKind = ExceptTKind<MathError, IdentityKind>;
 /// Divides `a` by `b`.  Throws `DivByZero` when `b == 0.0`.
 fn safe_div(a: f64, b: f64) -> Checked<f64> {
     if b == 0.0 {
-        <CKind as MonadError<MathError, f64, IdentityKind>>::throw_error(MathError::DivByZero)
+        Checked::throw(MathError::DivByZero)
     } else {
-        <CKind as MonadError<MathError, f64, IdentityKind>>::lift_either(Ok(a / b))
+        Checked::ok(a / b)
     }
 }
 
 /// Takes the square root of `x`.  Throws `NegativeSqrt` when `x < 0.0`.
 fn safe_sqrt(x: f64) -> Checked<f64> {
     if x < 0.0 {
-        <CKind as MonadError<MathError, f64, IdentityKind>>::throw_error(MathError::NegativeSqrt)
+        Checked::throw(MathError::NegativeSqrt)
     } else {
-        <CKind as MonadError<MathError, f64, IdentityKind>>::lift_either(Ok(x.sqrt()))
+        Checked::ok(x.sqrt())
     }
 }
 
@@ -84,26 +84,20 @@ fn main() {
     );
     println!("  {:?}  PASSED\n", res3);
 
-    // ── Test 4: catch_error recovers DivByZero with fallback 0.0 ──────────────
-    println!("Test 4: catch_error(safe_div(1.0, 0.0), |_| Ok(0.0)) — recovery");
-    let recovered = <CKind as MonadError<MathError, f64, IdentityKind>>::catch_error(
-        safe_div(1.0, 0.0),
-        |_e| <CKind as MonadError<MathError, f64, IdentityKind>>::lift_either(Ok(0.0)),
-    );
+    // ── Test 4: catch recovers DivByZero with fallback 0.0 ────────────────────
+    println!("Test 4: safe_div(1.0, 0.0).catch(|_| Checked::ok(0.0)) — recovery");
+    let recovered = safe_div(1.0, 0.0).catch(|_| Checked::ok(0.0));
     let Identity(res4) = recovered.run_except_t;
     assert_eq!(res4, Ok(0.0), "expected Ok(0.0), got {:?}", res4);
     println!("  {:?}  PASSED\n", res4);
 
-    // ── Test 5: catch_error over an Ok computation passes through unchanged ────
-    println!("Test 5: catch_error(safe_div(10.0, 2.0), handler) — Ok passes through");
-    let passthrough = <CKind as MonadError<MathError, f64, IdentityKind>>::catch_error(
-        safe_div(10.0, 2.0),
-        |_e| {
-            // Handler must NOT be invoked — if it were, an assertion below would
-            // catch the wrong value (the fallback -1.0).
-            <CKind as MonadError<MathError, f64, IdentityKind>>::lift_either(Ok(-1.0))
-        },
-    );
+    // ── Test 5: catch over an Ok computation passes through unchanged ──────────
+    println!("Test 5: safe_div(10.0, 2.0).catch(handler) — Ok passes through");
+    let passthrough = safe_div(10.0, 2.0).catch(|_e| {
+        // Handler must NOT be invoked — if it were, an assertion below would
+        // catch the wrong value (the fallback -1.0).
+        Checked::ok(-1.0)
+    });
     let Identity(res5) = passthrough.run_except_t;
     assert_eq!(
         res5,
@@ -135,10 +129,10 @@ fn main() {
     // ── Summary ───────────────────────────────────────────────────────────────
     println!("=== All tests passed! ===");
     println!("\nKey insight:");
-    println!("  * throw_error  injects an error and short-circuits the computation.");
-    println!("  * lift_either  embeds a pure Result into the Except monad.");
-    println!("  * catch_error  intercepts Err and runs a recovery handler;");
-    println!("                 Ok values pass through with the handler never called.");
-    println!("  * bind         sequences steps, propagating Err without calling");
-    println!("                 the continuation — total short-circuit semantics.");
+    println!("  * throw  injects an error and short-circuits the computation.");
+    println!("  * ok     lifts a value onto the success branch.");
+    println!("  * catch  intercepts Err and runs a recovery handler;");
+    println!("           Ok values pass through with the handler never called.");
+    println!("  * bind   sequences steps, propagating Err without calling");
+    println!("           the continuation — total short-circuit semantics.");
 }

--- a/examples/except_safe_calculator.rs
+++ b/examples/except_safe_calculator.rs
@@ -1,0 +1,144 @@
+//! Safe calculator using the `Except` monad for domain-error recovery.
+//!
+//! Demonstrates `throw_error`, `lift_either`, and `catch_error` with
+//! `ExceptT` over `IdentityKind`.  Division-by-zero and square-root-of-negative
+//! are modelled as typed errors; `catch_error` intercepts them and substitutes
+//! a fallback value without touching successful computations.
+//!
+//! Run with: `cargo run --example except_safe_calculator --features do-notation`
+
+use monadify::monad::kind::Bind;
+use monadify::transformers::except::{Except, ExceptTKind, MonadError};
+use monadify::{Identity, IdentityKind};
+
+// ── Error type ────────────────────────────────────────────────────────────────
+
+/// Domain errors that the safe calculator can raise.
+#[derive(Clone, PartialEq, Debug)]
+enum MathError {
+    /// Attempted to divide by zero.
+    DivByZero,
+    /// Attempted to take the square root of a negative number.
+    NegativeSqrt,
+}
+
+// ── Type aliases ──────────────────────────────────────────────────────────────
+
+/// A computation that either produces an `A` or raises a `MathError`.
+/// `Except<E, A> = ExceptT<E, IdentityKind, A>`.
+type Checked<A> = Except<MathError, A>;
+
+/// Kind marker for `ExceptT<MathError, IdentityKind, _>`.
+type CKind = ExceptTKind<MathError, IdentityKind>;
+
+// ── Smart constructors ────────────────────────────────────────────────────────
+
+/// Divides `a` by `b`.  Throws `DivByZero` when `b == 0.0`.
+fn safe_div(a: f64, b: f64) -> Checked<f64> {
+    if b == 0.0 {
+        <CKind as MonadError<MathError, f64, IdentityKind>>::throw_error(MathError::DivByZero)
+    } else {
+        <CKind as MonadError<MathError, f64, IdentityKind>>::lift_either(Ok(a / b))
+    }
+}
+
+/// Takes the square root of `x`.  Throws `NegativeSqrt` when `x < 0.0`.
+fn safe_sqrt(x: f64) -> Checked<f64> {
+    if x < 0.0 {
+        <CKind as MonadError<MathError, f64, IdentityKind>>::throw_error(MathError::NegativeSqrt)
+    } else {
+        <CKind as MonadError<MathError, f64, IdentityKind>>::lift_either(Ok(x.sqrt()))
+    }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+fn main() {
+    println!("=== Except monad: safe calculator with error recovery ===\n");
+
+    // ── Test 1: safe_div success ───────────────────────────────────────────────
+    println!("Test 1: safe_div(10.0, 2.0) — success path");
+    let Identity(res1) = safe_div(10.0, 2.0).run_except_t;
+    assert_eq!(res1, Ok(5.0), "expected Ok(5.0), got {:?}", res1);
+    println!("  {:?}  PASSED\n", res1);
+
+    // ── Test 2: safe_div throws DivByZero ─────────────────────────────────────
+    println!("Test 2: safe_div(1.0, 0.0) — divide-by-zero error");
+    let Identity(res2) = safe_div(1.0, 0.0).run_except_t;
+    assert_eq!(
+        res2,
+        Err(MathError::DivByZero),
+        "expected Err(DivByZero), got {:?}",
+        res2
+    );
+    println!("  {:?}  PASSED\n", res2);
+
+    // ── Test 3: safe_sqrt throws NegativeSqrt ─────────────────────────────────
+    println!("Test 3: safe_sqrt(-4.0) — negative-sqrt error");
+    let Identity(res3) = safe_sqrt(-4.0).run_except_t;
+    assert_eq!(
+        res3,
+        Err(MathError::NegativeSqrt),
+        "expected Err(NegativeSqrt), got {:?}",
+        res3
+    );
+    println!("  {:?}  PASSED\n", res3);
+
+    // ── Test 4: catch_error recovers DivByZero with fallback 0.0 ──────────────
+    println!("Test 4: catch_error(safe_div(1.0, 0.0), |_| Ok(0.0)) — recovery");
+    let recovered = <CKind as MonadError<MathError, f64, IdentityKind>>::catch_error(
+        safe_div(1.0, 0.0),
+        |_e| <CKind as MonadError<MathError, f64, IdentityKind>>::lift_either(Ok(0.0)),
+    );
+    let Identity(res4) = recovered.run_except_t;
+    assert_eq!(res4, Ok(0.0), "expected Ok(0.0), got {:?}", res4);
+    println!("  {:?}  PASSED\n", res4);
+
+    // ── Test 5: catch_error over an Ok computation passes through unchanged ────
+    println!("Test 5: catch_error(safe_div(10.0, 2.0), handler) — Ok passes through");
+    let passthrough = <CKind as MonadError<MathError, f64, IdentityKind>>::catch_error(
+        safe_div(10.0, 2.0),
+        |_e| {
+            // Handler must NOT be invoked — if it were, an assertion below would
+            // catch the wrong value (the fallback -1.0).
+            <CKind as MonadError<MathError, f64, IdentityKind>>::lift_either(Ok(-1.0))
+        },
+    );
+    let Identity(res5) = passthrough.run_except_t;
+    assert_eq!(
+        res5,
+        Ok(5.0),
+        "expected Ok(5.0) (handler must not fire), got {:?}",
+        res5
+    );
+    println!("  {:?}  PASSED\n", res5);
+
+    // ── Test 6: bind sequences two safe operations (exact: sqrt(4.0) == 2.0) ──
+    println!("Test 6: bind — sqrt(safe_div(16.0, 4.0)) == sqrt(4.0) == 2.0");
+    let chained = CKind::bind(safe_div(16.0, 4.0), safe_sqrt);
+    let Identity(res6) = chained.run_except_t;
+    assert_eq!(res6, Ok(2.0), "expected Ok(2.0), got {:?}", res6);
+    println!("  {:?}  PASSED\n", res6);
+
+    // ── Test 7: bind short-circuits — DivByZero skips the sqrt step ───────────
+    println!("Test 7: bind — DivByZero short-circuits, sqrt step never runs");
+    let short_circuit = CKind::bind(safe_div(1.0, 0.0), safe_sqrt);
+    let Identity(res7) = short_circuit.run_except_t;
+    assert_eq!(
+        res7,
+        Err(MathError::DivByZero),
+        "expected Err(DivByZero) (short-circuit), got {:?}",
+        res7
+    );
+    println!("  {:?}  PASSED\n", res7);
+
+    // ── Summary ───────────────────────────────────────────────────────────────
+    println!("=== All tests passed! ===");
+    println!("\nKey insight:");
+    println!("  * throw_error  injects an error and short-circuits the computation.");
+    println!("  * lift_either  embeds a pure Result into the Except monad.");
+    println!("  * catch_error  intercepts Err and runs a recovery handler;");
+    println!("                 Ok values pass through with the handler never called.");
+    println!("  * bind         sequences steps, propagating Err without calling");
+    println!("                 the continuation — total short-circuit semantics.");
+}

--- a/src/transformers/except.rs
+++ b/src/transformers/except.rs
@@ -56,23 +56,31 @@ pub mod kind {
     //! type Checked<A> = Except<String, A>;          // ExceptT<String, IdentityKind, A>
     //! type CheckedKind = ExceptTKind<String, IdentityKind>;
     //!
-    //! // `throw_error` injects an error; the rest of the bind chain is skipped.
-    //! let boom = |msg: &str| <CheckedKind as MonadError<String, i32, IdentityKind>>::throw_error(msg.to_string());
+    //! // `Checked::throw` injects an error; the rest of the bind chain is skipped.
+    //! let boom = |msg: &str| Checked::<i32>::throw(msg.to_string());
     //!
     //! let prog: Checked<i32> = CheckedKind::bind(boom("nope"), move |x| CheckedKind::bind(
-    //!     <CheckedKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(x + 1)),
-    //!     move |y| <CheckedKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(y * 2)),
+    //!     Checked::ok(x + 1),
+    //!     move |y| Checked::ok(y * 2),
     //! ));
     //! let Identity(res) = prog.run_except_t;
     //! assert_eq!(res, Err("nope".to_string())); // short-circuited
     //!
-    //! // `catch_error` recovers from the error.
-    //! let recovered: Checked<i32> = <CheckedKind as MonadError<String, i32, IdentityKind>>::catch_error(
-    //!     boom("bad"),
-    //!     |_e| <CheckedKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(0)),
-    //! );
+    //! // `.catch(..)` recovers from the error.
+    //! let recovered: Checked<i32> = boom("bad").catch(|_e| Checked::ok(0));
     //! let Identity(res2) = recovered.run_except_t;
     //! assert_eq!(res2, Ok(0));
+    //!
+    //! // `from_result` embeds a pure `Result`.
+    //! let from_ok: Checked<i32> = Checked::from_result(Ok(42));
+    //! let Identity(res3) = from_ok.run_except_t;
+    //! assert_eq!(res3, Ok(42));
+    //!
+    //! // For reference, the verbose trait form is still available for generic code:
+    //! let verbose: Checked<i32> =
+    //!     <CheckedKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(42));
+    //! let Identity(res4) = verbose.run_except_t;
+    //! assert_eq!(res4, Ok(42));
     //! ```
 
     use crate::applicative::kind as applicative_kind;
@@ -311,7 +319,7 @@ pub mod kind {
         }
     }
 
-    // --- Error-channel map (the analog of WriterT's `censor`) ---
+    // --- Error-channel map and ergonomic inherent constructors/combinators ---
 
     impl<E, MKind: Kind1, A> ExceptT<E, MKind, A> {
         /// Maps the error channel `E -> E2`, leaving the success value unchanged:
@@ -332,6 +340,64 @@ pub mod kind {
             ExceptT::new(MKind::map(self.run_except_t, move |r: Result<A, E>| {
                 r.map_err(&mut f)
             }))
+        }
+
+        /// Lifts a success value onto the `Ok` branch — the ergonomic concrete form of
+        /// `MonadError::lift_either(Ok(_))` (and of `Applicative::pure`). The generic
+        /// `MonadError` trait remains for code generic over the inner monad.
+        pub fn ok(value: A) -> Self
+        where
+            E: 'static,
+            A: 'static,
+            MKind: applicative_kind::Applicative<Result<A, E>> + 'static,
+            MKind::Of<Result<A, E>>: 'static,
+        {
+            ExceptT::new(MKind::pure(Ok(value)))
+        }
+
+        /// Short-circuits with an error — the ergonomic concrete form of `MonadError::throw_error`.
+        pub fn throw(error: E) -> Self
+        where
+            E: 'static,
+            A: 'static,
+            MKind: applicative_kind::Applicative<Result<A, E>> + 'static,
+            MKind::Of<Result<A, E>>: 'static,
+        {
+            ExceptT::new(MKind::pure(Err(error)))
+        }
+
+        /// Embeds a pure `Result<A, E>` — the ergonomic concrete form of `MonadError::lift_either`.
+        pub fn from_result(r: Result<A, E>) -> Self
+        where
+            E: 'static,
+            A: 'static,
+            MKind: applicative_kind::Applicative<Result<A, E>> + 'static,
+            MKind::Of<Result<A, E>>: 'static,
+        {
+            ExceptT::new(MKind::pure(r))
+        }
+
+        /// Chainable recovery: runs `self`, and on `Err(e)` runs `handler(e)` instead — the
+        /// method form of `MonadError::catch_error`.
+        pub fn catch<F>(self, handler: F) -> Self
+        where
+            E: 'static,
+            A: 'static,
+            MKind: monad_kind::Bind<Result<A, E>, Result<A, E>>
+                + applicative_kind::Applicative<Result<A, E>>
+                + 'static,
+            MKind::Of<Result<A, E>>: 'static,
+            F: Fn(E) -> ExceptT<E, MKind, A> + Clone + 'static,
+        {
+            ExceptT::new(
+                <MKind as monad_kind::Bind<Result<A, E>, Result<A, E>>>::bind(
+                    self.run_except_t,
+                    move |r: Result<A, E>| match r {
+                        Ok(a) => MKind::pure(Ok(a)),
+                        Err(e) => handler(e).run_except_t,
+                    },
+                ),
+            )
         }
     }
 

--- a/tests/kind/transformers/except.rs
+++ b/tests/kind/transformers/except.rs
@@ -201,6 +201,105 @@ fn with_except_t_maps_error_channel() {
     assert_eq!(r2, Ok(9));
 }
 
+// ── Inherent ergonomic API: identity-inner (Except<String, _>) ───────────────
+
+#[test]
+fn inherent_throw_equals_trait_throw_error() {
+    let inherent: E<i32> = ExceptT::throw("boom".to_string());
+    let trait_form: E<i32> =
+        <EKind as MonadError<String, i32, IdentityKind>>::throw_error("boom".to_string());
+    assert_eq!(run_id(inherent), run_id(trait_form));
+}
+
+#[test]
+fn inherent_ok_equals_trait_lift_either_ok() {
+    let inherent: E<i32> = ExceptT::ok(42);
+    let trait_form: E<i32> = <EKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(42));
+    assert_eq!(run_id(inherent), run_id(trait_form));
+}
+
+#[test]
+fn inherent_from_result_ok_equals_trait_lift_either() {
+    let r: Result<i32, String> = Ok(7);
+    let inherent: E<i32> = ExceptT::from_result(r.clone());
+    let trait_form: E<i32> = <EKind as MonadError<String, i32, IdentityKind>>::lift_either(r);
+    assert_eq!(run_id(inherent), run_id(trait_form));
+}
+
+#[test]
+fn inherent_from_result_err_equals_trait_lift_either() {
+    let r: Result<i32, String> = Err("x".to_string());
+    let inherent: E<i32> = ExceptT::from_result(r.clone());
+    let trait_form: E<i32> = <EKind as MonadError<String, i32, IdentityKind>>::lift_either(r);
+    assert_eq!(run_id(inherent), run_id(trait_form));
+}
+
+#[test]
+fn inherent_catch_err_runs_handler_matches_trait() {
+    let handler = |_e: String| -> E<i32> { ExceptT::ok(0) };
+    let inherent: E<i32> = ExceptT::throw("bad".to_string()).catch(handler.clone());
+    let trait_form: E<i32> = <EKind as MonadError<String, i32, IdentityKind>>::catch_error(
+        ExceptT::throw("bad".to_string()),
+        handler,
+    );
+    assert_eq!(run_id(inherent), run_id(trait_form));
+}
+
+#[test]
+fn inherent_catch_ok_skips_handler_matches_trait() {
+    let handler = |_e: String| -> E<i32> { ExceptT::ok(-1) };
+    let inherent: E<i32> = ExceptT::ok(7_i32).catch(handler.clone());
+    let trait_form: E<i32> =
+        <EKind as MonadError<String, i32, IdentityKind>>::catch_error(ExceptT::ok(7), handler);
+    assert_eq!(run_id(inherent), run_id(trait_form));
+}
+
+// ── Inherent ergonomic API: OptionKind inner monad ───────────────────────────
+
+#[test]
+fn inherent_throw_option_inner_equals_trait() {
+    let inherent: OptE<i32> = ExceptT::throw("oops".to_string());
+    let trait_form: OptE<i32> =
+        <OptEKind as MonadError<String, i32, OptionKind>>::throw_error("oops".to_string());
+    assert_eq!(inherent.run_except_t, trait_form.run_except_t);
+}
+
+#[test]
+fn inherent_ok_option_inner_equals_trait() {
+    let inherent: OptE<i32> = ExceptT::ok(5);
+    let trait_form: OptE<i32> =
+        <OptEKind as MonadError<String, i32, OptionKind>>::lift_either(Ok(5));
+    assert_eq!(inherent.run_except_t, trait_form.run_except_t);
+}
+
+#[test]
+fn inherent_from_result_option_inner_equals_trait() {
+    let r: Result<i32, String> = Err("e".to_string());
+    let inherent: OptE<i32> = ExceptT::from_result(r.clone());
+    let trait_form: OptE<i32> = <OptEKind as MonadError<String, i32, OptionKind>>::lift_either(r);
+    assert_eq!(inherent.run_except_t, trait_form.run_except_t);
+}
+
+#[test]
+fn inherent_catch_option_inner_err_runs_handler() {
+    let handler = |_e: String| -> OptE<i32> { ExceptT::ok(0) };
+    let inherent: OptE<i32> = ExceptT::throw("e".to_string()).catch(handler.clone());
+    let trait_form: OptE<i32> = <OptEKind as MonadError<String, i32, OptionKind>>::catch_error(
+        ExceptT::throw("e".to_string()),
+        handler,
+    );
+    assert_eq!(inherent.run_except_t, trait_form.run_except_t);
+}
+
+#[test]
+fn inherent_catch_option_inner_ok_skips_handler() {
+    let handler = |_e: String| -> OptE<i32> { ExceptT::ok(-1) };
+    let inherent: OptE<i32> = ExceptT::ok(3_i32).catch(handler.clone());
+    let trait_form: OptE<i32> =
+        <OptEKind as MonadError<String, i32, OptionKind>>::catch_error(ExceptT::ok(3), handler);
+    assert_eq!(inherent.run_except_t, trait_form.run_except_t);
+}
+
 // ── Effectful inner monad: OptionKind threading + inner None ─────────────────
 
 type OptE<A> = ExceptT<String, OptionKind, A>;


### PR DESCRIPTION
## Summary

Four runnable, self-verifying **`ExceptT`** examples demonstrating the Except monad transformer and its `MonadError` surface (`throw_error` / `catch_error` / `lift_either` / `with_except_t`), merged in #10. Mirrors the Writer (#9) / State (#7) examples cadence: each prints a narrative **and** asserts deterministic `Ok`/`Err` output (so it doubles as a test), covering a success path, an `Err`/short-circuit path, and a recovered path for the `catch_error` demos.

## Examples (`examples/except_*.rs`)

| Example | Demonstrates |
|---|---|
| **`except_form_validation`** | User-registration form validation in an `mdo!` block that short-circuits on the **first** invalid field (`lift_either`/`throw_error`); only the first error is returned. |
| **`except_safe_calculator`** | Divide-by-zero / domain errors thrown via `throw_error` and **recovered** via `catch_error` (handler not invoked on success). |
| **`except_config_loader`** | Parse `Config { port, retries }` from `&str` via `lift_either` over `str::parse`, unifying heterogeneous `ParseIntError`s into one `ConfigError` with **`with_except_t`**. |
| **`except_order_pipeline`** | `validate → reserve → charge` pipeline that aborts on the first failure — a thread-local counter proves the charge step **never runs** when an earlier stage fails — plus a `catch_error` recovery path. |

Each defines its own custom error `enum` (no `Monoid`/`Clone` constraint on `E` from the transformer), wired into `Cargo.toml` (`required-features = ["do-notation"]`) and listed in the README.

## Test plan / quality gates (all green)

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo build --examples --features do-notation`
- [x] all four `cargo run --example except_* --features do-notation` exit 0 with asserts passing
- [x] `cargo test --all-features`

Docs-only / additive (new `examples/` files + Cargo.toml entries + README). `rust-reviewer` pass: **APPROVE**, no blocking issues.