### PR TITLE
chore: finish deferred ergonomics/idiomatic follow-ups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,11 +96,11 @@ and `cargo test --all-features`. CI (`.github/workflows/rust.yml`) mirrors these
 separate jobs — `fmt`, `clippy` (`--all-features -- -D warnings`), `test` (default +
 `legacy` feature matrix, incl. doc-tests), and an `msrv` job checking against Rust
 1.66. The `clippy` job also lints `--benches` so `benches/compare.rs` can't
-silently rot. `clippy --all-targets --all-features -- -D warnings` is now **clean**
-across the whole tree (the historical ~50 auto-fixable test lints have been
-removed) though CI still runs `clippy` without `--all-targets`. The one remaining
-gap is `cargo doc -D warnings` (~11 rustdoc link warnings, mostly unresolved
-`Semigroup`/`Monoid` intra-doc links + redundant explicit link targets).
+silently rot. Both `clippy --all-targets --all-features -- -D warnings` and
+`cargo doc --no-deps --all-features` are now **clean** across the whole tree (the
+historical ~50 auto-fixable test lints and the ~11 rustdoc link warnings have all
+been fixed), though CI still runs `clippy` without `--all-targets` and does not yet
+run a `cargo doc` gate — wiring those into CI is the remaining hardening step.
 
 ```bash
 cargo test                  # default kind-based suite

--- a/src/monoid.rs
+++ b/src/monoid.rs
@@ -1,9 +1,9 @@
 //! # Semigroup and Monoid
 //!
-//! Algebraic structures for *combinable* values. A [`Semigroup`] has an
-//! associative binary operation [`combine`](Semigroup::combine) (Haskell's
-//! `<>` / `mappend`); a [`Monoid`] additionally has an identity element
-//! [`empty`](Monoid::empty) (Haskell's `mempty`).
+//! Algebraic structures for *combinable* values. A [`Semigroup`](crate::monoid::Semigroup) has an
+//! associative binary operation [`combine`](crate::monoid::Semigroup::combine) (Haskell's
+//! `<>` / `mappend`); a [`Monoid`](crate::monoid::Monoid) additionally has an identity element
+//! [`empty`](crate::monoid::Monoid::empty) (Haskell's `mempty`).
 //!
 //! These power the [`WriterT`](crate::transformers::writer) transformer, whose
 //! log type must accumulate monoidally: `tell` appends with `combine`, and

--- a/src/transformers/trans.rs
+++ b/src/transformers/trans.rs
@@ -6,10 +6,10 @@
 //! transformed monad `T m a` while adding *no* effect of its own.
 //!
 //! This crate implements `MonadTrans` for all four transformers:
-//! [`ReaderTKind`](crate::transformers::reader::ReaderTKind),
-//! [`StateTKind`](crate::transformers::state::StateTKind),
-//! [`WriterTKind`](crate::transformers::writer::WriterTKind), and
-//! [`ExceptTKind`](crate::transformers::except::ExceptTKind).
+//! [`ReaderTKind`],
+//! [`StateTKind`],
+//! [`WriterTKind`], and
+//! [`ExceptTKind`].
 //!
 //! ## Law
 //!
@@ -24,13 +24,12 @@
 //!
 //! ## Example
 //! ```
-//! use monadify::transformers::trans::MonadTrans;
 //! use monadify::transformers::writer::{Writer, WriterTKind};
 //! use monadify::{Applicative, Identity, IdentityKind};
 //!
 //! // Lift a pure inner `Identity(7)` into a `Writer<String, _>` — empty log.
 //! type W<A> = Writer<String, A>;
-//! let lifted: W<i32> = <WriterTKind<String, IdentityKind> as MonadTrans<i32, IdentityKind>>::lift(
+//! let lifted: W<i32> = WriterTKind::<String, IdentityKind>::lift(
 //!     IdentityKind::pure(7),
 //! );
 //! let Identity((v, log)) = lifted.run_writer_t;
@@ -49,7 +48,7 @@ use crate::transformers::writer::kind::{WriterT, WriterTKind};
 /// Lifts an inner monadic computation into a monad transformer.
 ///
 /// `Self` is the transformer's Kind marker (e.g.
-/// [`WriterTKind`](crate::transformers::writer::WriterTKind)); `MKind` is the
+/// [`WriterTKind`]); `MKind` is the
 /// inner monad's marker. [`lift`](Self::lift) maps `MKind::Of<A>` to
 /// `Self::Of<A>`, adding none of the transformer's own effect (an empty log,
 /// an unchanged state, an ignored environment).
@@ -126,5 +125,95 @@ where
         let wrapped: MKind::Of<Result<A, E>> =
             <MKind as functor_kind::Functor<A, Result<A, E>>>::map(inner, Ok);
         ExceptT::new(wrapped)
+    }
+}
+
+// ── Inherent ergonomic `lift` helpers ──────────────────────────────────────
+//
+// These delegate to the `MonadTrans` trait and expose the concrete shorthand
+// `RKind::lift(inner)` instead of the verbose UFCS form.  The trait impls
+// remain the canonical implementation and are still the right choice for
+// code that is generic over the transformer marker.
+
+impl<R, MKind: Kind1> ReaderTKind<R, MKind> {
+    /// Ergonomic inherent form of [`MonadTrans::lift`] for [`ReaderT`].
+    ///
+    /// Embeds an inner computation `MKind::Of<A>` into a `ReaderT<R, MKind, A>`,
+    /// ignoring the environment and adding no effect of its own. This is the
+    /// concrete shorthand for
+    /// `<ReaderTKind<R, MKind> as MonadTrans<A, MKind>>::lift(inner)`;
+    /// the trait form remains available for generic code.
+    #[must_use]
+    pub fn lift<A>(inner: MKind::Of<A>) -> ReaderT<R, MKind, A>
+    where
+        R: 'static,
+        A: 'static,
+        MKind: 'static,
+        MKind::Of<A>: Clone + 'static,
+    {
+        <Self as MonadTrans<A, MKind>>::lift(inner)
+    }
+}
+
+impl<S, MKind: Kind1> StateTKind<S, MKind> {
+    /// Ergonomic inherent form of [`MonadTrans::lift`] for [`StateT`].
+    ///
+    /// Embeds an inner computation `MKind::Of<A>` into a `StateT<S, MKind, A>`,
+    /// threading the state through unchanged and adding no effect of its own.
+    /// This is the concrete shorthand for
+    /// `<StateTKind<S, MKind> as MonadTrans<A, MKind>>::lift(inner)`;
+    /// the trait form remains available for generic code.
+    #[must_use]
+    pub fn lift<A>(inner: MKind::Of<A>) -> StateT<S, MKind, A>
+    where
+        S: Clone + 'static,
+        A: 'static,
+        MKind: functor_kind::Functor<A, (A, S)> + 'static,
+        MKind::Of<A>: Clone + 'static,
+        MKind::Of<(A, S)>: 'static,
+    {
+        <Self as MonadTrans<A, MKind>>::lift(inner)
+    }
+}
+
+impl<W, MKind: Kind1> WriterTKind<W, MKind> {
+    /// Ergonomic inherent form of [`MonadTrans::lift`] for [`WriterT`].
+    ///
+    /// Embeds an inner computation `MKind::Of<A>` into a `WriterT<W, MKind, A>`,
+    /// pairing the value with an empty log and adding no effect of its own. This
+    /// is the concrete shorthand for
+    /// `<WriterTKind<W, MKind> as MonadTrans<A, MKind>>::lift(inner)`;
+    /// the trait form remains available for generic code.
+    #[must_use]
+    pub fn lift<A>(inner: MKind::Of<A>) -> WriterT<W, MKind, A>
+    where
+        W: Monoid + 'static,
+        A: 'static,
+        MKind: functor_kind::Functor<A, (A, W)> + 'static,
+        MKind::Of<A>: 'static,
+        MKind::Of<(A, W)>: 'static,
+    {
+        <Self as MonadTrans<A, MKind>>::lift(inner)
+    }
+}
+
+impl<E, MKind: Kind1> ExceptTKind<E, MKind> {
+    /// Ergonomic inherent form of [`MonadTrans::lift`] for [`ExceptT`].
+    ///
+    /// Embeds an inner computation `MKind::Of<A>` into an `ExceptT<E, MKind, A>`,
+    /// wrapping the value on the success (`Ok`) branch and adding no effect of
+    /// its own. This is the concrete shorthand for
+    /// `<ExceptTKind<E, MKind> as MonadTrans<A, MKind>>::lift(inner)`;
+    /// the trait form remains available for generic code.
+    #[must_use]
+    pub fn lift<A>(inner: MKind::Of<A>) -> ExceptT<E, MKind, A>
+    where
+        E: 'static,
+        A: 'static,
+        MKind: functor_kind::Functor<A, Result<A, E>> + 'static,
+        MKind::Of<A>: 'static,
+        MKind::Of<Result<A, E>>: 'static,
+    {
+        <Self as MonadTrans<A, MKind>>::lift(inner)
     }
 }

--- a/src/transformers/writer.rs
+++ b/src/transformers/writer.rs
@@ -15,7 +15,7 @@ pub mod kind {
     //! needs only an inner [`Apply`](apply_kind::Apply), because two independent
     //! computations' logs are simply *combined* — there is no sequential data
     //! dependency like `StateT`'s threaded state. The new ingredient is that the
-    //! log type `W` must be a [`Monoid`](crate::monoid::Monoid): [`pure`](applicative_kind::Applicative::pure)
+    //! log type `W` must be a [`Monoid`]: [`pure`](applicative_kind::Applicative::pure)
     //! seeds the log with [`Monoid::empty`], and every sequencing step
     //! [`combine`](crate::monoid::Semigroup::combine)s the two logs.
     //!
@@ -71,7 +71,7 @@ pub mod kind {
     /// is stored in [`run_writer_t`](Self::run_writer_t).
     ///
     /// # Type Parameters
-    /// - `W`: the log type (must be a [`Monoid`](crate::monoid::Monoid) for the
+    /// - `W`: the log type (must be a [`Monoid`] for the
     ///   `Applicative`/`Monad` instances).
     /// - `MKind`: the Kind marker for the inner monad (must implement [`Kind1`]).
     /// - `A`: the value produced alongside the log.

--- a/tests/kind/do_notation/except.rs
+++ b/tests/kind/do_notation/except.rs
@@ -24,17 +24,17 @@ use monadify::applicative::kind::Applicative;
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
 use monadify::monad::kind::Bind;
-use monadify::transformers::except::{Except, ExceptTKind, MonadError};
+use monadify::transformers::except::{Except, ExceptT, ExceptTKind};
 use proptest::prelude::*;
 
 type EKind = ExceptTKind<String, IdentityKind>;
 type Checked<A> = Except<String, A>;
 
 fn ok(n: i32) -> Checked<i32> {
-    <EKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(n))
+    ExceptT::ok(n)
 }
 fn boom(msg: &str) -> Checked<i32> {
-    <EKind as MonadError<String, i32, IdentityKind>>::throw_error(msg.to_string())
+    ExceptT::throw(msg.to_string())
 }
 fn run_id<A>(m: Checked<A>) -> Result<A, String> {
     let Identity(r) = m.run_except_t;

--- a/tests/kind/do_notation/reader.rs
+++ b/tests/kind/do_notation/reader.rs
@@ -47,7 +47,7 @@ use monadify::applicative::kind::Applicative;
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
 use monadify::monad::kind::Bind;
-use monadify::transformers::reader::{MonadReader, Reader, ReaderT, ReaderTKind};
+use monadify::transformers::reader::{Reader, ReaderT, ReaderTKind};
 use proptest::prelude::*;
 
 /// A minimal read-only configuration environment used throughout these tests.
@@ -66,7 +66,7 @@ type ConfigReader<A> = Reader<Config, A>;
 
 /// Helper: call `ask()` pinned to `Config` / `IdentityKind` so tests are less verbose.
 fn ask_env() -> ConfigReader<Config> {
-    <ReaderKind as MonadReader<Config, Config, IdentityKind>>::ask()
+    ReaderKind::ask()
 }
 
 /// Helper: run a `ConfigReader<i32>` against a `Config` and unwrap the `Identity`.
@@ -416,14 +416,10 @@ fn reader_mdo_local_doubles_factor_for_inner_computation() {
     let read_factor: ConfigReader<i32> = ReaderT::new(|cfg: Config| Identity(cfg.factor));
 
     // Wrap it so its env has `factor` doubled.
-    let doubled_factor: ConfigReader<i32> =
-        <ReaderKind as MonadReader<Config, i32, IdentityKind>>::local(
-            |mut cfg: Config| {
-                cfg.factor *= 2;
-                cfg
-            },
-            read_factor,
-        );
+    let doubled_factor: ConfigReader<i32> = read_factor.local(|mut cfg: Config| {
+        cfg.factor *= 2;
+        cfg
+    });
 
     // In the do-block:
     //   `original` reads from the REAL env (factor = 5)
@@ -451,13 +447,10 @@ fn reader_mdo_local_doubles_factor_for_inner_computation() {
 fn reader_mdo_local_only_affects_its_inner_computation() {
     // local inflates `base` × 100 for its wrapped computation
     let inflated_base: ConfigReader<i32> =
-        <ReaderKind as MonadReader<Config, i32, IdentityKind>>::local(
-            |mut cfg: Config| {
-                cfg.base *= 100;
-                cfg
-            },
-            ReaderT::new(|cfg: Config| Identity(cfg.base)),
-        );
+        ReaderT::new(|cfg: Config| Identity(cfg.base)).local(|mut cfg: Config| {
+            cfg.base *= 100;
+            cfg
+        });
 
     // Read `base` and `factor` together in one step so `inflated_base` (non-Copy)
     // is only referenced at depth 1 in the mdo expansion.  The bound tuple
@@ -481,13 +474,10 @@ fn reader_mdo_local_only_affects_its_inner_computation() {
 #[test]
 fn reader_mdo_local_negated_base_combined_with_original() {
     let negated_base: ConfigReader<i32> =
-        <ReaderKind as MonadReader<Config, i32, IdentityKind>>::local(
-            |mut cfg: Config| {
-                cfg.base = -cfg.base;
-                cfg
-            },
-            ReaderT::new(|cfg: Config| Identity(cfg.base)),
-        );
+        ReaderT::new(|cfg: Config| Identity(cfg.base)).local(|mut cfg: Config| {
+            cfg.base = -cfg.base;
+            cfg
+        });
 
     let computation: ConfigReader<i32> = mdo! {
         ReaderKind;

--- a/tests/kind/do_notation/state.rs
+++ b/tests/kind/do_notation/state.rs
@@ -27,17 +27,17 @@ use monadify::applicative::kind::Applicative;
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
 use monadify::monad::kind::Bind;
-use monadify::transformers::state::{MonadState, State, StateTKind};
+use monadify::transformers::state::{State, StateTKind};
 use proptest::prelude::*;
 
 type StKind = StateTKind<i32, IdentityKind>;
 type Counter<A> = State<i32, A>;
 
 fn get() -> Counter<i32> {
-    <StKind as MonadState<i32, i32, IdentityKind>>::get()
+    StKind::get()
 }
 fn put(s: i32) -> Counter<()> {
-    <StKind as MonadState<i32, (), IdentityKind>>::put(s)
+    StKind::put(s)
 }
 fn run_id<A>(st: Counter<A>, s0: i32) -> (A, i32) {
     let Identity(pair) = (st.run_state_t)(s0);
@@ -63,7 +63,7 @@ fn state_mdo_threads_and_updates() {
 fn state_mdo_uses_modify() {
     let comp: Counter<i32> = mdo! {
         StKind;
-        _ <- <StKind as MonadState<i32, (), IdentityKind>>::modify(|s| s * 2);
+        _ <- StKind::modify(|s| s * 2);
         x <- get();
         StKind::pure(x + 1)
     };
@@ -121,13 +121,13 @@ proptest! {
         let via_mdo: Counter<i32> = mdo! {
             StKind;
             x <- get();
-            _ <- <StKind as MonadState<i32, (), IdentityKind>>::modify(move |s| s.wrapping_add(d));
+            _ <- StKind::modify(move |s| s.wrapping_add(d));
             y <- get();
             StKind::pure(x.wrapping_add(y))
         };
         let via_bind: Counter<i32> = StKind::bind(get(), move |x| {
             StKind::bind(
-                <StKind as MonadState<i32, (), IdentityKind>>::modify(move |s| s.wrapping_add(d)),
+                StKind::modify(move |s| s.wrapping_add(d)),
                 move |_| StKind::bind(get(), move |y| StKind::pure(x.wrapping_add(y))),
             )
         });

--- a/tests/kind/do_notation/writer.rs
+++ b/tests/kind/do_notation/writer.rs
@@ -26,14 +26,14 @@ use monadify::applicative::kind::Applicative;
 use monadify::identity::{Identity, IdentityKind};
 use monadify::mdo;
 use monadify::monad::kind::Bind;
-use monadify::transformers::writer::{MonadWriter, Writer, WriterTKind};
+use monadify::transformers::writer::{Writer, WriterTKind};
 use proptest::prelude::*;
 
 type WKind = WriterTKind<Vec<i32>, IdentityKind>;
 type Logged<A> = Writer<Vec<i32>, A>;
 
 fn tell(n: i32) -> Logged<()> {
-    <WKind as MonadWriter<Vec<i32>, (), IdentityKind>>::tell(vec![n])
+    WKind::tell(vec![n])
 }
 fn run_id<A>(w: Logged<A>) -> (A, Vec<i32>) {
     let Identity(pair) = w.run_writer_t;
@@ -59,7 +59,7 @@ fn writer_mdo_interleaves_values_and_log() {
     let comp: Logged<i32> = mdo! {
         WKind;
         _ <- tell(10);
-        x <- <WKind as MonadWriter<Vec<i32>, i32, IdentityKind>>::writer(5, vec![20]);
+        x <- WKind::writer(5, vec![20]);
         _ <- tell(30);
         WKind::pure(x + 1)
     };

--- a/tests/kind/proptest_laws/except.rs
+++ b/tests/kind/proptest_laws/except.rs
@@ -19,7 +19,7 @@ use monadify::function::RcFn;
 use monadify::identity::{Identity, IdentityKind};
 use monadify::kind_based::kind::VecKind;
 use monadify::monad::kind::Bind;
-use monadify::transformers::except::{Except, ExceptT, ExceptTKind, MonadError};
+use monadify::transformers::except::{Except, ExceptT, ExceptTKind};
 use proptest::prelude::*;
 
 type E<A> = Except<String, A>;
@@ -35,10 +35,10 @@ fn run<A>(m: E<A>) -> Result<A, String> {
 fn arrow(slope: i32, intercept: i32, err: String) -> impl Fn(i32) -> E<i32> + Clone {
     move |x: i32| {
         if x == 0 {
-            <EKind as MonadError<String, i32, IdentityKind>>::throw_error(err.clone())
+            ExceptT::throw(err.clone())
         } else {
             let mut lf = linear_fn(slope, intercept);
-            <EKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(lf(x)))
+            ExceptT::ok(lf(x))
         }
     }
 }
@@ -90,21 +90,18 @@ proptest! {
     fn except_throw_left_zero(err in "[a-z]{1,8}", (sl, ic) in (any::<i32>(), any::<i32>())) {
         let k = arrow(sl, ic, "unused".to_string());
         let lhs = EKind::bind(
-            <EKind as MonadError<String, i32, IdentityKind>>::throw_error(err.clone()),
+            ExceptT::throw(err.clone()),
             k,
         );
-        let rhs = <EKind as MonadError<String, i32, IdentityKind>>::throw_error(err);
+        let rhs: E<i32> = ExceptT::throw(err);
         prop_assert_eq!(run(lhs), run(rhs));
     }
 
     /// catch-throw: `catch(throw(e), h) == h(e)`.
     #[test]
     fn except_catch_throw(err in "[a-z]{1,8}", n in any::<i32>()) {
-        let h = move |_e: String| <EKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(n));
-        let lhs = <EKind as MonadError<String, i32, IdentityKind>>::catch_error(
-            <EKind as MonadError<String, i32, IdentityKind>>::throw_error(err.clone()),
-            h,
-        );
+        let h = move |_e: String| ExceptT::ok(n);
+        let lhs = ExceptT::<String, IdentityKind, i32>::throw(err.clone()).catch(h);
         let rhs = h(err);
         prop_assert_eq!(run(lhs), run(rhs));
     }
@@ -112,8 +109,8 @@ proptest! {
     /// catch-pure: `catch(pure(a), h) == pure(a)` (handler never runs).
     #[test]
     fn except_catch_pure(a in any::<i32>()) {
-        let h = |_e: String| <EKind as MonadError<String, i32, IdentityKind>>::throw_error("ignored".to_string());
-        let lhs = <EKind as MonadError<String, i32, IdentityKind>>::catch_error(EKind::pure(a), h);
+        let h = |_e: String| ExceptT::<String, IdentityKind, i32>::throw("ignored".to_string());
+        let lhs = EKind::pure(a).catch(h);
         prop_assert_eq!(run(lhs), Ok(a));
     }
 }

--- a/tests/kind/proptest_laws/state.rs
+++ b/tests/kind/proptest_laws/state.rs
@@ -16,7 +16,7 @@ use monadify::applicative::kind::Applicative;
 use monadify::functor::kind::Functor;
 use monadify::identity::{Identity, IdentityKind};
 use monadify::monad::kind::Bind;
-use monadify::transformers::state::{MonadState, State, StateTKind};
+use monadify::transformers::state::{State, StateTKind};
 use proptest::prelude::*;
 
 type S<A> = State<i32, A>;
@@ -31,17 +31,17 @@ fn run_unit(st: S<()>, s0: i32) -> ((), i32) {
     pair
 }
 fn get() -> S<i32> {
-    <SKind as MonadState<i32, i32, IdentityKind>>::get()
+    SKind::get()
 }
 fn put(s: i32) -> S<()> {
-    <SKind as MonadState<i32, (), IdentityKind>>::put(s)
+    SKind::put(s)
 }
 /// A threaded Kleisli arrow: maps the value by a linear fn and bumps the state.
 fn arrow(slope: i32, intercept: i32, ds: i32) -> impl Fn(i32) -> S<i32> + Clone {
     move |x: i32| {
         let mut lf = linear_fn(slope, intercept);
         let v = lf(x);
-        <SKind as MonadState<i32, i32, IdentityKind>>::state(move |s: i32| (v, s.wrapping_add(ds)))
+        SKind::state(move |s: i32| (v, s.wrapping_add(ds)))
     }
 }
 
@@ -64,10 +64,10 @@ proptest! {
     #[test]
     fn state_monad_right_identity(s0 in any::<i32>(), ds in any::<i32>()) {
         let lhs = SKind::bind(
-            <SKind as MonadState<i32, i32, IdentityKind>>::state(move |s: i32| (s, s.wrapping_add(ds))),
+            SKind::state(move |s: i32| (s, s.wrapping_add(ds))),
             SKind::pure,
         );
-        let rhs = <SKind as MonadState<i32, i32, IdentityKind>>::state(move |s: i32| (s, s.wrapping_add(ds)));
+        let rhs = SKind::state(move |s: i32| (s, s.wrapping_add(ds)));
         prop_assert_eq!(run(lhs, s0), run(rhs, s0));
     }
 
@@ -78,7 +78,7 @@ proptest! {
                                  (sl2, ic2, ds2) in (any::<i32>(), any::<i32>(), any::<i32>())) {
         let f = arrow(sl1, ic1, ds1);
         let g = arrow(sl2, ic2, ds2);
-        let m = || <SKind as MonadState<i32, i32, IdentityKind>>::state(move |s: i32| (s, s.wrapping_add(1)));
+        let m = || SKind::state(move |s: i32| (s, s.wrapping_add(1)));
 
         let lhs = SKind::bind(SKind::bind(m(), f.clone()), g.clone());
         let rhs = SKind::bind(m(), move |x| SKind::bind(f(x), g.clone()));
@@ -120,7 +120,7 @@ proptest! {
     /// `gets(f) == get.map(f)` and `modify(f) == get >>= (put . f)`.
     #[test]
     fn state_gets_and_modify_derivations(s0 in any::<i32>(), (sl, ic) in (any::<i32>(), any::<i32>())) {
-        let gets = <SKind as MonadState<i32, i32, IdentityKind>>::gets(move |s| {
+        let gets = SKind::gets(move |s| {
             let mut lf = linear_fn(sl, ic);
             lf(s)
         });
@@ -130,7 +130,7 @@ proptest! {
         });
         prop_assert_eq!(run(gets, s0), run(derived_gets, s0));
 
-        let modify = <SKind as MonadState<i32, (), IdentityKind>>::modify(move |s| {
+        let modify = SKind::modify(move |s| {
             let mut lf = linear_fn(sl, ic);
             lf(s)
         });

--- a/tests/kind/proptest_laws/writer.rs
+++ b/tests/kind/proptest_laws/writer.rs
@@ -15,7 +15,7 @@ use monadify::applicative::kind::Applicative;
 use monadify::identity::{Identity, IdentityKind};
 use monadify::monad::kind::Bind;
 use monadify::monoid::{Monoid, Semigroup};
-use monadify::transformers::writer::{MonadWriter, Writer, WriterTKind};
+use monadify::transformers::writer::{Writer, WriterTKind};
 use proptest::prelude::*;
 
 type W<A> = Writer<Vec<i32>, A>;
@@ -31,7 +31,7 @@ fn arrow(slope: i32, intercept: i32, log: Vec<i32>) -> impl Fn(i32) -> W<i32> + 
     move |x: i32| {
         let mut lf = linear_fn(slope, intercept);
         let v = lf(x);
-        <WKind as MonadWriter<Vec<i32>, i32, IdentityKind>>::writer(v, log.clone())
+        WKind::writer(v, log.clone())
     }
 }
 
@@ -57,7 +57,7 @@ proptest! {
     /// Right identity: `bind(m, pure) == m`.
     #[test]
     fn writer_monad_right_identity(v in any::<i32>(), log in arb_log()) {
-        let m = || <WKind as MonadWriter<Vec<i32>, i32, IdentityKind>>::writer(v, log.clone());
+        let m = || WKind::writer(v, log.clone());
         let lhs = WKind::bind(m(), WKind::pure);
         prop_assert_eq!(run(lhs), run(m()));
     }
@@ -69,7 +69,7 @@ proptest! {
                                   (sl2, ic2) in (any::<i32>(), any::<i32>()), log2 in arb_log()) {
         let f = arrow(sl1, ic1, log1);
         let g = arrow(sl2, ic2, log2);
-        let m = || <WKind as MonadWriter<Vec<i32>, i32, IdentityKind>>::writer(v, m_log.clone());
+        let m = || WKind::writer(v, m_log.clone());
 
         let lhs = WKind::bind(WKind::bind(m(), f.clone()), g.clone());
         let rhs = WKind::bind(m(), move |x| WKind::bind(f(x), g.clone()));
@@ -81,7 +81,7 @@ proptest! {
     /// `tell(w1) >> tell(w2) == tell(w1 <> w2)`.
     #[test]
     fn writer_tell_appends_monoidally(w1 in arb_log(), w2 in arb_log()) {
-        let tell = |w: Vec<i32>| <WKind as MonadWriter<Vec<i32>, (), IdentityKind>>::tell(w);
+        let tell = |w: Vec<i32>| WKind::tell(w);
         let lhs = WKind::bind(tell(w1.clone()), {
             let w2 = w2.clone();
             move |_| tell(w2.clone())
@@ -93,7 +93,7 @@ proptest! {
     /// `tell(empty) == pure(())`.
     #[test]
     fn writer_tell_empty_is_pure_unit(_ignored in any::<bool>()) {
-        let lhs = <WKind as MonadWriter<Vec<i32>, (), IdentityKind>>::tell(Vec::empty());
+        let lhs = WKind::tell(Vec::empty());
         let rhs: W<()> = WKind::pure(());
         prop_assert_eq!(run(lhs), run(rhs));
     }
@@ -101,11 +101,8 @@ proptest! {
     /// `censor` then run == apply the rewrite to the final log.
     #[test]
     fn writer_censor_rewrites_log(w in arb_log()) {
-        let tell = <WKind as MonadWriter<Vec<i32>, (), IdentityKind>>::tell(w.clone());
-        let censored = <WKind as MonadWriter<Vec<i32>, (), IdentityKind>>::censor(
-            |mut log: Vec<i32>| { log.reverse(); log },
-            tell,
-        );
+        let tell = WKind::tell(w.clone());
+        let censored = tell.censor(|mut log: Vec<i32>| { log.reverse(); log });
         let mut expected = w;
         expected.reverse();
         prop_assert_eq!(run(censored).1, expected);

--- a/tests/kind/transformers/except.rs
+++ b/tests/kind/transformers/except.rs
@@ -32,11 +32,11 @@ fn run_id<A>(m: E<A>) -> Result<A, String> {
 }
 
 fn throw(msg: &str) -> E<i32> {
-    <EKind as MonadError<String, i32, IdentityKind>>::throw_error(msg.to_string())
+    ExceptT::throw(msg.to_string())
 }
 
 fn ok(n: i32) -> E<i32> {
-    <EKind as MonadError<String, i32, IdentityKind>>::lift_either(Ok(n))
+    ExceptT::ok(n)
 }
 
 // ── Functor / Applicative / Apply / Bind / Monad smoke tests ────────────────
@@ -167,7 +167,7 @@ fn throw_left_zero() {
 fn catch_throw_runs_handler() {
     // catch(throw(e), h) == h(e)
     let h = |e: String| ok(e.len() as i32);
-    let lhs = <EKind as MonadError<String, i32, IdentityKind>>::catch_error(throw("err"), h);
+    let lhs = throw("err").catch(h);
     let rhs = h("err".to_string());
     assert_eq!(run_id(lhs.clone()), run_id(rhs));
     assert_eq!(run_id(lhs), Ok(3)); // "err".len() == 3
@@ -177,15 +177,14 @@ fn catch_throw_runs_handler() {
 fn catch_pure_ignores_handler() {
     // catch(pure(a), h) == pure(a)  — the handler never runs on success.
     let h = |_e: String| ok(-1);
-    let lhs = <EKind as MonadError<String, i32, IdentityKind>>::catch_error(ok(7), h);
+    let lhs = ok(7).catch(h);
     assert_eq!(run_id(lhs), Ok(7));
 }
 
 #[test]
 fn lift_either_embeds_result() {
     assert_eq!(run_id(ok(5)), Ok(5));
-    let err: E<i32> =
-        <EKind as MonadError<String, i32, IdentityKind>>::lift_either(Err("x".into()));
+    let err: E<i32> = ExceptT::from_result(Err("x".into()));
     assert_eq!(run_id(err), Err("x".to_string()));
 }
 
@@ -308,19 +307,14 @@ type OptEKind = ExceptTKind<String, OptionKind>;
 #[test]
 fn option_inner_threads_ok() {
     let m: OptE<i32> = OptEKind::pure(3);
-    let bound = OptEKind::bind(m, |x| {
-        <OptEKind as MonadError<String, i32, OptionKind>>::lift_either(Ok(x + 1))
-    });
+    let bound = OptEKind::bind(m, |x| ExceptT::ok(x + 1));
     assert_eq!(bound.run_except_t, Some(Ok(4)));
 }
 
 #[test]
 fn option_inner_carries_err() {
-    let thrown: OptE<i32> =
-        <OptEKind as MonadError<String, i32, OptionKind>>::throw_error("e".to_string());
-    let bound = OptEKind::bind(thrown, |x| {
-        <OptEKind as MonadError<String, i32, OptionKind>>::lift_either(Ok(x))
-    });
+    let thrown: OptE<i32> = ExceptT::throw("e".to_string());
+    let bound = OptEKind::bind(thrown, |x| ExceptT::ok(x));
     // The ExceptT-level error is carried in the inner Some.
     assert_eq!(bound.run_except_t, Some(Err("e".to_string())));
 }
@@ -329,18 +323,13 @@ fn option_inner_carries_err() {
 fn option_inner_none_short_circuits() {
     // A failure in the inner Option discards everything (distinct from an Err).
     let failing: OptE<i32> = ExceptT::new(None);
-    let bound = OptEKind::bind(failing, |x| {
-        <OptEKind as MonadError<String, i32, OptionKind>>::lift_either(Ok(x))
-    });
+    let bound = OptEKind::bind(failing, |x| ExceptT::ok(x));
     assert_eq!(bound.run_except_t, None);
 }
 
 #[test]
 fn option_inner_catch_recovers() {
-    let thrown: OptE<i32> =
-        <OptEKind as MonadError<String, i32, OptionKind>>::throw_error("e".to_string());
-    let recovered = <OptEKind as MonadError<String, i32, OptionKind>>::catch_error(thrown, |_e| {
-        <OptEKind as MonadError<String, i32, OptionKind>>::lift_either(Ok(0))
-    });
+    let thrown: OptE<i32> = ExceptT::throw("e".to_string());
+    let recovered = thrown.catch(|_e| ExceptT::ok(0));
     assert_eq!(recovered.run_except_t, Some(Ok(0)));
 }

--- a/tests/kind/transformers/reader.rs
+++ b/tests/kind/transformers/reader.rs
@@ -48,7 +48,7 @@ fn test_reader_t_kind_monad_bind() {
 fn test_monad_reader_kind_ask() {
     // Renamed test
     let ask_reader: ReaderT<EnvConfig, IdentityKind, EnvConfig> = // Changed IdentityHKTMarker
-        <TestReaderKind as MonadReader<EnvConfig, EnvConfig, IdentityKind>>::ask(); // Renamed Marker
+        TestReaderKind::ask(); // Renamed Marker
     let result = (ask_reader.run_reader_t)(EnvConfig { val: 7 });
     assert_eq!(result, Identity(EnvConfig { val: 7 }));
 }

--- a/tests/kind/transformers/state.rs
+++ b/tests/kind/transformers/state.rs
@@ -36,13 +36,13 @@ fn assert_eq_at<A: PartialEq + std::fmt::Debug>(l: TestState<A>, r: TestState<A>
 }
 
 fn st_state<A: 'static, F: Fn(i32) -> (A, i32) + 'static>(f: F) -> TestState<A> {
-    <TestStateKind as MonadState<i32, A, IdentityKind>>::state(f)
+    TestStateKind::state(f)
 }
 fn st_get() -> TestState<i32> {
-    <TestStateKind as MonadState<i32, i32, IdentityKind>>::get()
+    TestStateKind::get()
 }
 fn st_put(s: i32) -> TestState<()> {
-    <TestStateKind as MonadState<i32, (), IdentityKind>>::put(s)
+    TestStateKind::put(s)
 }
 
 // ── Functor / Applicative / Apply / Bind / Monad smoke tests ────────────────
@@ -170,12 +170,12 @@ fn monadstate_put_put() {
 
 #[test]
 fn modify_and_gets_derive_correctly() {
-    let modify = <TestStateKind as MonadState<i32, (), IdentityKind>>::modify(|s| s + 100);
+    let modify = TestStateKind::modify(|s| s + 100);
     // modify(f) == get.bind(|s| put(f(s)))
     let derived_modify = TestStateKind::bind(st_get(), |s| st_put(s + 100));
     assert_eq_at(modify, derived_modify, 5);
 
-    let gets = <TestStateKind as MonadState<i32, i32, IdentityKind>>::gets(|s| s * 3);
+    let gets = TestStateKind::gets(|s| s * 3);
     // gets(f) == get.map(f)
     let derived_gets = TestStateKind::map(st_get(), |s| s * 3);
     assert_eq_at(gets, derived_gets, 5);
@@ -192,10 +192,8 @@ fn run_opt<A>(st: OptState<A>, s0: i32) -> Option<(A, i32)> {
 
 #[test]
 fn option_inner_threads_state_when_all_some() {
-    let m: OptState<i32> = <OptStateKind as MonadState<i32, i32, OptionKind>>::get();
-    let bound = OptStateKind::bind(m, |x| {
-        <OptStateKind as MonadState<i32, i32, OptionKind>>::state(move |s| (x + s, s + 1))
-    });
+    let m: OptState<i32> = OptStateKind::get();
+    let bound = OptStateKind::bind(m, |x| OptStateKind::state(move |s| (x + s, s + 1)));
     // get at 4 -> Some((4,4)); state from 4 -> Some((4+4, 5)) = Some((8,5))
     assert_eq!(run_opt(bound, 4), Some((8, 5)));
 }
@@ -204,16 +202,14 @@ fn option_inner_threads_state_when_all_some() {
 fn option_inner_none_short_circuits() {
     // A computation that fails inside the inner Option.
     let failing: OptState<i32> = StateT::new(|_s: i32| None);
-    let bound = OptStateKind::bind(failing, |x| {
-        <OptStateKind as MonadState<i32, i32, OptionKind>>::state(move |s| (x, s))
-    });
+    let bound = OptStateKind::bind(failing, |x| OptStateKind::state(move |s| (x, s)));
     assert_eq!(run_opt(bound, 10), None);
 }
 
 #[test]
 fn option_inner_monadstate_laws_hold() {
     // put-put last-write-wins over OptionKind.
-    let put = |s: i32| <OptStateKind as MonadState<i32, (), OptionKind>>::put(s);
+    let put = |s: i32| OptStateKind::put(s);
     let lhs = OptStateKind::bind(put(3), move |_| put(8));
     assert_eq!(run_opt(lhs.clone(), 0), run_opt(put(8), 0));
     assert_eq!(run_opt(lhs, 0), Some(((), 8)));

--- a/tests/kind/transformers/trans.rs
+++ b/tests/kind/transformers/trans.rs
@@ -17,8 +17,7 @@ use monadify::transformers::writer::{Writer, WriterTKind};
 #[test]
 fn reader_lift_ignores_env() {
     type RKind = ReaderTKind<i32, IdentityKind>;
-    let lifted: Reader<i32, &'static str> =
-        <RKind as MonadTrans<&'static str, IdentityKind>>::lift(IdentityKind::pure("hi"));
+    let lifted: Reader<i32, &'static str> = RKind::lift(IdentityKind::pure("hi"));
     // The lifted computation yields the inner value for any environment.
     assert_eq!((lifted.run_reader_t)(0), Identity("hi"));
 }
@@ -27,8 +26,7 @@ fn reader_lift_ignores_env() {
 fn reader_lift_equals_pure() {
     // lift(pure(a)) == pure(a)
     type RKind = ReaderTKind<i32, IdentityKind>;
-    let lifted: Reader<i32, i32> =
-        <RKind as MonadTrans<i32, IdentityKind>>::lift(IdentityKind::pure(5));
+    let lifted: Reader<i32, i32> = RKind::lift(IdentityKind::pure(5));
     let pured: Reader<i32, i32> = RKind::pure(5);
     assert_eq!((lifted.run_reader_t)(42), (pured.run_reader_t)(42));
 }
@@ -38,8 +36,7 @@ fn reader_lift_equals_pure() {
 #[test]
 fn state_lift_threads_state_unchanged() {
     type SKind = StateTKind<i32, IdentityKind>;
-    let lifted: State<i32, &'static str> =
-        <SKind as MonadTrans<&'static str, IdentityKind>>::lift(IdentityKind::pure("v"));
+    let lifted: State<i32, &'static str> = SKind::lift(IdentityKind::pure("v"));
     // Value comes from the inner computation; state passes through untouched.
     assert_eq!((lifted.run_state_t)(99), Identity(("v", 99)));
 }
@@ -47,8 +44,7 @@ fn state_lift_threads_state_unchanged() {
 #[test]
 fn state_lift_equals_pure() {
     type SKind = StateTKind<i32, IdentityKind>;
-    let lifted: State<i32, i32> =
-        <SKind as MonadTrans<i32, IdentityKind>>::lift(IdentityKind::pure(8));
+    let lifted: State<i32, i32> = SKind::lift(IdentityKind::pure(8));
     let pured: State<i32, i32> = SKind::pure(8);
     assert_eq!((lifted.run_state_t)(3), (pured.run_state_t)(3));
 }
@@ -58,8 +54,7 @@ fn state_lift_equals_pure() {
 #[test]
 fn writer_lift_adds_empty_log() {
     type WKind = WriterTKind<String, IdentityKind>;
-    let lifted: Writer<String, i32> =
-        <WKind as MonadTrans<i32, IdentityKind>>::lift(IdentityKind::pure(7));
+    let lifted: Writer<String, i32> = WKind::lift(IdentityKind::pure(7));
     let Identity((v, log)) = lifted.run_writer_t;
     assert_eq!(v, 7);
     assert_eq!(log, ""); // empty log
@@ -68,8 +63,7 @@ fn writer_lift_adds_empty_log() {
 #[test]
 fn writer_lift_equals_pure() {
     type WKind = WriterTKind<String, IdentityKind>;
-    let lifted: Writer<String, i32> =
-        <WKind as MonadTrans<i32, IdentityKind>>::lift(IdentityKind::pure(6));
+    let lifted: Writer<String, i32> = WKind::lift(IdentityKind::pure(6));
     let pured: Writer<String, i32> = WKind::pure(6);
     assert_eq!(lifted.run_writer_t, pured.run_writer_t);
 }
@@ -80,7 +74,7 @@ fn writer_lift_equals_pure() {
 fn writer_lift_over_option_some() {
     use monadify::OptionKind;
     type WKind = WriterTKind<String, OptionKind>;
-    let lifted = <WKind as MonadTrans<i32, OptionKind>>::lift(Some(11));
+    let lifted = WKind::lift(Some(11_i32));
     assert_eq!(lifted.run_writer_t, Some((11, String::new())));
 }
 
@@ -88,7 +82,7 @@ fn writer_lift_over_option_some() {
 fn writer_lift_over_option_none() {
     use monadify::OptionKind;
     type WKind = WriterTKind<String, OptionKind>;
-    let lifted = <WKind as MonadTrans<i32, OptionKind>>::lift(None);
+    let lifted = WKind::lift(None::<i32>);
     assert_eq!(lifted.run_writer_t, None);
 }
 
@@ -98,8 +92,7 @@ fn writer_lift_over_option_none() {
 fn except_lift_wraps_ok() {
     use monadify::transformers::except::{Except, ExceptTKind};
     type EKind = ExceptTKind<String, IdentityKind>;
-    let lifted: Except<String, i32> =
-        <EKind as MonadTrans<i32, IdentityKind>>::lift(IdentityKind::pure(7));
+    let lifted: Except<String, i32> = EKind::lift(IdentityKind::pure(7));
     let Identity(r) = lifted.run_except_t;
     assert_eq!(r, Ok(7)); // lifting adds no error
 }
@@ -108,8 +101,7 @@ fn except_lift_wraps_ok() {
 fn except_lift_equals_pure() {
     use monadify::transformers::except::{Except, ExceptTKind};
     type EKind = ExceptTKind<String, IdentityKind>;
-    let lifted: Except<String, i32> =
-        <EKind as MonadTrans<i32, IdentityKind>>::lift(IdentityKind::pure(6));
+    let lifted: Except<String, i32> = EKind::lift(IdentityKind::pure(6));
     let pured: Except<String, i32> = EKind::pure(6);
     assert_eq!(lifted.run_except_t, pured.run_except_t);
 }
@@ -119,7 +111,7 @@ fn except_lift_over_option_some() {
     use monadify::transformers::except::ExceptTKind;
     use monadify::OptionKind;
     type EKind = ExceptTKind<String, OptionKind>;
-    let lifted = <EKind as MonadTrans<i32, OptionKind>>::lift(Some(11));
+    let lifted = EKind::lift(Some(11_i32));
     assert_eq!(lifted.run_except_t, Some(Ok(11)));
 }
 
@@ -128,6 +120,29 @@ fn except_lift_over_option_none() {
     use monadify::transformers::except::ExceptTKind;
     use monadify::OptionKind;
     type EKind = ExceptTKind<String, OptionKind>;
-    let lifted = <EKind as MonadTrans<i32, OptionKind>>::lift(None);
+    let lifted = EKind::lift(None::<i32>);
     assert_eq!(lifted.run_except_t, None::<Result<i32, String>>);
+}
+
+// ── Parity: inherent form == trait form ─────────────────────────────────────
+//
+// These tests assert that the ergonomic inherent shorthand produces identical
+// results to the explicit UFCS trait call, keeping trait-form coverage alive.
+
+#[test]
+fn reader_lift_inherent_parity() {
+    type RKind = ReaderTKind<i32, IdentityKind>;
+    let inherent: Reader<i32, i32> = RKind::lift(IdentityKind::pure(5));
+    let via_trait: Reader<i32, i32> =
+        <RKind as MonadTrans<i32, IdentityKind>>::lift(IdentityKind::pure(5));
+    assert_eq!((inherent.run_reader_t)(42), (via_trait.run_reader_t)(42));
+}
+
+#[test]
+fn writer_lift_inherent_parity() {
+    type WKind = WriterTKind<String, IdentityKind>;
+    let inherent: Writer<String, i32> = WKind::lift(IdentityKind::pure(9));
+    let via_trait: Writer<String, i32> =
+        <WKind as MonadTrans<i32, IdentityKind>>::lift(IdentityKind::pure(9));
+    assert_eq!(inherent.run_writer_t, via_trait.run_writer_t);
 }

--- a/tests/kind/transformers/writer.rs
+++ b/tests/kind/transformers/writer.rs
@@ -32,7 +32,7 @@ fn run_id<A>(w: W<A>) -> (A, String) {
 }
 
 fn tell(s: &str) -> W<()> {
-    <WKind as MonadWriter<String, (), IdentityKind>>::tell(s.to_string())
+    WKind::tell(s.to_string())
 }
 
 // ── Functor / Applicative / Apply / Bind / Monad smoke tests ────────────────
@@ -40,8 +40,7 @@ fn tell(s: &str) -> W<()> {
 #[test]
 fn functor_map_preserves_log() {
     // map touches the value, never the log.
-    let w: W<i32> =
-        <WKind as MonadWriter<String, i32, IdentityKind>>::writer(10, "log".to_string());
+    let w: W<i32> = WKind::writer(10, "log".to_string());
     let mapped = WKind::map(w, |v| v * 2);
     assert_eq!(run_id(mapped), (20, "log".to_string()));
 }
@@ -55,8 +54,7 @@ fn applicative_pure_has_empty_log() {
 #[test]
 fn apply_combines_logs_function_first() {
     // value carries log "v"; function carries log "f".
-    let value: W<i32> =
-        <WKind as MonadWriter<String, i32, IdentityKind>>::writer(5, "v".to_string());
+    let value: W<i32> = WKind::writer(5, "v".to_string());
     let func: W<RcFn<i32, i32>> =
         WriterT::new(Identity((RcFn::new(|a: i32| a * 10), "f".to_string())));
     let applied = <WKind as Apply<i32, i32>>::apply(value, func);
@@ -66,18 +64,15 @@ fn apply_combines_logs_function_first() {
 
 #[test]
 fn bind_combines_logs_in_order() {
-    let m: W<i32> = <WKind as MonadWriter<String, i32, IdentityKind>>::writer(1, "a".to_string());
-    let bound = WKind::bind(m, |x| {
-        <WKind as MonadWriter<String, i32, IdentityKind>>::writer(x + 1, "b".to_string())
-    });
+    let m: W<i32> = WKind::writer(1, "a".to_string());
+    let bound = WKind::bind(m, |x| WKind::writer(x + 1, "b".to_string()));
     // input log "a" then next log "b": "ab"; value 1 + 1 == 2.
     assert_eq!(run_id(bound), (2, "ab".to_string()));
 }
 
 #[test]
 fn join_flattens_combining_logs() {
-    let inner: W<i32> =
-        <WKind as MonadWriter<String, i32, IdentityKind>>::writer(7, "in".to_string());
+    let inner: W<i32> = WKind::writer(7, "in".to_string());
     let nested: W<W<i32>> = WriterT::new(Identity((inner, "out".to_string())));
     let flat = WKind::join(nested);
     // outer log "out" then inner log "in": "outin".
@@ -89,8 +84,7 @@ fn join_flattens_combining_logs() {
 #[test]
 fn monad_left_identity() {
     // pure(a).bind(f) == f(a)
-    let f =
-        |x: i32| <WKind as MonadWriter<String, i32, IdentityKind>>::writer(x * 3, "f".to_string());
+    let f = |x: i32| WKind::writer(x * 3, "f".to_string());
     let lhs = WKind::bind(WKind::pure(4), f);
     let rhs = f(4);
     assert_eq!(run_id(lhs), run_id(rhs));
@@ -99,8 +93,8 @@ fn monad_left_identity() {
 #[test]
 fn monad_right_identity() {
     // m.bind(pure) == m
-    let m: W<i32> = <WKind as MonadWriter<String, i32, IdentityKind>>::writer(9, "m".to_string());
-    let m2: W<i32> = <WKind as MonadWriter<String, i32, IdentityKind>>::writer(9, "m".to_string());
+    let m: W<i32> = WKind::writer(9, "m".to_string());
+    let m2: W<i32> = WKind::writer(9, "m".to_string());
     let lhs = WKind::bind(m, WKind::pure);
     assert_eq!(run_id(lhs), run_id(m2));
 }
@@ -108,15 +102,13 @@ fn monad_right_identity() {
 #[test]
 fn monad_associativity() {
     // m.bind(f).bind(g) == m.bind(|x| f(x).bind(g))
-    let f =
-        |x: i32| <WKind as MonadWriter<String, i32, IdentityKind>>::writer(x + 1, "f".to_string());
-    let g =
-        |y: i32| <WKind as MonadWriter<String, i32, IdentityKind>>::writer(y * 2, "g".to_string());
+    let f = |x: i32| WKind::writer(x + 1, "f".to_string());
+    let g = |y: i32| WKind::writer(y * 2, "g".to_string());
 
-    let m: W<i32> = <WKind as MonadWriter<String, i32, IdentityKind>>::writer(3, "m".to_string());
+    let m: W<i32> = WKind::writer(3, "m".to_string());
     let lhs = WKind::bind(WKind::bind(m, f), g);
 
-    let m2: W<i32> = <WKind as MonadWriter<String, i32, IdentityKind>>::writer(3, "m".to_string());
+    let m2: W<i32> = WKind::writer(3, "m".to_string());
     let rhs = WKind::bind(m2, move |x| WKind::bind(f(x), g));
 
     assert_eq!(run_id(lhs), run_id(rhs));
@@ -136,21 +128,21 @@ fn writer_tell_appends_monoidally() {
 #[test]
 fn writer_tell_empty_is_pure_unit() {
     // tell(empty) == pure(())
-    let lhs = <WKind as MonadWriter<String, (), IdentityKind>>::tell(String::empty());
+    let lhs = WKind::tell(String::empty());
     let rhs: W<()> = WKind::pure(());
     assert_eq!(run_id(lhs), run_id(rhs));
 }
 
 #[test]
 fn writer_constructs_value_and_log() {
-    let w = <WKind as MonadWriter<String, i32, IdentityKind>>::writer(99, "note".to_string());
+    let w = WKind::writer(99, "note".to_string());
     assert_eq!(run_id(w), (99, "note".to_string()));
 }
 
 #[test]
 fn writer_listen_exposes_log() {
     // listen(tell(w)) yields value ((), w) with the log left in place == w.
-    let listened = <WKind as MonadWriter<String, (), IdentityKind>>::listen(tell("xyz"));
+    let listened = tell("xyz").listen();
     let ((unit, exposed), log) = run_id(listened);
     assert_eq!(unit, ());
     assert_eq!(exposed, "xyz");
@@ -160,10 +152,7 @@ fn writer_listen_exposes_log() {
 #[test]
 fn writer_censor_rewrites_log() {
     // censor(f, tell(w)) rewrites the log to f(w), leaving the value.
-    let censored = <WKind as MonadWriter<String, (), IdentityKind>>::censor(
-        |w: String| w.to_uppercase(),
-        tell("quiet"),
-    );
+    let censored = tell("quiet").censor(|w: String| w.to_uppercase());
     assert_eq!(run_id(censored), ((), "QUIET".to_string()));
 }
 
@@ -171,7 +160,7 @@ fn writer_censor_rewrites_log() {
 fn writer_vec_log_accumulates() {
     // A Vec<&str> log accumulates as an event list across binds.
     type EvKind = WriterTKind<Vec<i32>, IdentityKind>;
-    let ev = |n: i32| <EvKind as MonadWriter<Vec<i32>, (), IdentityKind>>::tell(vec![n]);
+    let ev = |n: i32| EvKind::tell(vec![n]);
     let prog = EvKind::bind(ev(1), move |_| EvKind::bind(ev(2), move |_| ev(3)));
     let Identity(((), log)) = prog.run_writer_t;
     assert_eq!(log, vec![1, 2, 3]);
@@ -184,7 +173,7 @@ type OptWKind = WriterTKind<String, OptionKind>;
 
 #[test]
 fn option_inner_threads_log_when_some() {
-    let tell_opt = |s: &str| <OptWKind as MonadWriter<String, (), OptionKind>>::tell(s.to_string());
+    let tell_opt = |s: &str| OptWKind::tell(s.to_string());
     let prog = OptWKind::bind(tell_opt("a"), move |_| tell_opt("b"));
     assert_eq!(prog.run_writer_t, Some(((), "ab".to_string())));
 }
@@ -193,9 +182,7 @@ fn option_inner_threads_log_when_some() {
 fn option_inner_none_short_circuits() {
     // A computation that fails inside the inner Option discards the log.
     let failing: OptW<i32> = WriterT::new(None);
-    let bound = OptWKind::bind(failing, |x| {
-        <OptWKind as MonadWriter<String, i32, OptionKind>>::writer(x, "never".to_string())
-    });
+    let bound = OptWKind::bind(failing, |x| OptWKind::writer(x, "never".to_string()));
     assert_eq!(bound.run_writer_t, None);
 }
 


### PR DESCRIPTION
## Summary

Closes the three follow-ups deferred from the ergonomics (#13) and idiomatic-sweep (#14) work.

### 1. Inherent `lift` for all four transformers
`MonadTrans::lift` was the **one** transformer op still requiring the verbose `<Marker as MonadTrans<A, M>>::lift` UFCS. Added inherent `ReaderTKind::lift` / `StateTKind::lift` / `WriterTKind::lift` / `ExceptTKind::lift` (each `#[must_use]`, delegating to the trait with verbatim bounds), so:

```rust
WKind::lift(inner)   // was: <WKind as MonadTrans<i32, IdentityKind>>::lift(inner)
```

The `MonadTrans` trait is unchanged. Trans tests use the inherent form, **plus two new parity tests** retain trait-form coverage; the module doctest is tidied.

### 2. `cargo doc` is now clean (0 warnings)
Fixed all **11** rustdoc warnings — the unresolved `Semigroup`/`Monoid` intra-doc links (now crate-absolute paths in `monoid.rs`) and the redundant explicit link targets in `trans.rs` / `writer.rs`.

### 3. `tests/kind` UFCS tidy
Rewrote **~77** internal `<Marker as MonadX<..>>::method()` call sites across the transformer / proptest / do_notation test suites to the inherent ergonomic forms (`SKind::get()`, `m.listen()`, `ExceptT::throw(e)`, `m.catch(h)`, …). The intentional UFCS-vs-inherent **parity tests are preserved unchanged**.

`CLAUDE.md` updated: both `clippy --all-targets --all-features` and `cargo doc` are now clean tree-wide; wiring them into CI is the remaining hardening step.

## Test plan / quality gates (all green)

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo doc --no-deps --all-features` — **0 warnings**
- [x] `cargo test` (default, +2 new lift parity tests) + `--features do-notation` + `--all-features`
- [x] `cargo test --all-features --doc`
- [x] all 15 examples run green
- [x] MSRV 1.66; zero-dependency guard

Additive / non-behavioral. After this, every `MonadX` op (including `lift`) has an inherent ergonomic form, and both extended quality gates are clean.