### PR TITLE
ci: harden clippy (--all-targets) + cargo doc gate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,11 +30,23 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Lint lib & bins (deny warnings)
-        run: cargo clippy --all-features -- -D warnings
-      # Guards benches/compare.rs from silently rotting (e.g. stale marker names).
-      - name: Lint benches (deny warnings)
-        run: cargo clippy --all-features --benches -- -D warnings
+      # `--all-targets` covers lib, bins, tests, benches, and examples in one pass,
+      # so test/bench/example code (e.g. benches/compare.rs) can't silently rot.
+      - name: Lint all targets (deny warnings)
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  doc:
+    name: doc
+    runs-on: ubuntu-latest
+    # Fail the build on any rustdoc warning (broken intra-doc links, etc.).
+    env:
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build docs (deny warnings)
+        run: cargo doc --no-deps --all-features
 
   test:
     name: test (${{ matrix.name }})


### PR DESCRIPTION
Wires the two remaining quality gates into CI — both already pass locally across the whole tree, they just weren't enforced.

## Changes
- **`clippy` job → `--all-targets`**: now lints lib, bins, **tests, benches, and examples** in a single pass. This subsumes the previous separate `--benches` step, so example/test code can no longer silently accrue lints.
- **New `doc` job**: `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS="-D warnings"`, failing the build on any rustdoc warning (broken intra-doc links, etc.).

## Verification (local)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` → clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` → clean, no warnings

This is the final CI-hardening step noted in CLAUDE.md (CI previously ran clippy without `--all-targets` and had no `cargo doc` gate).