### PR TITLE
feat(except): inherent ergonomic API (ok/throw/from_result/catch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,9 @@ Core infrastructure lives in `src/kind_based/kind.rs`.
   `MonadWriter` (`tell`/`writer`/`listen`/`censor`) + runner `exec_writer_t`.
   `src/transformers/except.rs` — `ExceptT` + `MonadError`
   (`throw_error`/`catch_error`/`lift_either`) + error-channel map `with_except_t`.
+  `ExceptT` also provides inherent `ok`/`throw`/`from_result`/`catch` as the
+  ergonomic concrete forms of the `MonadError` surface (the trait stays for generic
+  code).
   `src/transformers/trans.rs` — `MonadTrans` (`lift`, impl'd for all four
   transformers). `src/monoid.rs` — `Semigroup`/`Monoid` (`combine`/`empty`).
   `src/utils.rs` — `fn0!`..`fn3!` macros.
@@ -58,7 +61,9 @@ Applicative (ExceptT e m)`). It imposes the **lightest payload constraint** of
 any transformer: `E: 'static` only — no `Monoid` (unlike `WriterT`'s `W`), no
 `Clone` (unlike `StateT`'s `S`). Its `MonadError` surface is `throw_error`
 (primitive), `catch_error`, and `lift_either`, with the catch laws (catch-throw,
-catch-pure) and throw-left-zero law-tested. `MonadTrans::lift` embeds an inner
+catch-pure) and throw-left-zero law-tested. `ExceptT` also provides inherent
+`ok`/`throw`/`from_result`/`catch` as the ergonomic concrete forms of the
+`MonadError` surface (the trait stays for generic code). `MonadTrans::lift` embeds an inner
 `M::Of<A>` into any of the four transformers, adding no effect (`ExceptT`'s
 `lift` wraps the value in `Ok`).
 

--- a/examples/except_config_loader.rs
+++ b/examples/except_config_loader.rs
@@ -9,7 +9,7 @@
 //! Run with: `cargo run --example except_config_loader --features do-notation`
 
 use monadify::monad::kind::Bind;
-use monadify::transformers::except::{Except, ExceptT, ExceptTKind, MonadError};
+use monadify::transformers::except::{Except, ExceptT, ExceptTKind};
 use monadify::{Identity, IdentityKind};
 use std::num::ParseIntError;
 
@@ -42,20 +42,12 @@ fn load(port_s: &str, retries_s: &str) -> Checked<Config> {
     // Build ExceptT<ParseIntError, IdentityKind, u16> from the parse result, then
     // remap the error channel ParseIntError -> ConfigError::BadPort.
     let port_raw: ExceptT<ParseIntError, IdentityKind, u16> =
-        <ExceptTKind<ParseIntError, IdentityKind> as MonadError<
-            ParseIntError,
-            u16,
-            IdentityKind,
-        >>::lift_either(port_s.parse::<u16>());
+        ExceptT::from_result(port_s.parse::<u16>());
     let port_c: Checked<u16> = port_raw.with_except_t(|e| ConfigError::BadPort(e.to_string()));
 
     // Same for retries, remapping to ConfigError::BadRetries.
     let retries_raw: ExceptT<ParseIntError, IdentityKind, u32> =
-        <ExceptTKind<ParseIntError, IdentityKind> as MonadError<
-            ParseIntError,
-            u32,
-            IdentityKind,
-        >>::lift_either(retries_s.parse::<u32>());
+        ExceptT::from_result(retries_s.parse::<u32>());
     let retries_c: Checked<u32> =
         retries_raw.with_except_t(|e| ConfigError::BadRetries(e.to_string()));
 
@@ -63,10 +55,7 @@ fn load(port_s: &str, retries_s: &str) -> Checked<Config> {
     // Short-circuit: Err in port_c skips the inner bind entirely.
     CKind::bind(port_c, move |port| {
         CKind::bind(retries_c.clone(), move |retries| {
-            <CKind as MonadError<ConfigError, Config, IdentityKind>>::lift_either(Ok(Config {
-                port,
-                retries,
-            }))
+            Checked::ok(Config { port, retries })
         })
     })
 }
@@ -115,7 +104,9 @@ fn main() {
 
     println!("\n=== All assertions passed! ===");
     println!("\nKey insight:");
-    println!("  * lift_either      wraps a Result into ExceptT<ParseIntError, IdentityKind, _>.");
+    println!(
+        "  * ExceptT::from_result  wraps a Result into ExceptT<ParseIntError, IdentityKind, _>."
+    );
     println!("  * with_except_t    remaps the error channel: ParseIntError -> ConfigError.");
     println!("  * bind             sequences Checked<_> steps, short-circuiting on Err.");
     println!("  * run_except_t     is a field exposing Identity<Result<Config, ConfigError>>.");

--- a/examples/except_form_validation.rs
+++ b/examples/except_form_validation.rs
@@ -20,7 +20,7 @@
 
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
-use monadify::transformers::except::{Except, ExceptTKind, MonadError};
+use monadify::transformers::except::{Except, ExceptTKind};
 
 // ── Domain types ──────────────────────────────────────────────────────────────
 
@@ -59,11 +59,9 @@ type CKind = ExceptTKind<ValidationError, IdentityKind>;
 /// parameter rather than a captured variable.
 fn check_username(username: String) -> Checked<String> {
     if username.is_empty() {
-        <CKind as MonadError<ValidationError, String, IdentityKind>>::throw_error(
-            ValidationError::EmptyUsername,
-        )
+        Checked::throw(ValidationError::EmptyUsername)
     } else {
-        <CKind as MonadError<ValidationError, String, IdentityKind>>::lift_either(Ok(username))
+        Checked::ok(username)
     }
 }
 
@@ -75,13 +73,9 @@ fn check_username(username: String) -> Checked<String> {
 /// move that would turn the depth-0 closure into `FnOnce`.
 fn check_password(username: String, password: String, email: String) -> Checked<(String, String)> {
     if password.len() < 8 {
-        <CKind as MonadError<ValidationError, (String, String), IdentityKind>>::throw_error(
-            ValidationError::PasswordTooShort,
-        )
+        Checked::throw(ValidationError::PasswordTooShort)
     } else {
-        <CKind as MonadError<ValidationError, (String, String), IdentityKind>>::lift_either(Ok((
-            username, email,
-        )))
+        Checked::ok((username, email))
     }
 }
 
@@ -90,14 +84,9 @@ fn check_password(username: String, password: String, email: String) -> Checked<
 /// Builds the final `User` on success.
 fn check_email(username: String, email: String) -> Checked<User> {
     if !email.contains('@') {
-        <CKind as MonadError<ValidationError, User, IdentityKind>>::throw_error(
-            ValidationError::InvalidEmail,
-        )
+        Checked::throw(ValidationError::InvalidEmail)
     } else {
-        <CKind as MonadError<ValidationError, User, IdentityKind>>::lift_either(Ok(User {
-            username,
-            email,
-        }))
+        Checked::ok(User { username, email })
     }
 }
 
@@ -200,8 +189,8 @@ fn main() {
 
     println!("=== All assertions passed! ===\n");
     println!("Key insight: `mdo!` with `Except<ValidationError, _>` sequences validation:");
-    println!("  * `throw_error(e)`      injects an error; all later `bind` steps are skipped.");
-    println!("  * `lift_either(Ok(x))`  lifts a success value into the Except monad.");
+    println!("  * `Checked::throw(e)`   injects an error; all later `bind` steps are skipped.");
+    println!("  * `Checked::ok(x)`      lifts a success value into the Except monad.");
     println!("  * `ExceptT::bind`       propagates `Err` without running the continuation.");
     println!("  * `run_except_t`        is a VALUE field; unwrap via `let Identity(res) = prog.run_except_t`.");
     println!("  * Each step carries forward the data the next step needs as its bind-result");

--- a/examples/except_order_pipeline.rs
+++ b/examples/except_order_pipeline.rs
@@ -3,8 +3,8 @@
 //!
 //! Demonstrates:
 //! - `mdo!` over `Except<OrderError, _>` short-circuiting on the first `Err`.
-//! - `throw_error` and `lift_either` from `MonadError`.
-//! - `catch_error` for recovery from a failed pipeline.
+//! - `ExceptT::throw` and `ExceptT::ok` from the inherent ergonomic API.
+//! - `.catch(..)` for recovery from a failed pipeline.
 //! - A thread-local counter proving `charge_card` is never invoked when an
 //!   earlier stage fails (short-circuit guarantee).
 //!
@@ -14,7 +14,7 @@ use std::cell::Cell;
 
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
-use monadify::transformers::except::{Except, ExceptTKind, MonadError};
+use monadify::transformers::except::{Except, ExceptTKind};
 
 // ── Domain types ──────────────────────────────────────────────────────────────
 
@@ -64,17 +64,17 @@ fn charge_count() -> u32 {
 
 fn validate_cart(o: Order) -> Checked<Order> {
     if o.items == 0 {
-        <CKind as MonadError<OrderError, Order, IdentityKind>>::throw_error(OrderError::EmptyCart)
+        Checked::throw(OrderError::EmptyCart)
     } else {
-        <CKind as MonadError<OrderError, Order, IdentityKind>>::lift_either(Ok(o))
+        Checked::ok(o)
     }
 }
 
 fn reserve_stock(o: Order) -> Checked<Order> {
     if !o.in_stock {
-        <CKind as MonadError<OrderError, Order, IdentityKind>>::throw_error(OrderError::OutOfStock)
+        Checked::throw(OrderError::OutOfStock)
     } else {
-        <CKind as MonadError<OrderError, Order, IdentityKind>>::lift_either(Ok(o))
+        Checked::ok(o)
     }
 }
 
@@ -82,13 +82,9 @@ fn charge_card(o: Order) -> Checked<Receipt> {
     // Incremented at the START — a count of 0 proves this function never ran.
     CHARGE_COUNT.with(|c| c.set(c.get() + 1));
     if !o.card_ok {
-        <CKind as MonadError<OrderError, Receipt, IdentityKind>>::throw_error(
-            OrderError::PaymentDeclined,
-        )
+        Checked::throw(OrderError::PaymentDeclined)
     } else {
-        <CKind as MonadError<OrderError, Receipt, IdentityKind>>::lift_either(Ok(Receipt {
-            total: o.total,
-        }))
+        Checked::ok(Receipt { total: o.total })
     }
 }
 
@@ -203,7 +199,7 @@ fn main() {
     );
     println!("Test 4 PASS — declined card => Err(PaymentDeclined)");
 
-    // ── Test 5: catch_error recovery ─────────────────────────────────────────
+    // ── Test 5: catch recovery ────────────────────────────────────────────────
     reset_counter();
     let failing = Order {
         items: 0,
@@ -211,25 +207,18 @@ fn main() {
         card_ok: true,
         total: 0,
     };
-    let recovered = <CKind as MonadError<OrderError, Receipt, IdentityKind>>::catch_error(
-        run_pipeline(failing),
-        |_e| {
-            <CKind as MonadError<OrderError, Receipt, IdentityKind>>::lift_either(Ok(Receipt {
-                total: 0,
-            }))
-        },
-    );
+    let recovered = run_pipeline(failing).catch(|_e| Checked::ok(Receipt { total: 0 }));
     assert_eq!(
         run(recovered),
         Ok(Receipt { total: 0 }),
-        "catch_error must recover from EmptyCart with a fallback Receipt"
+        "catch must recover from EmptyCart with a fallback Receipt"
     );
-    println!("Test 5 PASS — catch_error(EmptyCart) => Ok(Receipt {{ total: 0 }}) [recovery]");
+    println!("Test 5 PASS — catch(EmptyCart) => Ok(Receipt {{ total: 0 }}) [recovery]");
 
     println!("\n=== All 5 tests passed! ===");
     println!();
     println!("Key insights:");
     println!("  mdo! with ExceptT short-circuits: an Err in any stage skips all later stages.");
     println!("  charge_card count=0 proves it was never entered when an earlier stage failed.");
-    println!("  catch_error turns a failed pipeline into a fallback success computation.");
+    println!("  .catch(..) turns a failed pipeline into a fallback success computation.");
 }

--- a/examples/except_safe_calculator.rs
+++ b/examples/except_safe_calculator.rs
@@ -1,14 +1,14 @@
 //! Safe calculator using the `Except` monad for domain-error recovery.
 //!
-//! Demonstrates `throw_error`, `lift_either`, and `catch_error` with
+//! Demonstrates `throw`, `ok`, and `catch` with
 //! `ExceptT` over `IdentityKind`.  Division-by-zero and square-root-of-negative
-//! are modelled as typed errors; `catch_error` intercepts them and substitutes
+//! are modelled as typed errors; `catch` intercepts them and substitutes
 //! a fallback value without touching successful computations.
 //!
 //! Run with: `cargo run --example except_safe_calculator --features do-notation`
 
 use monadify::monad::kind::Bind;
-use monadify::transformers::except::{Except, ExceptTKind, MonadError};
+use monadify::transformers::except::{Except, ExceptTKind};
 use monadify::{Identity, IdentityKind};
 
 // ── Error type ────────────────────────────────────────────────────────────────
@@ -36,18 +36,18 @@ type CKind = ExceptTKind<MathError, IdentityKind>;
 /// Divides `a` by `b`.  Throws `DivByZero` when `b == 0.0`.
 fn safe_div(a: f64, b: f64) -> Checked<f64> {
     if b == 0.0 {
-        <CKind as MonadError<MathError, f64, IdentityKind>>::throw_error(MathError::DivByZero)
+        Checked::throw(MathError::DivByZero)
     } else {
-        <CKind as MonadError<MathError, f64, IdentityKind>>::lift_either(Ok(a / b))
+        Checked::ok(a / b)
     }
 }
 
 /// Takes the square root of `x`.  Throws `NegativeSqrt` when `x < 0.0`.
 fn safe_sqrt(x: f64) -> Checked<f64> {
     if x < 0.0 {
-        <CKind as MonadError<MathError, f64, IdentityKind>>::throw_error(MathError::NegativeSqrt)
+        Checked::throw(MathError::NegativeSqrt)
     } else {
-        <CKind as MonadError<MathError, f64, IdentityKind>>::lift_either(Ok(x.sqrt()))
+        Checked::ok(x.sqrt())
     }
 }
 
@@ -84,26 +84,20 @@ fn main() {
     );
     println!("  {:?}  PASSED\n", res3);
 
-    // ── Test 4: catch_error recovers DivByZero with fallback 0.0 ──────────────
-    println!("Test 4: catch_error(safe_div(1.0, 0.0), |_| Ok(0.0)) — recovery");
-    let recovered = <CKind as MonadError<MathError, f64, IdentityKind>>::catch_error(
-        safe_div(1.0, 0.0),
-        |_e| <CKind as MonadError<MathError, f64, IdentityKind>>::lift_either(Ok(0.0)),
-    );
+    // ── Test 4: catch recovers DivByZero with fallback 0.0 ────────────────────
+    println!("Test 4: safe_div(1.0, 0.0).catch(|_| Checked::ok(0.0)) — recovery");
+    let recovered = safe_div(1.0, 0.0).catch(|_| Checked::ok(0.0));
     let Identity(res4) = recovered.run_except_t;
     assert_eq!(res4, Ok(0.0), "expected Ok(0.0), got {:?}", res4);
     println!("  {:?}  PASSED\n", res4);
 
-    // ── Test 5: catch_error over an Ok computation passes through unchanged ────
-    println!("Test 5: catch_error(safe_div(10.0, 2.0), handler) — Ok passes through");
-    let passthrough = <CKind as MonadError<MathError, f64, IdentityKind>>::catch_error(
-        safe_div(10.0, 2.0),
-        |_e| {
-            // Handler must NOT be invoked — if it were, an assertion below would
-            // catch the wrong value (the fallback -1.0).
-            <CKind as MonadError<MathError, f64, IdentityKind>>::lift_either(Ok(-1.0))
-        },
-    );
+    // ── Test 5: catch over an Ok computation passes through unchanged ──────────
+    println!("Test 5: safe_div(10.0, 2.0).catch(handler) — Ok passes through");
+    let passthrough = safe_div(10.0, 2.0).catch(|_e| {
+        // Handler must NOT be invoked — if it were, an assertion below would
+        // catch the wrong value (the fallback -1.0).
+        Checked::ok(-1.0)
+    });
     let Identity(res5) = passthrough.run_except_t;
     assert_eq!(
         res5,
@@ -135,10 +129,10 @@ fn main() {
     // ── Summary ───────────────────────────────────────────────────────────────
     println!("=== All tests passed! ===");
     println!("\nKey insight:");
-    println!("  * throw_error  injects an error and short-circuits the computation.");
-    println!("  * lift_either  embeds a pure Result into the Except monad.");
-    println!("  * catch_error  intercepts Err and runs a recovery handler;");
-    println!("                 Ok values pass through with the handler never called.");
-    println!("  * bind         sequences steps, propagating Err without calling");
-    println!("                 the continuation — total short-circuit semantics.");
+    println!("  * throw  injects an error and short-circuits the computation.");
+    println!("  * ok     lifts a value onto the success branch.");
+    println!("  * catch  intercepts Err and runs a recovery handler;");
+    println!("           Ok values pass through with the handler never called.");
+    println!("  * bind   sequences steps, propagating Err without calling");
+    println!("           the continuation — total short-circuit semantics.");
 }

--- a/src/transformers/except.rs
+++ b/src/transformers/except.rs
@@ -56,23 +56,31 @@ pub mod kind {
     //! type Checked<A> = Except<String, A>;          // ExceptT<String, IdentityKind, A>
     //! type CheckedKind = ExceptTKind<String, IdentityKind>;
     //!
-    //! // `throw_error` injects an error; the rest of the bind chain is skipped.
-    //! let boom = |msg: &str| <CheckedKind as MonadError<String, i32, IdentityKind>>::throw_error(msg.to_string());
+    //! // `Checked::throw` injects an error; the rest of the bind chain is skipped.
+    //! let boom = |msg: &str| Checked::<i32>::throw(msg.to_string());
     //!
     //! let prog: Checked<i32> = CheckedKind::bind(boom("nope"), move |x| CheckedKind::bind(
-    //!     <CheckedKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(x + 1)),
-    //!     move |y| <CheckedKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(y * 2)),
+    //!     Checked::ok(x + 1),
+    //!     move |y| Checked::ok(y * 2),
     //! ));
     //! let Identity(res) = prog.run_except_t;
     //! assert_eq!(res, Err("nope".to_string())); // short-circuited
     //!
-    //! // `catch_error` recovers from the error.
-    //! let recovered: Checked<i32> = <CheckedKind as MonadError<String, i32, IdentityKind>>::catch_error(
-    //!     boom("bad"),
-    //!     |_e| <CheckedKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(0)),
-    //! );
+    //! // `.catch(..)` recovers from the error.
+    //! let recovered: Checked<i32> = boom("bad").catch(|_e| Checked::ok(0));
     //! let Identity(res2) = recovered.run_except_t;
     //! assert_eq!(res2, Ok(0));
+    //!
+    //! // `from_result` embeds a pure `Result`.
+    //! let from_ok: Checked<i32> = Checked::from_result(Ok(42));
+    //! let Identity(res3) = from_ok.run_except_t;
+    //! assert_eq!(res3, Ok(42));
+    //!
+    //! // For reference, the verbose trait form is still available for generic code:
+    //! let verbose: Checked<i32> =
+    //!     <CheckedKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(42));
+    //! let Identity(res4) = verbose.run_except_t;
+    //! assert_eq!(res4, Ok(42));
     //! ```
 
     use crate::applicative::kind as applicative_kind;
@@ -311,7 +319,7 @@ pub mod kind {
         }
     }
 
-    // --- Error-channel map (the analog of WriterT's `censor`) ---
+    // --- Error-channel map and ergonomic inherent constructors/combinators ---
 
     impl<E, MKind: Kind1, A> ExceptT<E, MKind, A> {
         /// Maps the error channel `E -> E2`, leaving the success value unchanged:
@@ -332,6 +340,64 @@ pub mod kind {
             ExceptT::new(MKind::map(self.run_except_t, move |r: Result<A, E>| {
                 r.map_err(&mut f)
             }))
+        }
+
+        /// Lifts a success value onto the `Ok` branch — the ergonomic concrete form of
+        /// `MonadError::lift_either(Ok(_))` (and of `Applicative::pure`). The generic
+        /// `MonadError` trait remains for code generic over the inner monad.
+        pub fn ok(value: A) -> Self
+        where
+            E: 'static,
+            A: 'static,
+            MKind: applicative_kind::Applicative<Result<A, E>> + 'static,
+            MKind::Of<Result<A, E>>: 'static,
+        {
+            ExceptT::new(MKind::pure(Ok(value)))
+        }
+
+        /// Short-circuits with an error — the ergonomic concrete form of `MonadError::throw_error`.
+        pub fn throw(error: E) -> Self
+        where
+            E: 'static,
+            A: 'static,
+            MKind: applicative_kind::Applicative<Result<A, E>> + 'static,
+            MKind::Of<Result<A, E>>: 'static,
+        {
+            ExceptT::new(MKind::pure(Err(error)))
+        }
+
+        /// Embeds a pure `Result<A, E>` — the ergonomic concrete form of `MonadError::lift_either`.
+        pub fn from_result(r: Result<A, E>) -> Self
+        where
+            E: 'static,
+            A: 'static,
+            MKind: applicative_kind::Applicative<Result<A, E>> + 'static,
+            MKind::Of<Result<A, E>>: 'static,
+        {
+            ExceptT::new(MKind::pure(r))
+        }
+
+        /// Chainable recovery: runs `self`, and on `Err(e)` runs `handler(e)` instead — the
+        /// method form of `MonadError::catch_error`.
+        pub fn catch<F>(self, handler: F) -> Self
+        where
+            E: 'static,
+            A: 'static,
+            MKind: monad_kind::Bind<Result<A, E>, Result<A, E>>
+                + applicative_kind::Applicative<Result<A, E>>
+                + 'static,
+            MKind::Of<Result<A, E>>: 'static,
+            F: Fn(E) -> ExceptT<E, MKind, A> + Clone + 'static,
+        {
+            ExceptT::new(
+                <MKind as monad_kind::Bind<Result<A, E>, Result<A, E>>>::bind(
+                    self.run_except_t,
+                    move |r: Result<A, E>| match r {
+                        Ok(a) => MKind::pure(Ok(a)),
+                        Err(e) => handler(e).run_except_t,
+                    },
+                ),
+            )
         }
     }
 

--- a/tests/kind/transformers/except.rs
+++ b/tests/kind/transformers/except.rs
@@ -201,6 +201,105 @@ fn with_except_t_maps_error_channel() {
     assert_eq!(r2, Ok(9));
 }
 
+// ── Inherent ergonomic API: identity-inner (Except<String, _>) ───────────────
+
+#[test]
+fn inherent_throw_equals_trait_throw_error() {
+    let inherent: E<i32> = ExceptT::throw("boom".to_string());
+    let trait_form: E<i32> =
+        <EKind as MonadError<String, i32, IdentityKind>>::throw_error("boom".to_string());
+    assert_eq!(run_id(inherent), run_id(trait_form));
+}
+
+#[test]
+fn inherent_ok_equals_trait_lift_either_ok() {
+    let inherent: E<i32> = ExceptT::ok(42);
+    let trait_form: E<i32> = <EKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(42));
+    assert_eq!(run_id(inherent), run_id(trait_form));
+}
+
+#[test]
+fn inherent_from_result_ok_equals_trait_lift_either() {
+    let r: Result<i32, String> = Ok(7);
+    let inherent: E<i32> = ExceptT::from_result(r.clone());
+    let trait_form: E<i32> = <EKind as MonadError<String, i32, IdentityKind>>::lift_either(r);
+    assert_eq!(run_id(inherent), run_id(trait_form));
+}
+
+#[test]
+fn inherent_from_result_err_equals_trait_lift_either() {
+    let r: Result<i32, String> = Err("x".to_string());
+    let inherent: E<i32> = ExceptT::from_result(r.clone());
+    let trait_form: E<i32> = <EKind as MonadError<String, i32, IdentityKind>>::lift_either(r);
+    assert_eq!(run_id(inherent), run_id(trait_form));
+}
+
+#[test]
+fn inherent_catch_err_runs_handler_matches_trait() {
+    let handler = |_e: String| -> E<i32> { ExceptT::ok(0) };
+    let inherent: E<i32> = ExceptT::throw("bad".to_string()).catch(handler.clone());
+    let trait_form: E<i32> = <EKind as MonadError<String, i32, IdentityKind>>::catch_error(
+        ExceptT::throw("bad".to_string()),
+        handler,
+    );
+    assert_eq!(run_id(inherent), run_id(trait_form));
+}
+
+#[test]
+fn inherent_catch_ok_skips_handler_matches_trait() {
+    let handler = |_e: String| -> E<i32> { ExceptT::ok(-1) };
+    let inherent: E<i32> = ExceptT::ok(7_i32).catch(handler.clone());
+    let trait_form: E<i32> =
+        <EKind as MonadError<String, i32, IdentityKind>>::catch_error(ExceptT::ok(7), handler);
+    assert_eq!(run_id(inherent), run_id(trait_form));
+}
+
+// ── Inherent ergonomic API: OptionKind inner monad ───────────────────────────
+
+#[test]
+fn inherent_throw_option_inner_equals_trait() {
+    let inherent: OptE<i32> = ExceptT::throw("oops".to_string());
+    let trait_form: OptE<i32> =
+        <OptEKind as MonadError<String, i32, OptionKind>>::throw_error("oops".to_string());
+    assert_eq!(inherent.run_except_t, trait_form.run_except_t);
+}
+
+#[test]
+fn inherent_ok_option_inner_equals_trait() {
+    let inherent: OptE<i32> = ExceptT::ok(5);
+    let trait_form: OptE<i32> =
+        <OptEKind as MonadError<String, i32, OptionKind>>::lift_either(Ok(5));
+    assert_eq!(inherent.run_except_t, trait_form.run_except_t);
+}
+
+#[test]
+fn inherent_from_result_option_inner_equals_trait() {
+    let r: Result<i32, String> = Err("e".to_string());
+    let inherent: OptE<i32> = ExceptT::from_result(r.clone());
+    let trait_form: OptE<i32> = <OptEKind as MonadError<String, i32, OptionKind>>::lift_either(r);
+    assert_eq!(inherent.run_except_t, trait_form.run_except_t);
+}
+
+#[test]
+fn inherent_catch_option_inner_err_runs_handler() {
+    let handler = |_e: String| -> OptE<i32> { ExceptT::ok(0) };
+    let inherent: OptE<i32> = ExceptT::throw("e".to_string()).catch(handler.clone());
+    let trait_form: OptE<i32> = <OptEKind as MonadError<String, i32, OptionKind>>::catch_error(
+        ExceptT::throw("e".to_string()),
+        handler,
+    );
+    assert_eq!(inherent.run_except_t, trait_form.run_except_t);
+}
+
+#[test]
+fn inherent_catch_option_inner_ok_skips_handler() {
+    let handler = |_e: String| -> OptE<i32> { ExceptT::ok(-1) };
+    let inherent: OptE<i32> = ExceptT::ok(3_i32).catch(handler.clone());
+    let trait_form: OptE<i32> =
+        <OptEKind as MonadError<String, i32, OptionKind>>::catch_error(ExceptT::ok(3), handler);
+    assert_eq!(inherent.run_except_t, trait_form.run_except_t);
+}
+
 // ── Effectful inner monad: OptionKind threading + inner None ─────────────────
 
 type OptE<A> = ExceptT<String, OptionKind, A>;


### PR DESCRIPTION
## Summary

Addresses readability feedback that the `ExceptT` surface is **too verbose just for `Ok`/`Err`** and that the `<Type as Trait>` syntax is hard to read. The `MonadError` trait keys its methods on the Kind marker **plus a value-type param**, which forces the fully-qualified form:

```rust
// before
<ExceptTKind<E, IdentityKind> as MonadError<E, A, IdentityKind>>::throw_error(e)
<CKind as MonadError<E, A, IdentityKind>>::lift_either(Ok(x))
<CKind as MonadError<E, A, IdentityKind>>::catch_error(m, handler)
```

This adds idiomatic **inherent** items on the concrete `ExceptT<E, MKind, A>` (delegating to the same bodies), so concrete code drops the `<Type as Trait>` spelling entirely:

```rust
// after
Checked::throw(e)
Checked::ok(x)                 // or Checked::from_result(Ok(x))
m.catch(handler)               // chainable
safe_div(1.0, 0.0).catch(|_| Checked::ok(0.0))
```

| Inherent item | Ergonomic form of |
|---|---|
| `ExceptT::ok(value)` | `lift_either(Ok(_))` / `pure` |
| `ExceptT::throw(error)` | `throw_error` |
| `ExceptT::from_result(r)` | `lift_either` |
| `m.catch(handler)` | `catch_error` (as a chainable method) |

## Design

- **Non-breaking & additive.** The `MonadError<E, A, MKind>` trait is **unchanged** — it stays as the abstraction for code generic over the inner monad. The inherent methods are the concrete-use ergonomic path (idiomatic Rust; mirrors the existing inherent `with_except_t`).
- Each item carries the **same where-bounds** as its trait counterpart — still **`E: 'static` only** (no `Monoid`, no `Clone`); `catch` takes `self` by value with `F: Fn(E) -> ExceptT + Clone + 'static`.
- **11 parity unit tests** assert `inherent == trait` over `Identity` and `Option` inner monads.
- The module doctest and **all four `examples/except_*.rs`** are refactored to the clean API (zero `<.. as MonadError ..>` remain; `with_except_t` left as-is).

## Test plan / quality gates (all green)

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test` (default) + `--features do-notation` (the inherent parity tests + examples)
- [x] `cargo test --all-features --doc` (updated module doctest)
- [x] all four `cargo run --example except_* --features do-notation` exit 0
- [x] MSRV 1.66 fresh-lock; zero-dependency guard

`rust-reviewer`: **APPROVE**, no blocking issues (two stale `println!` footer strings fixed post-review).

> **Note:** stacked on #11 (the ExceptT examples) — it refactors those example files. Auto-retargets to `main` once #11 merges. Review/merge #11 first.