### PR TITLE
chore: idiomatic-Rust sweep (must_use, PhantomData collapse, ergonomic tidy)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,11 @@ and `cargo test --all-features`. CI (`.github/workflows/rust.yml`) mirrors these
 separate jobs — `fmt`, `clippy` (`--all-features -- -D warnings`), `test` (default +
 `legacy` feature matrix, incl. doc-tests), and an `msrv` job checking against Rust
 1.66. The `clippy` job also lints `--benches` so `benches/compare.rs` can't
-silently rot. Still **not** enforced in CI (remaining gaps): full
-`clippy --all-targets` (the test files have ~50 auto-fixable lints, mostly
-`clone_on_copy`) and `cargo doc -D warnings` (one rustdoc link warning).
+silently rot. `clippy --all-targets --all-features -- -D warnings` is now **clean**
+across the whole tree (the historical ~50 auto-fixable test lints have been
+removed) though CI still runs `clippy` without `--all-targets`. The one remaining
+gap is `cargo doc -D warnings` (~11 rustdoc link warnings, mostly unresolved
+`Semigroup`/`Monoid` intra-doc links + redundant explicit link targets).
 
 ```bash
 cargo test                  # default kind-based suite

--- a/examples/reader_config.rs
+++ b/examples/reader_config.rs
@@ -7,7 +7,7 @@
 
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
-use monadify::transformers::reader::{MonadReader, Reader, ReaderT, ReaderTKind};
+use monadify::transformers::reader::{Reader, ReaderT, ReaderTKind};
 
 /// Application configuration: base rate and scaling factor.
 #[derive(Clone, Debug, PartialEq)]
@@ -50,7 +50,7 @@ fn compute_adjusted_rate(base: f64, factor: f64) -> ConfigReader<f64> {
 
 /// Helper: access the entire config with `ask()`.
 fn ask_config() -> ConfigReader<AppConfig> {
-    <ReaderKind as MonadReader<AppConfig, AppConfig, IdentityKind>>::ask()
+    ReaderKind::ask()
 }
 
 /// ─────────────────────────────────────────────────────────────────────────────

--- a/examples/state_bank_account.rs
+++ b/examples/state_bank_account.rs
@@ -10,7 +10,7 @@
 
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
-use monadify::transformers::state::{MonadState, State, StateTKind};
+use monadify::transformers::state::{State, StateTKind};
 
 /// Type alias: a computation that threads an `i64` balance (in cents) and
 /// returns an `Identity<A>`. `State<S, A> = StateT<S, IdentityKind, A>`.
@@ -23,17 +23,17 @@ type SKind = StateTKind<i64, IdentityKind>;
 
 /// Deposits `cents` into the account (increases the balance).
 fn deposit(cents: i64) -> Account<()> {
-    <SKind as MonadState<i64, (), IdentityKind>>::modify(move |b| b + cents)
+    SKind::modify(move |b| b + cents)
 }
 
 /// Withdraws `cents` from the account (decreases the balance).
 fn withdraw(cents: i64) -> Account<()> {
-    <SKind as MonadState<i64, (), IdentityKind>>::modify(move |b| b - cents)
+    SKind::modify(move |b| b - cents)
 }
 
 /// Reads the current balance without modifying it.
 fn balance() -> Account<i64> {
-    <SKind as MonadState<i64, i64, IdentityKind>>::get()
+    SKind::get()
 }
 
 // ── The ledger computation ───────────────────────────────────────────────────

--- a/examples/state_rng_lcg.rs
+++ b/examples/state_rng_lcg.rs
@@ -9,7 +9,7 @@ use monadify::applicative::kind::Applicative;
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
 use monadify::monad::kind::Bind;
-use monadify::transformers::state::{MonadState, State, StateTKind};
+use monadify::transformers::state::{State, StateTKind};
 
 /// Type alias: a stateful computation that threads a `u64` LCG seed.
 /// `State<S, A> = StateT<S, IdentityKind, A>`.
@@ -24,7 +24,7 @@ const ADD: u64 = 1442695040888963407;
 
 /// Advance the LCG seed and return the new seed as the produced value.
 fn next_u64() -> Rng<u64> {
-    <SKind as MonadState<u64, u64, IdentityKind>>::state(|seed| {
+    SKind::state(|seed| {
         let s2 = seed.wrapping_mul(MUL).wrapping_add(ADD);
         (s2, s2)
     })

--- a/examples/state_stack_machine.rs
+++ b/examples/state_stack_machine.rs
@@ -9,7 +9,7 @@
 
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
-use monadify::transformers::state::{MonadState, State, StateTKind};
+use monadify::transformers::state::{State, StateTKind};
 
 /// Type alias: a computation that threads a `Vec<i64>` operand stack and produces `A`.
 /// `State<S, A> = StateT<S, IdentityKind, A>`.
@@ -22,7 +22,7 @@ type SKind = StateTKind<Vec<i64>, IdentityKind>;
 
 /// Push an operand onto the stack (returns unit; modifies state).
 fn push(n: i64) -> Stack<()> {
-    <SKind as MonadState<Vec<i64>, (), IdentityKind>>::modify(move |mut st| {
+    SKind::modify(move |mut st| {
         st.push(n);
         st
     })
@@ -30,7 +30,7 @@ fn push(n: i64) -> Stack<()> {
 
 /// Apply a binary operator: pop two operands (right then left), push one result.
 fn binary_op(op: impl Fn(i64, i64) -> i64 + 'static) -> Stack<()> {
-    <SKind as MonadState<Vec<i64>, (), IdentityKind>>::state(move |mut st| {
+    SKind::state(move |mut st| {
         let b = st.pop().expect("stack underflow: missing right operand");
         let a = st.pop().expect("stack underflow: missing left operand");
         st.push(op(a, b));
@@ -50,9 +50,7 @@ fn mul_op() -> Stack<()> {
 
 /// Read the top of the stack without consuming it (state is left unchanged).
 fn peek_top() -> Stack<i64> {
-    <SKind as MonadState<Vec<i64>, i64, IdentityKind>>::gets(|st| {
-        *st.last().expect("peek_top: empty stack")
-    })
+    SKind::gets(|st| *st.last().expect("peek_top: empty stack"))
 }
 
 // ── Programs ─────────────────────────────────────────────────────────────────

--- a/examples/state_unique_id.rs
+++ b/examples/state_unique_id.rs
@@ -8,7 +8,7 @@
 
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
-use monadify::transformers::state::{MonadState, State, StateTKind};
+use monadify::transformers::state::{State, StateTKind};
 
 /// Type alias: a stateful computation that threads a `u64` counter and produces `A`.
 /// `State<S, A>` = `StateT<S, IdentityKind, A>`.
@@ -20,7 +20,7 @@ type SKind = StateTKind<u64, IdentityKind>;
 /// Allocates a fresh id: returns the current counter as the id, then advances
 /// the counter by one.  `state(|n| (n, n + 1))` means "value = n, new_state = n + 1".
 fn fresh() -> Gen<u64> {
-    <SKind as MonadState<u64, u64, IdentityKind>>::state(|n| (n, n + 1))
+    SKind::state(|n| (n, n + 1))
 }
 
 /// Assigns monotonically-increasing unique ids to the three labels in a single

--- a/examples/writer_audit_log.rs
+++ b/examples/writer_audit_log.rs
@@ -9,7 +9,7 @@
 
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
-use monadify::transformers::writer::{MonadWriter, Writer, WriterTKind};
+use monadify::transformers::writer::{Writer, WriterTKind};
 
 /// Type alias: a computation that accumulates a `Vec<String>` audit log and
 /// produces a value `A`.
@@ -23,7 +23,7 @@ type WKind = WriterTKind<Vec<String>, IdentityKind>;
 
 /// Appends a single audit entry to the log, yielding unit.
 fn step(s: &str) -> Logged<()> {
-    <WKind as MonadWriter<Vec<String>, (), IdentityKind>>::tell(vec![s.to_string()])
+    WKind::tell(vec![s.to_string()])
 }
 
 // ── Pipeline ─────────────────────────────────────────────────────────────────

--- a/examples/writer_cost_monoid.rs
+++ b/examples/writer_cost_monoid.rs
@@ -11,7 +11,7 @@
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
 use monadify::monoid::{Monoid, Semigroup};
-use monadify::transformers::writer::{MonadWriter, Writer, WriterTKind};
+use monadify::transformers::writer::{Writer, WriterTKind};
 
 // ── User-defined monoid ───────────────────────────────────────────────────────
 
@@ -49,7 +49,7 @@ type WKind = WriterTKind<Sum, IdentityKind>;
 
 /// Record a cost of `n` units, appending `Sum(n)` to the log and yielding unit.
 fn charge(n: u64) -> Costed<()> {
-    <WKind as MonadWriter<Sum, (), IdentityKind>>::tell(Sum(n))
+    WKind::tell(Sum(n))
 }
 
 // ── Programs ──────────────────────────────────────────────────────────────────

--- a/examples/writer_eval_trace.rs
+++ b/examples/writer_eval_trace.rs
@@ -10,7 +10,7 @@
 
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
-use monadify::transformers::writer::{MonadWriter, Writer, WriterTKind};
+use monadify::transformers::writer::{Writer, WriterTKind};
 
 /// Type alias: a computation that accumulates a `String` trace log and
 /// produces a value `A`.
@@ -24,7 +24,7 @@ type WKind = WriterTKind<String, IdentityKind>;
 
 /// Appends a single trace line to the log, yielding unit.
 fn trace(line: String) -> Traced<()> {
-    <WKind as MonadWriter<String, (), IdentityKind>>::tell(line)
+    WKind::tell(line)
 }
 
 // ── Step combinators ─────────────────────────────────────────────────────────

--- a/examples/writer_listen_censor.rs
+++ b/examples/writer_listen_censor.rs
@@ -12,7 +12,7 @@
 
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
-use monadify::transformers::writer::{MonadWriter, Writer, WriterTKind};
+use monadify::transformers::writer::{Writer, WriterTKind};
 
 /// Type alias: a computation that accumulates a `Vec<String>` log and produces `A`.
 /// `Writer<W, A> = WriterT<W, IdentityKind, A>`.
@@ -25,7 +25,7 @@ type WKind = WriterTKind<Vec<String>, IdentityKind>;
 
 /// Appends a single log entry, yielding unit.
 fn step(s: &str) -> Logged<()> {
-    <WKind as MonadWriter<Vec<String>, (), IdentityKind>>::tell(vec![s.to_string()])
+    WKind::tell(vec![s.to_string()])
 }
 
 // ── Shared sub-computation ────────────────────────────────────────────────────
@@ -48,7 +48,7 @@ fn auth_steps() -> Logged<()> {
 fn listen_demo() -> Logged<Vec<String>> {
     mdo! {
         WKind;
-        captured <- <WKind as MonadWriter<Vec<String>, (), IdentityKind>>::listen(auth_steps());
+        captured <- auth_steps().listen();
         pure(captured.1)
     }
 }
@@ -69,7 +69,7 @@ fn censor_demo() -> Logged<()> {
                 })
                 .collect()
         };
-        _ <- <WKind as MonadWriter<Vec<String>, (), IdentityKind>>::censor(redact, auth_steps());
+        _ <- auth_steps().censor(redact);
         _ <- step("main: done");
         pure(())
     }

--- a/src/applicative.rs
+++ b/src/applicative.rs
@@ -85,6 +85,7 @@ pub mod kind {
         ///
         /// # Returns
         /// The value wrapped in the Kind applicative structure, `Self::Of<T>`.
+        #[must_use]
         fn pure(value: T) -> Self::Of<T>;
     }
 
@@ -185,6 +186,7 @@ pub mod kind {
     /// );
     /// assert_eq!(lifted_vec, vec![false, true, false]);
     /// ```
+    #[must_use]
     pub fn lift_a1<F, A, B, FuncImpl>(func: FuncImpl, fa: F::Of<A>) -> F::Of<B>
     where
         F: Applicative<RcFn<A, B>> + Apply<A, B> + Kind1,

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -52,6 +52,7 @@ pub mod kind {
         ///
         /// # Returns
         /// A new Kind-structured value `Self::Of<B>`.
+        #[must_use]
         fn apply(
             value_container: Self::Of<A>,
             function_container: Self::Of<RcFn<A, B>>,
@@ -155,6 +156,7 @@ pub mod kind {
     ///
     /// Given `func: A -> RcFn<B, C>`, `fa: F::Of<A>`, and `fb: F::Of<B>`,
     /// `lift2` produces `F::Of<C>`.
+    #[must_use]
     pub fn lift2<F, A, B, C, FuncImpl>(
         func: FuncImpl, // A -> RcFn<B, C>
         fa: F::Of<A>,
@@ -175,6 +177,7 @@ pub mod kind {
     ///
     /// Given `func: A -> RcFn<B, RcFn<C, D>>`, `fa: F::Of<A>`, `fb: F::Of<B>`,
     /// and `fc: F::Of<C>`, `lift3` produces `F::Of<D>`.
+    #[must_use]
     pub fn lift3<F, A, B, C, D, FuncImpl>(
         func: FuncImpl, // A -> RcFn<B, RcFn<C, D>>
         fa: F::Of<A>,
@@ -196,6 +199,7 @@ pub mod kind {
 
     /// Combines two Kind-encoded actions, keeping only the result of the first.
     /// Often denoted as `<*`.
+    #[must_use]
     pub fn apply_first<F, A, B>(fa: F::Of<A>, fb: F::Of<B>) -> F::Of<A>
     where
         F: Apply<B, A> + Functor<A, RcFn<B, A>> + Kind1,
@@ -208,6 +212,7 @@ pub mod kind {
 
     /// Combines two Kind-encoded actions, keeping only the result of the second.
     /// Often denoted as `*>`.
+    #[must_use]
     pub fn apply_second<F, A, B>(fa: F::Of<A>, fb: F::Of<B>) -> F::Of<B>
     where
         F: Apply<B, B> + Functor<A, RcFn<B, B>> + Kind1,

--- a/src/function.rs
+++ b/src/function.rs
@@ -33,6 +33,7 @@ impl<A, B> CFnOnce<A, B> {
     ///
     /// # Returns
     /// A new `CFnOnce<A, B>` instance.
+    #[must_use]
     pub fn new<F>(f: F) -> Self
     where
         F: FnOnce(A) -> B + 'static,
@@ -143,6 +144,7 @@ impl<A, B> RcFn<A, B> {
     ///
     /// # Returns
     /// A new `RcFn<A, B>` instance whose clone shares the same closure allocation.
+    #[must_use]
     pub fn new<F>(f: F) -> Self
     where
         F: Fn(A) -> B + 'static,

--- a/src/functor.rs
+++ b/src/functor.rs
@@ -60,6 +60,7 @@ pub mod kind {
         /// # Returns
         /// A new Kind-structured value `Self::Of<B>` containing the result(s) of
         /// applying `func`.
+        #[must_use]
         fn map(input: Self::Of<A>, func: impl FnMut(A) -> B + Clone + 'static) -> Self::Of<B>;
     }
 

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -52,6 +52,7 @@ pub mod kind {
     ///
     /// This is the core data type for the `Identity` monad. It doesn't add
     /// any special context other than simply containing the value.
+    #[must_use]
     #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
     pub struct Identity<A>(pub A);
 

--- a/src/kind_based/kind.rs
+++ b/src/kind_based/kind.rs
@@ -70,7 +70,7 @@ impl<E> ResultKind<E> {
     /// Creates a new marker for `Result<_, E>`.
     /// This is primarily for type inference or explicit construction if needed,
     /// though often `Default::default()` or type inference is sufficient.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         ResultKind(std::marker::PhantomData)
     }
 }

--- a/src/monad.rs
+++ b/src/monad.rs
@@ -93,6 +93,7 @@ pub mod kind {
         /// let nested_none: Option<Option<i32>> = Some(None);
         /// assert_eq!(OptionKind::join(nested_none), None);
         /// ```
+        #[must_use]
         fn join(mma: Self::Of<Self::Of<A>>) -> Self::Of<A>; // Changed Applied to Of
     }
 
@@ -135,6 +136,7 @@ pub mod kind {
         /// Takes a value in context (`Self::Of<A>`) and a function (`A -> Self::Of<B>`).
         /// It applies the function to the unwrapped value (if present/valid) and returns
         /// the resulting context `Self::Of<B>`.
+        #[must_use]
         fn bind(
             input: Self::Of<A>,
             func: impl FnMut(A) -> Self::Of<B> + Clone + 'static,
@@ -251,7 +253,7 @@ pub mod kind {
         /// `None` becomes `None`.
         fn join(mma: Self::Of<Self::Of<A>>) -> Self::Of<A> {
             // mma is Option<Option<A>>. Changed Applied to Of
-            mma.and_then(core::convert::identity)
+            mma.flatten()
         }
     }
 
@@ -323,6 +325,7 @@ pub mod kind {
     /// let result: Option<f64> = bind::<OptionKind, _, _, _>(half, opt_val);
     /// assert_eq!(result, None);
     /// ```
+    #[must_use]
     pub fn bind<F, A, B, FuncImpl>(
         func: FuncImpl,
         ma: F::Of<A>, // Changed Applied to Of

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -41,6 +41,7 @@
 pub trait Semigroup {
     /// Combines two values associatively. Consumes both operands so the
     /// implementation can reuse their allocations (e.g. `String`/`Vec`).
+    #[must_use]
     fn combine(self, other: Self) -> Self;
 }
 
@@ -50,6 +51,7 @@ pub trait Semigroup {
 /// `empty().combine(x) == x` and `x.combine(empty()) == x`.
 pub trait Monoid: Semigroup {
     /// The identity element: combining it with any value yields that value.
+    #[must_use]
     fn empty() -> Self;
 }
 

--- a/src/profunctor.rs
+++ b/src/profunctor.rs
@@ -35,6 +35,7 @@ pub trait Profunctor<B, C> {
     ///
     /// # Returns
     /// A new profunctor instance `Self::Pro<A, D>`.
+    #[must_use]
     fn dimap<A, D, A2B, C2D>(self, a2b: A2B, c2d: C2D) -> Self::Pro<A, D>
     where
         A2B: Fn(A) -> B + 'static,
@@ -99,10 +100,12 @@ impl<B, C> Profunctor<B, C> for CFnOnce<B, C> {
 pub trait Strong<A, B>: Profunctor<A, B> {
     /// Adapts the profunctor to operate on the first component of a pair.
     /// If `self` is `P<A,B>`, `first` returns `P<(A,C), (B,C)>`.
+    #[must_use]
     fn first<C: 'static>(self) -> Self::Pro<(A, C), (B, C)>;
 
     /// Adapts the profunctor to operate on the second component of a pair.
     /// If `self` is `P<A,B>`, `second` returns `P<(C,A), (C,B)>`.
+    #[must_use]
     fn second<C: 'static>(self) -> Self::Pro<(C, A), (C, B)>;
 }
 
@@ -133,10 +136,12 @@ impl<A: 'static, B: 'static> Strong<A, B> for RcFn<A, B> {
 pub trait Choice<A, B>: Profunctor<A, B> {
     /// Adapts the profunctor to operate on the `Err` variant of a `Result`.
     /// If `self` is `P<A,B>`, `left` returns `P<Result<C,A>, Result<C,B>>`.
+    #[must_use]
     fn left<C>(self) -> Self::Pro<Result<C, A>, Result<C, B>>;
 
     /// Adapts the profunctor to operate on the `Ok` variant of a `Result`.
     /// If `self` is `P<A,B>`, `right` returns `P<Result<A,C>, Result<B,C>>`.
+    #[must_use]
     fn right<C>(self) -> Self::Pro<Result<A, C>, Result<B, C>>;
 }
 
@@ -180,10 +185,7 @@ pub struct Optic<POuter: Profunctor<S, T>, PInner: Profunctor<A, B>, S, T, A, B>
     /// The function that transforms an inner profunctor to an outer profunctor.
     /// `Box<dyn FnOnce(PInner) -> POuter>`
     pub optic: Box<dyn FnOnce(PInner) -> POuter>,
-    _s: PhantomData<S>,
-    _t: PhantomData<T>,
-    _a: PhantomData<A>,
-    _b: PhantomData<B>,
+    _marker: PhantomData<(S, T, A, B)>,
 }
 
 /// A `Lens` is a type of Optic that focuses on a part `A` of a whole `S`,
@@ -240,6 +242,7 @@ impl<PA: Strong<S, T>, PB: Strong<A, B>, S: 'static, T: 'static, A: 'static, B: 
 ///
 /// # Returns
 /// The extracted part `A`.
+#[must_use]
 pub fn view<S: 'static, T: 'static, A: 'static, B: 'static>(
     getter: AGetter<S, T, A, B>,
     s: S,
@@ -337,6 +340,7 @@ impl<R: 'static, AStrong: 'static, BStrong: 'static> Strong<AStrong, BStrong>
 ///   - Returns a pair:
 ///     - The focused part `A`.
 ///     - A function `RcFn<B, T>` that takes a new part `B` and reconstructs the whole `T`.
+#[must_use]
 pub fn lens_<PO, PI, PBC, S: 'static, T: 'static, A: 'static, B: 'static>(
     to: RcFn<S, (A, RcFn<B, T>)>,
 ) -> Lens<PO, PBC, S, T, A, B>
@@ -355,10 +359,7 @@ where
     };
     Lens(Optic {
         optic: Box::new(optics_fn),
-        _s: PhantomData,
-        _t: PhantomData,
-        _a: PhantomData,
-        _b: PhantomData,
+        _marker: PhantomData,
     })
 }
 
@@ -372,6 +373,7 @@ where
 ///
 /// # Returns
 /// A `Lens<PO, PI, S, T, A, B>`. The profunctor types `PO` and `PI` are usually inferred.
+#[must_use]
 pub fn lens<PO, PI, S: Copy + 'static, T: 'static, A: 'static, B: 'static>(
     s2a: RcFn<S, A>,
     s2b2t: RcFn<S, RcFn<B, T>>,
@@ -396,6 +398,7 @@ where
 /// Allows getting `A` and setting `A` to `B`, resulting in `(B, C)`.
 ///
 /// Type parameters `PA` and `PS` are the profunctor types involved, usually inferred.
+#[must_use]
 pub fn _1<
     A: 'static,
     B: 'static,
@@ -405,10 +408,7 @@ pub fn _1<
 >() -> Lens<PS, PA, (A, C), (B, C), A, B> {
     Lens(Optic {
         optic: Box::new(Strong::first),
-        _s: PhantomData,
-        _t: PhantomData,
-        _a: PhantomData,
-        _b: PhantomData,
+        _marker: PhantomData,
     })
 }
 
@@ -416,6 +416,7 @@ pub fn _1<
 /// Allows getting `A` and setting `A` to `B`, resulting in `(C, B)`.
 ///
 /// Type parameters `PA` and `PS` are the profunctor types involved, usually inferred.
+#[must_use]
 pub fn _2<
     A: 'static,
     B: 'static,
@@ -425,10 +426,7 @@ pub fn _2<
 >() -> Lens<PS, PA, (C, A), (C, B), A, B> {
     Lens(Optic {
         optic: Box::new(Strong::second),
-        _s: PhantomData,
-        _t: PhantomData,
-        _a: PhantomData,
-        _b: PhantomData,
+        _marker: PhantomData,
     })
 }
 
@@ -464,6 +462,7 @@ pub struct Check {
 
 /// A `Lens` that focuses on the `key` field of a `Check` struct.
 /// Allows getting `check.key` and setting it.
+#[must_use]
 pub fn _key<PO, PI>() -> Lens<PO, PI, Check, Check, i8, i8>
 where
     PO: Strong<Check, Check>,
@@ -493,6 +492,7 @@ where
 ///
 /// # Returns
 /// A new profunctor `Profunctor::Pro<A, C>`.
+#[must_use]
 pub fn lcmap<A, B, C, F, Pbc, Pac>(a2b: F, profunctor: Pbc) -> Pac
 where
     A: 'static,
@@ -515,6 +515,7 @@ where
 ///
 /// # Returns
 /// A new profunctor `Profunctor::Pro<A, C>`.
+#[must_use]
 pub fn rmap<A, B, C, F, Pab, Pac>(b2c: F, profunctor: Pab) -> Pac
 where
     A: 'static,

--- a/src/transformers/except.rs
+++ b/src/transformers/except.rs
@@ -105,9 +105,7 @@ pub mod kind {
     pub struct ExceptT<E, MKind: Kind1, A> {
         /// The wrapped inner computation: `MKind::Of<Result<A, E>>` (value-or-error).
         pub run_except_t: MKind::Of<Result<A, E>>,
-        _phantom_e: PhantomData<E>,
-        _phantom_m_kind: PhantomData<MKind>,
-        _phantom_a: PhantomData<A>,
+        _phantom: PhantomData<(E, MKind, A)>,
     }
 
     // Manual `Clone` bounded on the projected inner type (mirrors `WriterT`): a
@@ -120,21 +118,18 @@ pub mod kind {
         fn clone(&self) -> Self {
             ExceptT {
                 run_except_t: self.run_except_t.clone(),
-                _phantom_e: PhantomData,
-                _phantom_m_kind: PhantomData,
-                _phantom_a: PhantomData,
+                _phantom: PhantomData,
             }
         }
     }
 
     impl<E, MKind: Kind1, A> ExceptT<E, MKind, A> {
         /// Creates a new `ExceptT` from an inner value `MKind::Of<Result<A, E>>`.
+        #[must_use]
         pub fn new(inner: MKind::Of<Result<A, E>>) -> Self {
             ExceptT {
                 run_except_t: inner,
-                _phantom_e: PhantomData,
-                _phantom_m_kind: PhantomData,
-                _phantom_a: PhantomData,
+                _phantom: PhantomData,
             }
         }
     }
@@ -326,6 +321,7 @@ pub mod kind {
         /// `Err(e) -> Err(f(e))`, `Ok(a) -> Ok(a)` (inner `Functor`).
         ///
         /// The Rust analog of Haskell's `withExceptT`.
+        #[must_use]
         pub fn with_except_t<E2, F>(self, f: F) -> ExceptT<E2, MKind, A>
         where
             E: 'static,
@@ -345,6 +341,7 @@ pub mod kind {
         /// Lifts a success value onto the `Ok` branch — the ergonomic concrete form of
         /// `MonadError::lift_either(Ok(_))` (and of `Applicative::pure`). The generic
         /// `MonadError` trait remains for code generic over the inner monad.
+        #[must_use]
         pub fn ok(value: A) -> Self
         where
             E: 'static,
@@ -356,6 +353,7 @@ pub mod kind {
         }
 
         /// Short-circuits with an error — the ergonomic concrete form of `MonadError::throw_error`.
+        #[must_use]
         pub fn throw(error: E) -> Self
         where
             E: 'static,
@@ -367,6 +365,7 @@ pub mod kind {
         }
 
         /// Embeds a pure `Result<A, E>` — the ergonomic concrete form of `MonadError::lift_either`.
+        #[must_use]
         pub fn from_result(r: Result<A, E>) -> Self
         where
             E: 'static,
@@ -379,6 +378,7 @@ pub mod kind {
 
         /// Chainable recovery: runs `self`, and on `Err(e)` runs `handler(e)` instead — the
         /// method form of `MonadError::catch_error`.
+        #[must_use]
         pub fn catch<F>(self, handler: F) -> Self
         where
             E: 'static,
@@ -423,6 +423,7 @@ pub mod kind {
         Self: Sized,
     {
         /// Injects an error, short-circuiting: `MKind::pure(Err(e))`. The primitive.
+        #[must_use]
         fn throw_error(e: E) -> ExceptT<E, MKind, A>
         where
             E: 'static,
@@ -432,6 +433,7 @@ pub mod kind {
 
         /// Runs `m`; if it produced `Err(e)`, runs `handler(e)` instead;
         /// otherwise passes the `Ok` value through unchanged.
+        #[must_use]
         fn catch_error<F>(m: ExceptT<E, MKind, A>, handler: F) -> ExceptT<E, MKind, A>
         where
             E: 'static,
@@ -443,6 +445,7 @@ pub mod kind {
             F: Fn(E) -> ExceptT<E, MKind, A> + Clone + 'static;
 
         /// Embeds a pure `Result<A, E>` directly: `MKind::pure(r)`.
+        #[must_use]
         fn lift_either(r: Result<A, E>) -> ExceptT<E, MKind, A>
         where
             E: 'static,

--- a/src/transformers/reader.rs
+++ b/src/transformers/reader.rs
@@ -59,7 +59,7 @@ pub mod kind {
     //! assert_eq!((mapped_val.run_reader_t)(config1.clone()), Some(20));
     //!
     //! // 3. Using 'bind'
-    //! let ask_op_for_bind: ConfigReaderOption<Config> = <ConfigReaderOptionKind as MonadReader<Config, Config, OptionKind>>::ask();
+    //! let ask_op_for_bind: ConfigReaderOption<Config> = ConfigReaderOptionKind::ask();
     //! let computation: ConfigReaderOption<String> = ConfigReaderOptionKind::bind(
     //!     ask_op_for_bind, // Gets Config
     //!     |config: Config| {
@@ -130,23 +130,20 @@ pub mod kind {
         /// The core function that defines the `ReaderT` computation.
         /// It takes an environment `R` and returns the result wrapped in the inner monad `MKind::Of<A>`.
         pub run_reader_t: Rc<dyn Fn(R) -> MKind::Of<A> + 'static>, // Changed MMarker::Applied to MKind::Of
-        _phantom_r: PhantomData<R>,
-        _phantom_m_kind: PhantomData<MKind>, // Changed _phantom_m_marker to _phantom_m_kind
-        _phantom_a: PhantomData<A>,
+        _phantom: PhantomData<(R, MKind, A)>,
     }
 
     impl<R, MKind: Kind1, A> ReaderT<R, MKind, A> {
         // Changed MMarker to MKind, HKT1 to Kind1
         /// Creates a new `ReaderT` from a function `R -> MKind::Of<A>`.
+        #[must_use]
         pub fn new<F>(f: F) -> Self
         where
             F: Fn(R) -> MKind::Of<A> + 'static, // Changed MMarker::Applied to MKind::Of
         {
             ReaderT {
                 run_reader_t: Rc::new(f),
-                _phantom_r: PhantomData,
-                _phantom_m_kind: PhantomData, // Changed _phantom_m_marker to _phantom_m_kind
-                _phantom_a: PhantomData,
+                _phantom: PhantomData,
             }
         }
 
@@ -165,6 +162,7 @@ pub mod kind {
         /// let result = (comp.local(|env: i32| env + 10).run_reader_t)(5);
         /// assert_eq!(result, Identity(30)); // (5+10)*2 = 30
         /// ```
+        #[must_use]
         pub fn local<F>(self, f: F) -> Self
         where
             R: 'static,
@@ -364,6 +362,7 @@ pub mod kind {
         /// let env = MyConfig { id: 123 };
         /// assert_eq!((get_config.run_reader_t)(env.clone()), Some(env));
         /// ```
+        #[must_use]
         fn ask() -> ReaderT<REnv, MKind, REnv>
         where
             REnv: Clone + 'static,
@@ -404,6 +403,7 @@ pub mod kind {
         /// assert_eq!((get_value_str.run_reader_t)(initial_config.clone()), Some("Value: 10".to_string()));
         /// assert_eq!((modified_computation.run_reader_t)(initial_config.clone()), Some("New Value: 20".to_string()));
         /// ```
+        #[must_use]
         fn local<FMapEnv>(
             map_env_fn: FMapEnv,
             computation: ReaderT<REnv, MKind, AVal>,
@@ -465,6 +465,7 @@ pub mod kind {
         /// let get_env: ReaderT<Cfg, OptionKind, Cfg> = CfgReaderKind::ask();
         /// assert_eq!((get_env.run_reader_t)(Cfg { id: 7 }), Some(Cfg { id: 7 }));
         /// ```
+        #[must_use]
         pub fn ask() -> ReaderT<R, MKindImpl, R>
         where
             R: Clone + 'static,

--- a/src/transformers/state.rs
+++ b/src/transformers/state.rs
@@ -44,7 +44,7 @@ pub mod kind {
     //!
     //! ## Example
     //! ```
-    //! use monadify::transformers::state::{State, StateT, StateTKind, MonadState};
+    //! use monadify::transformers::state::{State, StateT, StateTKind};
     //! use monadify::IdentityKind;
     //! use monadify::Identity;
     //! use monadify::applicative::kind::Applicative;
@@ -61,10 +61,10 @@ pub mod kind {
     //!
     //! // `get` then `put`: read the state, store `x + 5`, return the original `x`.
     //! let prog: Counter<i32> = CounterKind::bind(
-    //!     <CounterKind as MonadState<i32, i32, IdentityKind>>::get(),
+    //!     CounterKind::get(),
     //!     |x| {
     //!         CounterKind::bind(
-    //!             <CounterKind as MonadState<i32, (), IdentityKind>>::put(x + 5),
+    //!             CounterKind::put(x + 5),
     //!             move |_| CounterKind::pure(x),
     //!         )
     //!     },
@@ -74,7 +74,7 @@ pub mod kind {
     //!
     //! // Runners: project just the value or just the final state.
     //! let again: Counter<i32> =
-    //!     <CounterKind as MonadState<i32, i32, IdentityKind>>::state(|s| (s * 2, s + 100));
+    //!     CounterKind::state(|s| (s * 2, s + 100));
     //! assert_eq!(again.clone().eval_state_t(3), Identity(6));
     //! assert_eq!(again.exec_state_t(3), Identity(103));
     //! ```
@@ -106,22 +106,19 @@ pub mod kind {
         // The boxed-`Fn` carrier is inherent to the encoding (mirrors ReaderT).
         #[allow(clippy::type_complexity)]
         pub run_state_t: Rc<dyn Fn(S) -> MKind::Of<(A, S)> + 'static>,
-        _phantom_s: PhantomData<S>,
-        _phantom_m_kind: PhantomData<MKind>,
-        _phantom_a: PhantomData<A>,
+        _phantom: PhantomData<(S, MKind, A)>,
     }
 
     impl<S, MKind: Kind1, A> StateT<S, MKind, A> {
         /// Creates a new `StateT` from a function `S -> MKind::Of<(A, S)>`.
+        #[must_use]
         pub fn new<F>(f: F) -> Self
         where
             F: Fn(S) -> MKind::Of<(A, S)> + 'static,
         {
             StateT {
                 run_state_t: Rc::new(f),
-                _phantom_s: PhantomData,
-                _phantom_m_kind: PhantomData,
-                _phantom_a: PhantomData,
+                _phantom: PhantomData,
             }
         }
     }
@@ -312,6 +309,7 @@ pub mod kind {
     impl<S, MKind: Kind1, A> StateT<S, MKind, A> {
         /// Runs the computation and keeps only the produced value, discarding
         /// the final state: `MKind::Of<A>` (inner `Functor`, projecting `fst`).
+        #[must_use]
         pub fn eval_state_t(self, s: S) -> MKind::Of<A>
         where
             S: Clone + 'static,
@@ -324,6 +322,7 @@ pub mod kind {
 
         /// Runs the computation and keeps only the final state, discarding the
         /// value: `MKind::Of<S>` (inner `Functor`, projecting `snd`).
+        #[must_use]
         pub fn exec_state_t(self, s: S) -> MKind::Of<S>
         where
             S: Clone + 'static,
@@ -353,6 +352,7 @@ pub mod kind {
     {
         /// Embeds a pure state transition `S -> (A, S)`. The primitive from which
         /// `get`/`put`/`modify`/`gets` derive.
+        #[must_use]
         fn state<F>(f: F) -> StateT<S, MKind, A>
         where
             S: Clone + 'static,
@@ -362,6 +362,7 @@ pub mod kind {
             F: Fn(S) -> (A, S) + 'static;
 
         /// Reads the whole state as the value, leaving it unchanged: `s -> (s, s)`.
+        #[must_use]
         fn get() -> StateT<S, MKind, S>
         where
             S: Clone + 'static,
@@ -369,6 +370,7 @@ pub mod kind {
             MKind::Of<(S, S)>: 'static;
 
         /// Replaces the state, returning unit: `_ -> ((), new_state)`.
+        #[must_use]
         fn put(new_state: S) -> StateT<S, MKind, ()>
         where
             S: Clone + 'static,
@@ -376,6 +378,7 @@ pub mod kind {
             MKind::Of<((), S)>: 'static;
 
         /// Applies `f` to the state, returning unit: `s -> ((), f(s))`.
+        #[must_use]
         fn modify<F>(f: F) -> StateT<S, MKind, ()>
         where
             S: Clone + 'static,
@@ -385,6 +388,7 @@ pub mod kind {
 
         /// Projects the state through `f` as the value, leaving the state
         /// unchanged: `s -> (f(s), s)`.
+        #[must_use]
         fn gets<F, B>(f: F) -> StateT<S, MKind, B>
         where
             S: Clone + 'static,
@@ -472,6 +476,7 @@ pub mod kind {
         /// `<StateTKind<S, M> as MonadState<S, A, M>>::state(f)`.
         /// The generic [`MonadState`] trait stays for code that is generic
         /// over the transformer.
+        #[must_use]
         pub fn state<F, A>(f: F) -> StateT<S, MKindImpl, A>
         where
             S: Clone + 'static,
@@ -490,6 +495,7 @@ pub mod kind {
         /// `<StateTKind<S, M> as MonadState<S, S, M>>::get()`.
         /// The generic [`MonadState`] trait stays for code that is generic
         /// over the transformer.
+        #[must_use]
         pub fn get() -> StateT<S, MKindImpl, S>
         where
             S: Clone + 'static,
@@ -507,6 +513,7 @@ pub mod kind {
         /// `<StateTKind<S, M> as MonadState<S, (), M>>::put(s)`.
         /// The generic [`MonadState`] trait stays for code that is generic
         /// over the transformer.
+        #[must_use]
         pub fn put(new_state: S) -> StateT<S, MKindImpl, ()>
         where
             S: Clone + 'static,
@@ -524,6 +531,7 @@ pub mod kind {
         /// `<StateTKind<S, M> as MonadState<S, (), M>>::modify(f)`.
         /// The generic [`MonadState`] trait stays for code that is generic
         /// over the transformer.
+        #[must_use]
         pub fn modify<F>(f: F) -> StateT<S, MKindImpl, ()>
         where
             S: Clone + 'static,
@@ -542,6 +550,7 @@ pub mod kind {
         /// `<StateTKind<S, M> as MonadState<S, B, M>>::gets(f)`.
         /// The generic [`MonadState`] trait stays for code that is generic
         /// over the transformer.
+        #[must_use]
         pub fn gets<F, B>(f: F) -> StateT<S, MKindImpl, B>
         where
             S: Clone + 'static,

--- a/src/transformers/trans.rs
+++ b/src/transformers/trans.rs
@@ -59,6 +59,7 @@ use crate::transformers::writer::kind::{WriterT, WriterTKind};
 /// - `MKind`: the Kind marker of the inner monad.
 pub trait MonadTrans<A, MKind: Kind1>: Kind {
     /// Embeds `inner: MKind::Of<A>` into the transformer `Self::Of<A>`.
+    #[must_use]
     fn lift(inner: MKind::Of<A>) -> Self::Of<A>;
 }
 

--- a/src/transformers/writer.rs
+++ b/src/transformers/writer.rs
@@ -78,9 +78,7 @@ pub mod kind {
     pub struct WriterT<W, MKind: Kind1, A> {
         /// The wrapped inner computation: `MKind::Of<(A, W)>` (value-then-log).
         pub run_writer_t: MKind::Of<(A, W)>,
-        _phantom_w: PhantomData<W>,
-        _phantom_m_kind: PhantomData<MKind>,
-        _phantom_a: PhantomData<A>,
+        _phantom: PhantomData<(W, MKind, A)>,
     }
 
     // Manual `Clone` bounded on the projected inner type (mirrors `RcFn`): a
@@ -93,21 +91,18 @@ pub mod kind {
         fn clone(&self) -> Self {
             WriterT {
                 run_writer_t: self.run_writer_t.clone(),
-                _phantom_w: PhantomData,
-                _phantom_m_kind: PhantomData,
-                _phantom_a: PhantomData,
+                _phantom: PhantomData,
             }
         }
     }
 
     impl<W, MKind: Kind1, A> WriterT<W, MKind, A> {
         /// Creates a new `WriterT` from an inner value `MKind::Of<(A, W)>`.
+        #[must_use]
         pub fn new(inner: MKind::Of<(A, W)>) -> Self {
             WriterT {
                 run_writer_t: inner,
-                _phantom_w: PhantomData,
-                _phantom_m_kind: PhantomData,
-                _phantom_a: PhantomData,
+                _phantom: PhantomData,
             }
         }
     }
@@ -148,6 +143,7 @@ pub mod kind {
         /// let Identity(((), log)) = w.run_writer_t;
         /// assert_eq!(log, "hello");
         /// ```
+        #[must_use]
         pub fn tell(w: W) -> WriterT<W, MKindImpl, ()>
         where
             W: 'static,
@@ -174,6 +170,7 @@ pub mod kind {
         /// let Identity((val, log)) = w.run_writer_t;
         /// assert_eq!((val, log), (42, "note".to_string()));
         /// ```
+        #[must_use]
         pub fn writer<A>(value: A, log: W) -> WriterT<W, MKindImpl, A>
         where
             W: 'static,
@@ -354,6 +351,7 @@ pub mod kind {
     impl<W, MKind: Kind1, A> WriterT<W, MKind, A> {
         /// Runs the computation and keeps only the produced value, discarding
         /// the log: `MKind::Of<A>` (inner `Functor`, projecting `fst`).
+        #[must_use]
         pub fn eval_writer_t(self) -> MKind::Of<A>
         where
             W: 'static,
@@ -366,6 +364,7 @@ pub mod kind {
 
         /// Runs the computation and keeps only the accumulated log, discarding
         /// the value: `MKind::Of<W>` (inner `Functor`, projecting `snd`).
+        #[must_use]
         pub fn exec_writer_t(self) -> MKind::Of<W>
         where
             W: 'static,
@@ -393,6 +392,7 @@ pub mod kind {
         /// assert_eq!(exposed, "xyz");
         /// assert_eq!(log, "xyz");
         /// ```
+        #[must_use]
         pub fn listen(self) -> WriterT<W, MKind, (A, W)>
         where
             W: Clone + 'static,
@@ -420,6 +420,7 @@ pub mod kind {
         /// let Identity(((), log)) = w.censor(|s: String| s.to_uppercase()).run_writer_t;
         /// assert_eq!(log, "QUIET");
         /// ```
+        #[must_use]
         pub fn censor<F>(self, f: F) -> Self
         where
             W: 'static,
@@ -452,6 +453,7 @@ pub mod kind {
         Self: Sized,
     {
         /// Appends `w` to the log, producing unit: `((), w)`. The primitive.
+        #[must_use]
         fn tell(w: W) -> WriterT<W, MKind, ()>
         where
             W: 'static,
@@ -459,6 +461,7 @@ pub mod kind {
             MKind::Of<((), W)>: 'static;
 
         /// The general constructor: embeds a `(value, log)` pair directly.
+        #[must_use]
         fn writer(value: A, log: W) -> WriterT<W, MKind, A>
         where
             W: 'static,
@@ -468,6 +471,7 @@ pub mod kind {
 
         /// Exposes the accumulated log alongside the value, leaving it in place:
         /// turns a `WriterT<W, M, A>` into `WriterT<W, M, (A, W)>` with the same log.
+        #[must_use]
         fn listen(m: WriterT<W, MKind, A>) -> WriterT<W, MKind, (A, W)>
         where
             W: Clone + 'static,
@@ -478,6 +482,7 @@ pub mod kind {
 
         /// Rewrites the log with `f`, leaving the value unchanged: `(a, f(w))`.
         /// (The ergonomic specialization of Haskell's `pass`.)
+        #[must_use]
         fn censor<F>(f: F, m: WriterT<W, MKind, A>) -> WriterT<W, MKind, A>
         where
             W: 'static,


### PR DESCRIPTION
## Summary

A codebase-wide **audit-and-fix pass** for idiomatic-Rust improvements that `clippy --all-targets --all-features -D warnings` does **not** already catch. Comprehensive audit (4 parallel auditors across core traits, transformers, function/profunctor, and docs/examples) → implement the safe subset. **All changes are additive / non-behavioral** — no public signature or runtime behavior change.

## What changed

- **`#[must_use]` (68 sites)** on pure value-returning items — the `Functor`/`Apply`/`Applicative`/`Bind`/`Monad`, `MonadReader`/`State`/`Writer`/`Error`/`Trans`, `Profunctor`/`Strong`/`Choice`, and `Semigroup`/`Monoid` trait methods; the free combinators (`lift2`/`lift3`/`apply_first`/`apply_second`/`lift_a1`/`bind`); the optics constructors (`view`/`lcmap`/`rmap`/`lens`/`_1`/`_2`/`_key`); the transformer constructors, runners, and inherent ergonomic forms; `RcFn::new`/`CFnOnce::new`; and the `Identity` newtype. (Deliberately **not** on `call`/`call_once`, which run a user closure.)
- **PhantomData collapse** — the three `_phantom_*` fields in each of `ReaderT`/`StateT`/`WriterT`/`ExceptT` collapse to one `PhantomData<(.., MKind, ..)>`, and `Optic`'s four collapse to one `PhantomData<(S,T,A,B)>`. Variance preserved; constructors + manual `Clone` impls updated.
- **Idiomatic tweaks** — `OptionKind::join` uses `Option::flatten()` instead of `and_then(identity)`; `ResultKind::new` is now `const fn`.
- **Ergonomic tidy** — the 9 `examples/*.rs` and the primary module doctests now use the inherent forms (`SKind::get()`, `m.listen()`, `ReaderKind::ask()`, …) instead of the verbose `<Marker as MonadX<…>>::method()` UFCS.
- **CLAUDE.md** — corrected the stale quality-gates note: `clippy --all-targets` is now clean tree-wide (the historical ~50 test lints are gone).

## Audit findings deferred (reported, not done)

- The ~79 internal `tests/kind/*` UFCS sites (cosmetic; the intentional UFCS-vs-inherent **parity tests** must keep the trait-form side).
- An inherent ergonomic form for `MonadTrans::lift` (still only callable via UFCS — a consistency gap).
- The ~11 `cargo doc` intra-doc link warnings (mostly unresolved `Semigroup`/`Monoid` links + redundant explicit targets) — the one remaining non-enforced gate.
- `profunctor.rs` exposes some `pub` fields / demo items (encapsulation nit, left intentional).

## Test plan / quality gates (all green)

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test` (default) + `--features do-notation` + `--all-features`
- [x] `cargo test --all-features --doc`
- [x] all 15 `cargo run --example … --features do-notation` exit 0
- [x] MSRV 1.66 fresh-lock; zero-dependency guard

`rust-reviewer`: **APPROVE**, no blocking issues (variance-neutral PhantomData collapse, correct `#[must_use]` placement, no behavior change).