### PR TITLE
feat(transformers): inherent ergonomic forms for Reader/State/Writer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,15 @@ Core infrastructure lives in `src/kind_based/kind.rs`.
   code).
   `src/transformers/trans.rs` — `MonadTrans` (`lift`, impl'd for all four
   transformers). `src/monoid.rs` — `Semigroup`/`Monoid` (`combine`/`empty`).
+- **Ergonomic inherent forms (all transformers).** To avoid the verbose
+  `<Marker as MonadX<…>>::method()` UFCS at concrete call sites, each transformer
+  exposes inherent forms of its `MonadX` surface that delegate to the trait with
+  identical bounds (the trait stays for code generic over the inner monad):
+  constructors whose value type is fixed by the result live on the **Kind marker**
+  (`ReaderTKind::ask`; `StateTKind::{state,get,put,modify,gets}`;
+  `WriterTKind::{tell,writer}`; plus `ExceptT::{ok,throw,from_result}` on the type),
+  while computation-consuming ops are chainable **methods**
+  (`ReaderT::local`, `WriterT::{listen,censor}`, `ExceptT::{catch,with_except_t}`).
   `src/utils.rs` — `fn0!`..`fn3!` macros.
 - `src/legacy/` — the older associated-type implementation, behind the `legacy`
   feature flag (kept for comparison/benchmarking; not the default).

--- a/src/transformers/reader.rs
+++ b/src/transformers/reader.rs
@@ -44,8 +44,8 @@ pub mod kind {
     //! type ConfigReaderOption<A> = ReaderT<Config, OptionKind, A>;
     //! type ConfigReaderOptionKind = ReaderTKind<Config, OptionKind>;
     //!
-    //! // 1. Using 'ask' to get the environment
-    //! let ask_for_greeting_op: ConfigReaderOption<Config> = <ConfigReaderOptionKind as MonadReader<Config, Config, OptionKind>>::ask();
+    //! // 1. Using 'ask' to get the environment (ergonomic inherent form)
+    //! let ask_for_greeting_op: ConfigReaderOption<Config> = ConfigReaderOptionKind::ask();
     //! let ask_for_greeting: ConfigReaderOption<String> = <ConfigReaderOptionKind as Functor<Config, String>>::map(
     //!     ask_for_greeting_op,
     //!     |config: Config| config.greeting
@@ -148,6 +148,32 @@ pub mod kind {
                 _phantom_m_kind: PhantomData, // Changed _phantom_m_marker to _phantom_m_kind
                 _phantom_a: PhantomData,
             }
+        }
+
+        /// Runs `self` in a modified environment — the chainable method form of
+        /// [`MonadReader::local`].
+        ///
+        /// Applies `f` to the environment before the computation sees it, without
+        /// changing the environment visible to the surrounding context.
+        ///
+        /// # Example
+        /// ```
+        /// use monadify::transformers::reader::kind::{ReaderT, ReaderTKind};
+        /// use monadify::identity::kind::{Identity, IdentityKind};
+        ///
+        /// let comp: ReaderT<i32, IdentityKind, i32> = ReaderT::new(|env: i32| Identity(env * 2));
+        /// let result = (comp.local(|env: i32| env + 10).run_reader_t)(5);
+        /// assert_eq!(result, Identity(30)); // (5+10)*2 = 30
+        /// ```
+        pub fn local<F>(self, f: F) -> Self
+        where
+            R: 'static,
+            A: 'static,
+            MKind: 'static,
+            MKind::Of<A>: 'static,
+            F: Fn(R) -> R + 'static,
+        {
+            <ReaderTKind<R, MKind> as MonadReader<R, A, MKind>>::local(f, self)
         }
     }
 
@@ -419,6 +445,33 @@ pub mod kind {
                 let modified_env = map_env_fn(current_env);
                 computation_run(modified_env)
             })
+        }
+    }
+
+    impl<R, MKindImpl: Kind1> ReaderTKind<R, MKindImpl> {
+        /// Retrieves the environment as the value — the ergonomic concrete form of
+        /// [`MonadReader::ask`]. The generic `MonadReader` trait remains for code
+        /// generic over the inner monad.
+        ///
+        /// # Example
+        /// ```
+        /// use monadify::transformers::reader::kind::{ReaderT, ReaderTKind};
+        /// use monadify::kind_based::kind::OptionKind;
+        ///
+        /// #[derive(Clone, PartialEq, Debug)]
+        /// struct Cfg { id: i32 }
+        /// type CfgReaderKind = ReaderTKind<Cfg, OptionKind>;
+        ///
+        /// let get_env: ReaderT<Cfg, OptionKind, Cfg> = CfgReaderKind::ask();
+        /// assert_eq!((get_env.run_reader_t)(Cfg { id: 7 }), Some(Cfg { id: 7 }));
+        /// ```
+        pub fn ask() -> ReaderT<R, MKindImpl, R>
+        where
+            R: Clone + 'static,
+            MKindImpl: applicative_kind::Applicative<R> + 'static,
+            MKindImpl::Of<R>: 'static,
+        {
+            <Self as MonadReader<R, R, MKindImpl>>::ask()
         }
     }
 }

--- a/src/transformers/state.rs
+++ b/src/transformers/state.rs
@@ -55,7 +55,7 @@ pub mod kind {
     //!
     //! // `state`: a pure state transition. Return the old value, increment the state.
     //! let tick: Counter<i32> =
-    //!     <CounterKind as MonadState<i32, i32, IdentityKind>>::state(|s| (s, s + 1));
+    //!     CounterKind::state(|s| (s, s + 1));
     //! let Identity((v, s)) = (tick.run_state_t)(10);
     //! assert_eq!((v, s), (10, 11));
     //!
@@ -451,6 +451,106 @@ pub mod kind {
             F: Fn(S) -> B + 'static,
         {
             StateT::new(move |s: S| MKindImpl::pure((f(s.clone()), s)))
+        }
+    }
+
+    // --- Ergonomic inherent associated functions on the Kind marker ---
+    //
+    // These replicate the five [`MonadState`] surface methods directly on the
+    // `StateTKind<S, MKindImpl>` marker, so callers can write
+    // `StateTKind::<i32, IdentityKind>::get()` instead of the verbose
+    // `<StateTKind<i32, IdentityKind> as MonadState<i32, i32, IdentityKind>>::get()`.
+    // Each method simply delegates to the corresponding `MonadState` impl with
+    // identical bounds. The `MonadState` trait itself is unchanged and remains
+    // the right choice for code that is generic over the transformer.
+
+    impl<S, MKindImpl: Kind1> StateTKind<S, MKindImpl> {
+        /// Embeds a pure state transition `f: S -> (A, S)` — the ergonomic
+        /// concrete form of [`MonadState::state`].
+        ///
+        /// Callers can write `StateTKind::<S, M>::state(f)` instead of
+        /// `<StateTKind<S, M> as MonadState<S, A, M>>::state(f)`.
+        /// The generic [`MonadState`] trait stays for code that is generic
+        /// over the transformer.
+        pub fn state<F, A>(f: F) -> StateT<S, MKindImpl, A>
+        where
+            S: Clone + 'static,
+            A: 'static,
+            MKindImpl: applicative_kind::Applicative<(A, S)> + 'static,
+            MKindImpl::Of<(A, S)>: 'static,
+            F: Fn(S) -> (A, S) + 'static,
+        {
+            <Self as MonadState<S, A, MKindImpl>>::state(f)
+        }
+
+        /// Reads the whole state as the value, leaving it unchanged
+        /// (`s -> (s, s)`) — the ergonomic concrete form of [`MonadState::get`].
+        ///
+        /// Callers can write `StateTKind::<S, M>::get()` instead of
+        /// `<StateTKind<S, M> as MonadState<S, S, M>>::get()`.
+        /// The generic [`MonadState`] trait stays for code that is generic
+        /// over the transformer.
+        pub fn get() -> StateT<S, MKindImpl, S>
+        where
+            S: Clone + 'static,
+            MKindImpl: applicative_kind::Applicative<(S, S)> + 'static,
+            MKindImpl::Of<(S, S)>: 'static,
+        {
+            <Self as MonadState<S, S, MKindImpl>>::get()
+        }
+
+        /// Replaces the state with `new_state`, returning unit
+        /// (`_ -> ((), new_state)`) — the ergonomic concrete form of
+        /// [`MonadState::put`].
+        ///
+        /// Callers can write `StateTKind::<S, M>::put(s)` instead of
+        /// `<StateTKind<S, M> as MonadState<S, (), M>>::put(s)`.
+        /// The generic [`MonadState`] trait stays for code that is generic
+        /// over the transformer.
+        pub fn put(new_state: S) -> StateT<S, MKindImpl, ()>
+        where
+            S: Clone + 'static,
+            MKindImpl: applicative_kind::Applicative<((), S)> + 'static,
+            MKindImpl::Of<((), S)>: 'static,
+        {
+            <Self as MonadState<S, (), MKindImpl>>::put(new_state)
+        }
+
+        /// Applies `f` to the current state and stores the result, returning
+        /// unit (`s -> ((), f(s))`) — the ergonomic concrete form of
+        /// [`MonadState::modify`].
+        ///
+        /// Callers can write `StateTKind::<S, M>::modify(f)` instead of
+        /// `<StateTKind<S, M> as MonadState<S, (), M>>::modify(f)`.
+        /// The generic [`MonadState`] trait stays for code that is generic
+        /// over the transformer.
+        pub fn modify<F>(f: F) -> StateT<S, MKindImpl, ()>
+        where
+            S: Clone + 'static,
+            MKindImpl: applicative_kind::Applicative<((), S)> + 'static,
+            MKindImpl::Of<((), S)>: 'static,
+            F: Fn(S) -> S + 'static,
+        {
+            <Self as MonadState<S, (), MKindImpl>>::modify(f)
+        }
+
+        /// Projects the state through `f` as the value, leaving the state
+        /// unchanged (`s -> (f(s), s)`) — the ergonomic concrete form of
+        /// [`MonadState::gets`].
+        ///
+        /// Callers can write `StateTKind::<S, M>::gets(f)` instead of
+        /// `<StateTKind<S, M> as MonadState<S, B, M>>::gets(f)`.
+        /// The generic [`MonadState`] trait stays for code that is generic
+        /// over the transformer.
+        pub fn gets<F, B>(f: F) -> StateT<S, MKindImpl, B>
+        where
+            S: Clone + 'static,
+            B: 'static,
+            MKindImpl: applicative_kind::Applicative<(B, S)> + 'static,
+            MKindImpl::Of<(B, S)>: 'static,
+            F: Fn(S) -> B + 'static,
+        {
+            <Self as MonadState<S, B, MKindImpl>>::gets(f)
         }
     }
 }

--- a/src/transformers/writer.rs
+++ b/src/transformers/writer.rs
@@ -42,7 +42,7 @@ pub mod kind {
     //! type LoggedKind = WriterTKind<String, IdentityKind>;
     //!
     //! // `tell` appends to the log and yields unit.
-    //! let step = |msg: &str| <LoggedKind as MonadWriter<String, (), IdentityKind>>::tell(msg.to_string());
+    //! let step = |msg: &str| LoggedKind::tell(msg.to_string());
     //!
     //! // Sequence two log-writes; the logs concatenate monoidally.
     //! let prog: Logged<()> = LoggedKind::bind(step("hello "), move |_| step("world"));
@@ -129,6 +129,61 @@ pub mod kind {
         type Of<A> = WriterT<W, MKind, A>;
     }
     // Kind1 is provided by the blanket impl in kind_based/kind.rs.
+
+    impl<W, MKindImpl: Kind1> WriterTKind<W, MKindImpl> {
+        /// Appends `w` to the log and produces unit — the ergonomic alternative to
+        /// `<WriterTKind<W, MKindImpl> as MonadWriter<W, (), MKindImpl>>::tell(w)`.
+        ///
+        /// Avoids the UFCS syntax for the common case. Generic code that is
+        /// parameterized over the concrete Kind marker should continue to use the
+        /// trait form.
+        ///
+        /// # Example
+        /// ```
+        /// use monadify::transformers::writer::{Writer, WriterTKind};
+        /// use monadify::identity::{Identity, IdentityKind};
+        ///
+        /// let w: Writer<String, ()> =
+        ///     WriterTKind::<String, IdentityKind>::tell("hello".to_string());
+        /// let Identity(((), log)) = w.run_writer_t;
+        /// assert_eq!(log, "hello");
+        /// ```
+        pub fn tell(w: W) -> WriterT<W, MKindImpl, ()>
+        where
+            W: 'static,
+            MKindImpl: applicative_kind::Applicative<((), W)> + 'static,
+            MKindImpl::Of<((), W)>: 'static,
+        {
+            <Self as MonadWriter<W, (), MKindImpl>>::tell(w)
+        }
+
+        /// Embeds a `(value, log)` pair directly — the ergonomic alternative to
+        /// `<WriterTKind<W, MKindImpl> as MonadWriter<W, A, MKindImpl>>::writer(value, log)`.
+        ///
+        /// Avoids the UFCS syntax for the common case. Generic code that is
+        /// parameterized over the concrete Kind marker should continue to use the
+        /// trait form.
+        ///
+        /// # Example
+        /// ```
+        /// use monadify::transformers::writer::{Writer, WriterTKind};
+        /// use monadify::identity::{Identity, IdentityKind};
+        ///
+        /// let w: Writer<String, i32> =
+        ///     WriterTKind::<String, IdentityKind>::writer(42, "note".to_string());
+        /// let Identity((val, log)) = w.run_writer_t;
+        /// assert_eq!((val, log), (42, "note".to_string()));
+        /// ```
+        pub fn writer<A>(value: A, log: W) -> WriterT<W, MKindImpl, A>
+        where
+            W: 'static,
+            A: Clone + 'static,
+            MKindImpl: applicative_kind::Applicative<(A, W)> + 'static,
+            MKindImpl::Of<(A, W)>: 'static,
+        {
+            <Self as MonadWriter<W, A, MKindImpl>>::writer(value, log)
+        }
+    }
 
     /// A type alias for `WriterT` with [`IdentityKind`] as the inner monad.
     /// This is the plain Writer monad: `Writer<W, A>` wraps `Identity<(A, W)>`.
@@ -319,6 +374,61 @@ pub mod kind {
             MKind::Of<(A, W)>: 'static,
         {
             MKind::map(self.run_writer_t, |(_a, w)| w)
+        }
+
+        /// Exposes the accumulated log alongside the value, leaving it in place —
+        /// the chainable method form of
+        /// `<WriterTKind<W, MKind> as MonadWriter<W, A, MKind>>::listen(self)`.
+        ///
+        /// The produced value becomes `(A, W)` and the log remains `W`.
+        ///
+        /// # Example
+        /// ```
+        /// use monadify::transformers::writer::{Writer, WriterTKind, MonadWriter};
+        /// use monadify::identity::{Identity, IdentityKind};
+        ///
+        /// let w: Writer<String, ()> =
+        ///     WriterTKind::<String, IdentityKind>::tell("xyz".to_string());
+        /// let Identity((((), exposed), log)) = w.listen().run_writer_t;
+        /// assert_eq!(exposed, "xyz");
+        /// assert_eq!(log, "xyz");
+        /// ```
+        pub fn listen(self) -> WriterT<W, MKind, (A, W)>
+        where
+            W: Clone + 'static,
+            A: 'static,
+            MKind: functor_kind::Functor<(A, W), ((A, W), W)> + 'static,
+            MKind::Of<(A, W)>: 'static,
+            MKind::Of<((A, W), W)>: 'static,
+        {
+            <WriterTKind<W, MKind> as MonadWriter<W, A, MKind>>::listen(self)
+        }
+
+        /// Rewrites the log with `f`, leaving the value unchanged — the chainable
+        /// method form of
+        /// `<WriterTKind<W, MKind> as MonadWriter<W, A, MKind>>::censor(f, self)`.
+        ///
+        /// The result is `(a, f(w))`.
+        ///
+        /// # Example
+        /// ```
+        /// use monadify::transformers::writer::{Writer, WriterTKind, MonadWriter};
+        /// use monadify::identity::{Identity, IdentityKind};
+        ///
+        /// let w: Writer<String, ()> =
+        ///     WriterTKind::<String, IdentityKind>::tell("quiet".to_string());
+        /// let Identity(((), log)) = w.censor(|s: String| s.to_uppercase()).run_writer_t;
+        /// assert_eq!(log, "QUIET");
+        /// ```
+        pub fn censor<F>(self, f: F) -> Self
+        where
+            W: 'static,
+            A: 'static,
+            MKind: functor_kind::Functor<(A, W), (A, W)> + 'static,
+            MKind::Of<(A, W)>: 'static,
+            F: Fn(W) -> W + Clone + 'static,
+        {
+            <WriterTKind<W, MKind> as MonadWriter<W, A, MKind>>::censor(f, self)
         }
     }
 

--- a/tests/kind/transformers/reader.rs
+++ b/tests/kind/transformers/reader.rs
@@ -168,6 +168,66 @@ fn test_reader_t_kind_monad_law_associativity() {
     assert_eq!(val_lhs, "15");
 }
 
+// --- Parity tests: inherent ergonomic forms vs trait UFCS forms ---
+
+#[test]
+fn test_reader_t_inherent_ask_parity_identity() {
+    let env = EnvConfig { val: 42 };
+
+    // Inherent ergonomic form
+    let ask_inherent: TestReader<EnvConfig> = TestReaderKind::ask();
+    // Trait UFCS form
+    let ask_trait: TestReader<EnvConfig> =
+        <TestReaderKind as MonadReader<EnvConfig, EnvConfig, IdentityKind>>::ask();
+
+    let result_inherent = (ask_inherent.run_reader_t)(env.clone());
+    let result_trait = (ask_trait.run_reader_t)(env.clone());
+    assert_eq!(result_inherent, result_trait);
+    assert_eq!(result_inherent, Identity(EnvConfig { val: 42 }));
+}
+
+#[test]
+fn test_reader_t_inherent_ask_parity_option() {
+    use monadify::ReaderT as RT;
+    type OptReaderKind = monadify::ReaderTKind<i32, monadify::OptionKind>;
+
+    let env: i32 = 99;
+
+    // Inherent ergonomic form
+    let ask_inherent: RT<i32, monadify::OptionKind, i32> = OptReaderKind::ask();
+    // Trait UFCS form
+    let ask_trait: RT<i32, monadify::OptionKind, i32> =
+        <OptReaderKind as MonadReader<i32, i32, monadify::OptionKind>>::ask();
+
+    assert_eq!(
+        (ask_inherent.run_reader_t)(env),
+        (ask_trait.run_reader_t)(env),
+    );
+    assert_eq!((ask_inherent.run_reader_t)(env), Some(99));
+}
+
+#[test]
+fn test_reader_t_inherent_local_parity_identity() {
+    let env = EnvConfig { val: 5 };
+    let base: TestReader<i32> = ReaderT::new(|cfg: EnvConfig| Identity(cfg.val * 2));
+    // A non-capturing closure is Copy so we can pass it to both forms.
+    let modifier = |mut cfg: EnvConfig| {
+        cfg.val += 10;
+        cfg
+    };
+
+    // Method (inherent) form: comp.local(f)
+    let local_method = base.clone().local(modifier);
+    // Trait UFCS form: MonadReader::local(f, comp)
+    let local_trait = TestReaderKind::local(modifier, base);
+
+    let result_method = (local_method.run_reader_t)(env.clone());
+    let result_trait = (local_trait.run_reader_t)(env.clone());
+    assert_eq!(result_method, result_trait);
+    // env.val=5, modifier adds 10 -> 15, *2 -> 30
+    assert_eq!(result_method, Identity(30));
+}
+
 // Helper to run ReaderT with Option inner monad and compare
 fn run_kind_reader_t_option<
     R: Clone + 'static,

--- a/tests/kind/transformers/state.rs
+++ b/tests/kind/transformers/state.rs
@@ -218,3 +218,68 @@ fn option_inner_monadstate_laws_hold() {
     assert_eq!(run_opt(lhs.clone(), 0), run_opt(put(8), 0));
     assert_eq!(run_opt(lhs, 0), Some(((), 8)));
 }
+
+// ── Parity tests: inherent ergonomic form == MonadState trait form ─────────────
+//
+// Each test runs both the inherent `StateTKind::method(..)` form and the
+// explicit `<StateTKind as MonadState<..>>::method(..)` UFCS form against
+// the same initial state and asserts they produce identical `(value, state)` pairs.
+
+#[test]
+fn ergonomic_state_parity_identity() {
+    let s0 = 5_i32;
+    let erg: TestState<i32> = TestStateKind::state(|s| (s * 2, s + 1));
+    let via_trait: TestState<i32> =
+        <TestStateKind as MonadState<i32, i32, IdentityKind>>::state(|s| (s * 2, s + 1));
+    assert_eq!(run_id(erg, s0), run_id(via_trait, s0));
+}
+
+#[test]
+fn ergonomic_get_parity_identity() {
+    let s0 = 42_i32;
+    let erg: TestState<i32> = TestStateKind::get();
+    let via_trait: TestState<i32> = <TestStateKind as MonadState<i32, i32, IdentityKind>>::get();
+    assert_eq!(run_id(erg, s0), run_id(via_trait, s0));
+}
+
+#[test]
+fn ergonomic_put_parity_identity() {
+    let s0 = 7_i32;
+    let erg: TestState<()> = TestStateKind::put(99);
+    let via_trait: TestState<()> = <TestStateKind as MonadState<i32, (), IdentityKind>>::put(99);
+    assert_eq!(run_id(erg, s0), run_id(via_trait, s0));
+}
+
+#[test]
+fn ergonomic_modify_parity_identity() {
+    let s0 = 3_i32;
+    let erg: TestState<()> = TestStateKind::modify(|s| s * 10);
+    let via_trait: TestState<()> =
+        <TestStateKind as MonadState<i32, (), IdentityKind>>::modify(|s| s * 10);
+    assert_eq!(run_id(erg, s0), run_id(via_trait, s0));
+}
+
+#[test]
+fn ergonomic_gets_parity_identity() {
+    let s0 = 4_i32;
+    let erg: TestState<i32> = TestStateKind::gets(|s| s + 100);
+    let via_trait: TestState<i32> =
+        <TestStateKind as MonadState<i32, i32, IdentityKind>>::gets(|s| s + 100);
+    assert_eq!(run_id(erg, s0), run_id(via_trait, s0));
+}
+
+#[test]
+fn ergonomic_get_parity_option() {
+    let s0 = 10_i32;
+    let erg: OptState<i32> = OptStateKind::get();
+    let via_trait: OptState<i32> = <OptStateKind as MonadState<i32, i32, OptionKind>>::get();
+    assert_eq!(run_opt(erg, s0), run_opt(via_trait, s0));
+}
+
+#[test]
+fn ergonomic_put_parity_option() {
+    let s0 = 5_i32;
+    let erg: OptState<()> = OptStateKind::put(77);
+    let via_trait: OptState<()> = <OptStateKind as MonadState<i32, (), OptionKind>>::put(77);
+    assert_eq!(run_opt(erg, s0), run_opt(via_trait, s0));
+}

--- a/tests/kind/transformers/writer.rs
+++ b/tests/kind/transformers/writer.rs
@@ -204,3 +204,43 @@ fn option_inner_pure_empty_log() {
     let w: OptW<i32> = OptWKind::pure(7);
     assert_eq!(w.run_writer_t, Some((7, String::empty())));
 }
+
+// ── Inherent ergonomic API parity: each inherent form == the trait form ───────
+
+/// `WKind::tell(w)` must equal `<WKind as MonadWriter<..>>::tell(w)`.
+#[test]
+fn inherent_tell_parity() {
+    let trait_form = <WKind as MonadWriter<String, (), IdentityKind>>::tell("hello".to_string());
+    let inherent_form = WKind::tell("hello".to_string());
+    assert_eq!(run_id(trait_form), run_id(inherent_form));
+}
+
+/// `WKind::writer(a, w)` must equal `<WKind as MonadWriter<..>>::writer(a, w)`.
+#[test]
+fn inherent_writer_parity() {
+    let trait_form =
+        <WKind as MonadWriter<String, i32, IdentityKind>>::writer(42, "note".to_string());
+    let inherent_form = WKind::writer(42, "note".to_string());
+    assert_eq!(run_id(trait_form), run_id(inherent_form));
+}
+
+/// `m.listen()` must equal `<WKind as MonadWriter<..>>::listen(m)`.
+#[test]
+fn inherent_listen_parity() {
+    let m1 = tell("xyz");
+    let m2 = tell("xyz");
+    let trait_form = <WKind as MonadWriter<String, (), IdentityKind>>::listen(m1);
+    let inherent_form = m2.listen();
+    assert_eq!(run_id(trait_form), run_id(inherent_form));
+}
+
+/// `m.censor(f)` must equal `<WKind as MonadWriter<..>>::censor(f, m)`.
+#[test]
+fn inherent_censor_parity() {
+    let m1 = tell("quiet");
+    let m2 = tell("quiet");
+    let f = |w: String| w.to_uppercase();
+    let trait_form = <WKind as MonadWriter<String, (), IdentityKind>>::censor(f, m1);
+    let inherent_form = m2.censor(f);
+    assert_eq!(run_id(trait_form), run_id(inherent_form));
+}


### PR DESCRIPTION
## Summary

Applies the **same idiomatic fix** shipped for ExceptT (#12) to the other transformers that had the problem. `MonadReader` / `MonadState` / `MonadWriter` key their methods on the Kind marker **plus a value-type param**, which forces the verbose, hard-to-read fully-qualified form at concrete call sites:

```rust
// before
<StateTKind<i64, IdentityKind> as MonadState<i64, i64, IdentityKind>>::get()
<ReaderKind as MonadReader<Config, Config, IdentityKind>>::ask()
<WKind as MonadWriter<Vec<String>, (), IdentityKind>>::censor(redact, m)

// after
SKind::get()
ReaderKind::ask()
m.censor(redact)
```

Each new item delegates to the **same trait body with identical where-bounds**; the `MonadReader`/`MonadState`/`MonadWriter` traits are **unchanged** (kept for code generic over the inner monad). Placement follows from which type params a signature fixes — constructors whose value type is fixed by the result live on the **Kind marker**, while computation-consuming ops are chainable **methods**:

| Transformer | Marker assoc fns | Chainable methods |
|---|---|---|
| `ReaderT` | `ReaderTKind::ask()` | `reader.local(f)` |
| `StateT` | `StateTKind::{state, get, put, modify, gets}` | — |
| `WriterT` | `WriterTKind::{tell, writer}` | `writer.listen()`, `writer.censor(f)` |

This matches the merged ExceptT precedent (`ExceptT::{ok, throw, from_result}` on the type, `.catch` / `.with_except_t` as methods).

## Tests

Parity unit tests assert each inherent form behaves **identically** to its trait counterpart, over `Identity` and `Option` inner monads. One module doctest per transformer is tidied to the clean form. `CLAUDE.md` documents the pattern crate-wide.

## Test plan / quality gates (all green)

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test` (default) + `--features do-notation` + `--all-features`
- [x] `cargo test --all-features --doc`
- [x] MSRV 1.66 fresh-lock; zero-dependency guard

**Additive & non-breaking** — no new bounds (`WriterTKind::writer` keeps `A: Clone`, `WriterT::censor` keeps `F: Clone`, `StateT` ops keep `S: Clone`). `rust-reviewer`: **APPROVE**, no blocking issues.

### Noted follow-ups (not in this PR)
An audit surfaced a few optional, non-behavioral wins for later: `#[must_use]` on the pure constructors/combinators (a pedantic lint not in `-D warnings`), collapsing the three `PhantomData` fields per struct into one, and `#[inline]` on the one-line delegating wrappers.